### PR TITLE
remove blocking reqwests for wasm (using #[cfg(target_family = "wasm")])

### DIFF
--- a/iri_s/Cargo.toml
+++ b/iri_s/Cargo.toml
@@ -10,7 +10,6 @@ homepage.workspace = true
 repository.workspace = true
 
 [features]
-default = []
 rdf-star = [ "oxrdf/rdf-star" ]
 
 [dependencies]

--- a/iri_s/src/iris.rs
+++ b/iri_s/src/iris.rs
@@ -1,7 +1,5 @@
 use oxiri::Iri;
 use oxrdf::NamedNode;
-use reqwest::header;
-use reqwest::header::USER_AGENT;
 use serde::de;
 use serde::de::Visitor;
 use serde::Deserialize;
@@ -9,7 +7,6 @@ use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
 use std::fmt;
-use std::fs;
 use std::str::FromStr;
 use url::Url;
 
@@ -107,7 +104,12 @@ impl IriS {
     /// [Dereference](https://www.w3.org/wiki/DereferenceURI) the IRI and get the content available from it
     /// It handles also IRIs with the `file` scheme as local file names. For example: `file:///person.txt`
     ///
+    #[cfg(not(target_family = "wasm"))]
     pub fn dereference(&self, base: &Option<IriS>) -> Result<String, IriSError> {
+        use reqwest::header;
+        use reqwest::header::USER_AGENT;
+        use std::fs;
+
         let url = match base {
             Some(base_iri) => {
                 let base =
@@ -171,6 +173,13 @@ impl IriS {
                 Ok(body)
             }
         }
+    }
+
+    #[cfg(target_family = "wasm")]
+    pub fn dereference(&self, _base: &Option<IriS>) -> Result<String, IriSError> {
+        return Err(IriSError::ReqwestClientCreation {
+            error: String::from("reqwest is not enabled"),
+        });
     }
 
     /*    pub fn is_absolute(&self) -> bool {

--- a/rudof_lib/src/lib.rs
+++ b/rudof_lib/src/lib.rs
@@ -10,3 +10,7 @@ pub use rudof::*;
 pub use rudof_config::*;
 pub use rudof_error::*;
 pub use shapes_graph_source::*;
+pub use srdf;
+pub use shacl_validation;
+pub use shacl_ast;
+pub use oxrdf;

--- a/rudof_lib/src/rudof.rs
+++ b/rudof_lib/src/rudof.rs
@@ -27,7 +27,9 @@ pub use shapemap::{QueryShapeMap, ResultShapeMap, ShapeMapFormat, ValidationStat
 pub use shex_compact::{ShExFormatter, ShapeMapParser, ShapemapFormatter as ShapeMapFormatter};
 pub use shex_validation::Validator as ShExValidator;
 pub use shex_validation::{ShExFormat, ValidatorConfig};
-pub use srdf::{QuerySolution, QuerySolutions, RDFFormat, ReaderMode, SRDFSparql, VarName};
+pub use srdf::{
+    QuerySolution, QuerySolutions, RDFFormat, ReaderMode, SRDFSparql, VarName,
+};
 pub type Result<T> = result::Result<T, RudofError>;
 pub use shacl_ast::ast::Schema as ShaclSchema;
 pub use shapes_converter::UmlGenerationMode;

--- a/shacl_ast/src/compiled/shape.rs
+++ b/shacl_ast/src/compiled/shape.rs
@@ -58,6 +58,13 @@ impl<S: SRDFBasic> CompiledShape<S> {
         }
     }
 
+    pub fn path_str(&self) -> Option<String> {
+        match self {
+            CompiledShape::NodeShape(_) => None,
+            CompiledShape::PropertyShape(ps) => Some(ps.path().to_string()),
+        }
+    }
+
     pub fn severity(&self) -> S::Term {
         let iri_s = match self {
             CompiledShape::NodeShape(ns) => ns.severity().into(),

--- a/shacl_validation/src/lib.rs
+++ b/shacl_validation/src/lib.rs
@@ -1,19 +1,19 @@
 #![doc = include_str!("../README.md")]
 
-mod constraints;
-mod engine;
-mod focus_nodes;
+pub mod constraints;
+pub mod engine;
+pub mod focus_nodes;
 mod helpers;
 pub mod shacl_config;
 /// The SHACL processor implementation, used for validating a data graph against
 /// a shapes graph and obtaining a Validation Report as a result.
 pub mod shacl_processor;
 pub mod shacl_validation_vocab;
-mod shape;
+pub mod shape;
 /// Utilities for handling local graphs (serialized), SPARQL endpoints and SHACL
 /// shapes graphs.
 pub mod store;
 pub mod validate_error;
 /// The result of the validation process.
 pub mod validation_report;
-mod value_nodes;
+pub mod value_nodes;

--- a/shacl_validation/src/validation_report/result.rs
+++ b/shacl_validation/src/validation_report/result.rs
@@ -56,6 +56,10 @@ impl ValidationResult {
         self
     }
 
+    pub fn source(&self) -> Option<&Object> {
+        self.source.as_ref()
+    }
+
     pub fn focus_node(&self) -> &Object {
         &self.focus_node
     }

--- a/shex_validation/Cargo.toml
+++ b/shex_validation/Cargo.toml
@@ -9,6 +9,9 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[features]
+default = []
+
 [dependencies]
 iri_s = { workspace = true }
 rbe = { workspace = true }
@@ -22,7 +25,7 @@ thiserror = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = { workspace = true }
-tokio = { version = "^1.35", features = ["full"] }
+tokio = { version = "^1.35", features = ["rt"], optional = true }
 tracing = { workspace = true }
 indexmap = { version = "2" }
 colored = "2"

--- a/shex_validation/src/rests/validation_error.rs
+++ b/shex_validation/src/rests/validation_error.rs
@@ -1,7 +1,6 @@
 use shex_ast::CompiledSchemaError;
 use std::fmt::Debug;
 use thiserror::Error;
-use tokio::task::JoinError;
 
 use crate::CardinalityError;
 
@@ -21,24 +20,24 @@ where
     #[error("Compiling schema: {error:?}")]
     CompilingSchema { error: CompiledSchemaError },
 
-
     #[error("SRDF Error {error:?}")]
     SRDFError { error: String },
 
     #[error("Cardinality error: {ce:?}")]
     CardinalityError { ce: CardinalityError },
 
+    #[cfg(not(target_family = "wasm"))]
     #[error("JoinError: {je:?}")]
-    JoinError { je: JoinError },
-
+    JoinError { je: tokio::task::JoinError },
 }
 
+#[cfg(not(target_family = "wasm"))]
 impl<'a, SL> From<JoinError> for ValidationError<'a, SL>
 where
     SL: Debug,
 {
     fn from(je: JoinError) -> Self {
-        ValidationError::JoinError { je: je }
+        ValidationError::JoinError { je }
     }
 }
 

--- a/shex_validation/src/schema_without_imports.rs
+++ b/shex_validation/src/schema_without_imports.rs
@@ -4,7 +4,6 @@ use serde_derive::{Deserialize, Serialize};
 use shex_ast::{IriOrStr, Schema, SchemaJsonError, Shape, ShapeDecl, ShapeExpr, ShapeExprLabel};
 use shex_compact::ShExParser;
 use std::collections::{hash_map::Entry, HashMap};
-use tracing::debug;
 use url::Url;
 
 use crate::{ResolveMethod, SchemaWithoutImportsError, ShExFormat};
@@ -205,7 +204,10 @@ pub fn resolve_iri_or_str(
     }
 }
 
+#[cfg(not(target_family = "wasm"))]
 pub fn local_folder_as_iri() -> Result<IriS, SchemaJsonError> {
+    use tracing::debug;
+
     let current_dir = std::env::current_dir().map_err(|e| SchemaJsonError::CurrentDir {
         error: format!("{e}"),
     })?;
@@ -214,6 +216,13 @@ pub fn local_folder_as_iri() -> Result<IriS, SchemaJsonError> {
         .map_err(|_e| SchemaJsonError::LocalFolderIriError { path: current_dir })?;
     debug!("url: {url}");
     Ok(IriS::new_unchecked(url.as_str()))
+}
+
+#[cfg(target_family = "wasm")]
+pub fn local_folder_as_iri() -> Result<IriS, SchemaJsonError> {
+    Err(SchemaJsonError::CurrentDir {
+        error: String::from("No local folder on web"),
+    })
 }
 
 pub fn get_schema_from_iri(

--- a/srdf/Cargo.toml
+++ b/srdf/Cargo.toml
@@ -39,7 +39,6 @@ oxrdfxml = "0.1.0-rc.1"
 oxiri = "0.2.3-alpha.1"
 oxsdatatypes = "0.2.0-alpha.2"
 sparesults = { version = "0.2.0-rc.2" }
-tokio = { version = "1.38", features = ["full"] }
 colored = { workspace = true }
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 url = { workspace = true }
@@ -48,3 +47,4 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
+tokio = { version = "1.38", features = ["full"] }

--- a/srdf/src/shacl_path.rs
+++ b/srdf/src/shacl_path.rs
@@ -20,6 +20,12 @@ impl SHACLPath {
     pub fn iri(pred: IriS) -> Self {
         SHACLPath::Predicate { pred }
     }
+    pub fn pred(&self) -> Option<&IriS> {
+        match self {
+            SHACLPath::Predicate { pred } => Some(pred),
+            _ => None
+        }
+    }
 }
 
 impl Display for SHACLPath {


### PR DESCRIPTION
Hi Rudof people,

I really like rudof, and I use it inside [my semantic web language server](https://github.com/ajuvercr/semantic-web-lsp), yet the lsp should run on wasm.
To make this work, I wrapped everything that used `reqwest::blocking` into  `#[cfg(not(target_family = "wasm"))]` and made stubs for `#[cfg(target_family = "wasm")]`.

I also reexport some of the internal libraries from lib, which makes it possible for me to not follow the default flow, but hook into the flow more easily.

This fixes #49 in a not ideal way.