### PR TITLE
Enhance the CLI using Clientele.rs

### DIFF
--- a/rudof_cli/Cargo.toml
+++ b/rudof_cli/Cargo.toml
@@ -33,6 +33,7 @@ anyhow = { workspace = true }
 thiserror = { workspace = true }
 void = "1"
 clap = { workspace = true }
+clientele = "0.2"
 oxrdf = { workspace = true }
 oxiri = "0.2.3-alpha.1"
 regex = "^1.10"

--- a/rudof_cli/src/main.rs
+++ b/rudof_cli/src/main.rs
@@ -63,6 +63,9 @@ use tracing_subscriber::{filter::EnvFilter, fmt};
 
 #[allow(unused_variables)]
 fn main() -> Result<()> {
+    // Load environment variables from `.env`:
+    clientele::dotenv().ok();
+
     let fmt_layer = fmt::layer()
         .with_file(true)
         .with_target(false)
@@ -80,7 +83,11 @@ fn main() -> Result<()> {
 
     // tracing::info!("rudof is running...");
 
-    let cli = Cli::parse();
+    // Expand wildcards and @argfiles:
+    let args = clientele::args_os()?;
+
+    // Parse command-line options:
+    let cli = Cli::parse_from(args);
 
     match &cli.command {
         Some(Command::Service {


### PR DESCRIPTION
This pull request implements some CLI best practices using [Clientele.rs](https://github.com/dryrust/clientele.rs):

> **Clientele** makes it easy to write superb command-line utilities in Rust that follow consistent best practices on all target platforms including Linux, macOS, and Windows. It packages and re-exports [`clap`], [`camino`], [`dotenvy`], [`argfile`], and [`wild`] into a single easy dependency.

## Load environment variables from `.env` files:

The CLI now supports loading environment variables from a [dotenv](https://github.com/motdotla/dotenv) file, if present:

```console
% cat .env
RUST_LOG=trace
% rudof
```

## Expand @argfiles similarly to `javac` or Python

The CLI now supports specifying command-line options and arguments in @argfiles, simplifying many use cases without needing a configuration file per se:

```console
% cat turtle
--data-format=turtle
--result-format=turtle
% rudof data @turtle know.ttl
```

## Expand wildcards (globs) on Windows

The CLI now supports wildcard arguments (`*foo*`, `file.???`, `*.log.[0-9]`, etc.) uniformly on all platforms, including Windows.

This is needed because Unix shells automatically interpret wildcard arguments and pass them expanded (already converted to file names) to applications, but Windows's `cmd.exe` doesn't do that. So, for consistent cross-platform behavior, this pull request emulates Unix-like expansion on Windows as well.

[`argfile`]: https://crates.io/crates/argfile
[`camino`]: https://crates.io/crates/camino
[`clap`]: https://crates.io/crates/clap
[`dotenvy`]: https://crates.io/crates/dotenvy
[`wild`]: https://crates.io/crates/wild
