### PR TITLE
Improve the naming conventions of the core traits

### DIFF
--- a/shacl_ast/src/compiled/component.rs
+++ b/shacl_ast/src/compiled/component.rs
@@ -13,10 +13,10 @@ use iri_s::iri;
 use iri_s::IriS;
 use node_kind::NodeKind;
 use srdf::RDFNode;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 
 #[derive(Debug)]
-pub enum CompiledComponent<S: SRDFBasic> {
+pub enum CompiledComponent<S: Rdf> {
     Class(Class<S>),
     Datatype(Datatype<S>),
     NodeKind(Nodekind),
@@ -46,7 +46,7 @@ pub enum CompiledComponent<S: SRDFBasic> {
     QualifiedValueShape(QualifiedValueShape<S>),
 }
 
-impl<S: SRDFBasic> CompiledComponent<S> {
+impl<S: Rdf> CompiledComponent<S> {
     pub fn compile(component: Component, schema: &Schema) -> Result<Self, CompiledShaclError> {
         let component = match component {
             Component::Class(object) => {
@@ -215,11 +215,11 @@ impl MinCount {
 ///
 /// https://www.w3.org/TR/shacl/#AndConstraintComponent
 #[derive(Debug)]
-pub struct And<S: SRDFBasic> {
+pub struct And<S: Rdf> {
     shapes: Vec<CompiledShape<S>>,
 }
 
-impl<S: SRDFBasic> And<S> {
+impl<S: Rdf> And<S> {
     pub fn new(shapes: Vec<CompiledShape<S>>) -> Self {
         And { shapes }
     }
@@ -234,11 +234,11 @@ impl<S: SRDFBasic> And<S> {
 ///
 /// https://www.w3.org/TR/shacl/#NotConstraintComponent
 #[derive(Debug)]
-pub struct Not<S: SRDFBasic> {
+pub struct Not<S: Rdf> {
     shape: CompiledShape<S>,
 }
 
-impl<S: SRDFBasic> Not<S> {
+impl<S: Rdf> Not<S> {
     pub fn new(shape: CompiledShape<S>) -> Self {
         Not { shape }
     }
@@ -255,11 +255,11 @@ impl<S: SRDFBasic> Not<S> {
 /// https://www.w3.org/TR/shacl/#AndConstraintComponent
 
 #[derive(Debug)]
-pub struct Or<S: SRDFBasic> {
+pub struct Or<S: Rdf> {
     shapes: Vec<CompiledShape<S>>,
 }
 
-impl<S: SRDFBasic> Or<S> {
+impl<S: Rdf> Or<S> {
     pub fn new(shapes: Vec<CompiledShape<S>>) -> Self {
         Or { shapes }
     }
@@ -275,11 +275,11 @@ impl<S: SRDFBasic> Or<S> {
 ///
 /// https://www.w3.org/TR/shacl/#XoneConstraintComponent
 #[derive(Debug)]
-pub struct Xone<S: SRDFBasic> {
+pub struct Xone<S: Rdf> {
     shapes: Vec<CompiledShape<S>>,
 }
 
-impl<S: SRDFBasic> Xone<S> {
+impl<S: Rdf> Xone<S> {
     pub fn new(shapes: Vec<CompiledShape<S>>) -> Self {
         Xone { shapes }
     }
@@ -301,12 +301,12 @@ impl<S: SRDFBasic> Xone<S> {
 ///
 /// https://www.w3.org/TR/shacl/#ClosedConstraintComponent
 #[derive(Debug)]
-pub struct Closed<S: SRDFBasic> {
+pub struct Closed<S: Rdf> {
     is_closed: bool,
     ignored_properties: Vec<S::IRI>,
 }
 
-impl<S: SRDFBasic> Closed<S> {
+impl<S: Rdf> Closed<S> {
     pub fn new(is_closed: bool, ignored_properties: Vec<S::IRI>) -> Self {
         Closed {
             is_closed,
@@ -328,11 +328,11 @@ impl<S: SRDFBasic> Closed<S> {
 ///
 /// https://www.w3.org/TR/shacl/#HasValueConstraintComponent
 #[derive(Debug)]
-pub struct HasValue<S: SRDFBasic> {
+pub struct HasValue<S: Rdf> {
     value: S::Term,
 }
 
-impl<S: SRDFBasic> HasValue<S> {
+impl<S: Rdf> HasValue<S> {
     pub fn new(value: S::Term) -> Self {
         HasValue { value }
     }
@@ -347,11 +347,11 @@ impl<S: SRDFBasic> HasValue<S> {
 ///
 /// https://www.w3.org/TR/shacl/#InConstraintComponent
 #[derive(Debug)]
-pub struct In<S: SRDFBasic> {
+pub struct In<S: Rdf> {
     values: Vec<S::Term>,
 }
 
-impl<S: SRDFBasic> In<S> {
+impl<S: Rdf> In<S> {
     pub fn new(values: Vec<S::Term>) -> Self {
         In { values }
     }
@@ -367,11 +367,11 @@ impl<S: SRDFBasic> In<S> {
 ///
 /// https://www.w3.org/TR/shacl/#DisjointConstraintComponent
 #[derive(Debug)]
-pub struct Disjoint<S: SRDFBasic> {
+pub struct Disjoint<S: Rdf> {
     iri_ref: S::IRI,
 }
 
-impl<S: SRDFBasic> Disjoint<S> {
+impl<S: Rdf> Disjoint<S> {
     pub fn new(iri_ref: S::IRI) -> Self {
         Disjoint { iri_ref }
     }
@@ -387,11 +387,11 @@ impl<S: SRDFBasic> Disjoint<S> {
 ///
 /// https://www.w3.org/TR/shacl/#EqualsConstraintComponent
 #[derive(Debug)]
-pub struct Equals<S: SRDFBasic> {
+pub struct Equals<S: Rdf> {
     iri_ref: S::IRI,
 }
 
-impl<S: SRDFBasic> Equals<S> {
+impl<S: Rdf> Equals<S> {
     pub fn new(iri_ref: S::IRI) -> Self {
         Equals { iri_ref }
     }
@@ -409,11 +409,11 @@ impl<S: SRDFBasic> Equals<S> {
 ///
 /// https://www.w3.org/TR/shacl/#LessThanOrEqualsConstraintComponent
 #[derive(Debug)]
-pub struct LessThanOrEquals<S: SRDFBasic> {
+pub struct LessThanOrEquals<S: Rdf> {
     iri_ref: S::IRI,
 }
 
-impl<S: SRDFBasic> LessThanOrEquals<S> {
+impl<S: Rdf> LessThanOrEquals<S> {
     pub fn new(iri_ref: S::IRI) -> Self {
         LessThanOrEquals { iri_ref }
     }
@@ -429,11 +429,11 @@ impl<S: SRDFBasic> LessThanOrEquals<S> {
 ///
 /// https://www.w3.org/TR/shacl/#LessThanConstraintComponent
 #[derive(Debug)]
-pub struct LessThan<S: SRDFBasic> {
+pub struct LessThan<S: Rdf> {
     iri_ref: S::IRI,
 }
 
-impl<S: SRDFBasic> LessThan<S> {
+impl<S: Rdf> LessThan<S> {
     pub fn new(iri_ref: S::IRI) -> Self {
         LessThan { iri_ref }
     }
@@ -448,11 +448,11 @@ impl<S: SRDFBasic> LessThan<S> {
 ///
 /// https://www.w3.org/TR/shacl/#NodeShapeComponent
 #[derive(Debug)]
-pub struct Node<S: SRDFBasic> {
+pub struct Node<S: Rdf> {
     shape: CompiledShape<S>,
 }
 
-impl<S: SRDFBasic> Node<S> {
+impl<S: Rdf> Node<S> {
     pub fn new(shape: CompiledShape<S>) -> Self {
         Node { shape }
     }
@@ -471,14 +471,14 @@ impl<S: SRDFBasic> Node<S> {
 ///
 /// https://www.w3.org/TR/shacl/#QualifiedValueShapeConstraintComponent
 #[derive(Debug)]
-pub struct QualifiedValueShape<S: SRDFBasic> {
+pub struct QualifiedValueShape<S: Rdf> {
     shape: CompiledShape<S>,
     qualified_min_count: Option<isize>,
     qualified_max_count: Option<isize>,
     qualified_value_shapes_disjoint: Option<bool>,
 }
 
-impl<S: SRDFBasic> QualifiedValueShape<S> {
+impl<S: Rdf> QualifiedValueShape<S> {
     pub fn new(
         shape: CompiledShape<S>,
         qualified_min_count: Option<isize>,
@@ -515,11 +515,11 @@ impl<S: SRDFBasic> QualifiedValueShape<S> {
 ///
 /// https://www.w3.org/TR/shacl/#LanguageInConstraintComponent
 #[derive(Debug)]
-pub struct LanguageIn<S: SRDFBasic> {
+pub struct LanguageIn<S: Rdf> {
     langs: Vec<S::Literal>,
 }
 
-impl<S: SRDFBasic> LanguageIn<S> {
+impl<S: Rdf> LanguageIn<S> {
     pub fn new(langs: Vec<S::Literal>) -> Self {
         LanguageIn { langs }
     }
@@ -617,11 +617,11 @@ impl UniqueLang {
 ///
 /// https://www.w3.org/TR/shacl/#ClassConstraintComponent
 #[derive(Debug)]
-pub struct Class<S: SRDFBasic> {
+pub struct Class<S: Rdf> {
     class_rule: S::Term,
 }
 
-impl<S: SRDFBasic> Class<S> {
+impl<S: Rdf> Class<S> {
     pub fn new(class_rule: S::Term) -> Self {
         Class { class_rule }
     }
@@ -636,11 +636,11 @@ impl<S: SRDFBasic> Class<S> {
 ///
 /// https://www.w3.org/TR/shacl/#ClassConstraintComponent
 #[derive(Debug)]
-pub struct Datatype<S: SRDFBasic> {
+pub struct Datatype<S: Rdf> {
     datatype: S::IRI,
 }
 
-impl<S: SRDFBasic> Datatype<S> {
+impl<S: Rdf> Datatype<S> {
     pub fn new(datatype: S::IRI) -> Self {
         Datatype { datatype }
     }
@@ -671,11 +671,11 @@ impl Nodekind {
 
 /// https://www.w3.org/TR/shacl/#MaxExclusiveConstraintComponent
 #[derive(Debug)]
-pub struct MaxExclusive<S: SRDFBasic> {
+pub struct MaxExclusive<S: Rdf> {
     max_exclusive: S::Term,
 }
 
-impl<S: SRDFBasic> MaxExclusive<S> {
+impl<S: Rdf> MaxExclusive<S> {
     pub fn new(literal: S::Term) -> Self {
         MaxExclusive {
             max_exclusive: literal,
@@ -689,11 +689,11 @@ impl<S: SRDFBasic> MaxExclusive<S> {
 
 /// https://www.w3.org/TR/shacl/#MaxInclusiveConstraintComponent
 #[derive(Debug)]
-pub struct MaxInclusive<S: SRDFBasic> {
+pub struct MaxInclusive<S: Rdf> {
     max_inclusive: S::Term,
 }
 
-impl<S: SRDFBasic> MaxInclusive<S> {
+impl<S: Rdf> MaxInclusive<S> {
     pub fn new(literal: S::Term) -> Self {
         MaxInclusive {
             max_inclusive: literal,
@@ -707,11 +707,11 @@ impl<S: SRDFBasic> MaxInclusive<S> {
 
 /// https://www.w3.org/TR/shacl/#MinExclusiveConstraintComponent
 #[derive(Debug)]
-pub struct MinExclusive<S: SRDFBasic> {
+pub struct MinExclusive<S: Rdf> {
     min_exclusive: S::Term,
 }
 
-impl<S: SRDFBasic> MinExclusive<S> {
+impl<S: Rdf> MinExclusive<S> {
     pub fn new(literal: S::Term) -> Self {
         MinExclusive {
             min_exclusive: literal,
@@ -725,11 +725,11 @@ impl<S: SRDFBasic> MinExclusive<S> {
 
 /// https://www.w3.org/TR/shacl/#MinInclusiveConstraintComponent
 #[derive(Debug)]
-pub struct MinInclusive<S: SRDFBasic> {
+pub struct MinInclusive<S: Rdf> {
     min_inclusive: S::Term,
 }
 
-impl<S: SRDFBasic> MinInclusive<S> {
+impl<S: Rdf> MinInclusive<S> {
     pub fn new(literal: S::Term) -> Self {
         MinInclusive {
             min_inclusive: literal,
@@ -741,7 +741,7 @@ impl<S: SRDFBasic> MinInclusive<S> {
     }
 }
 
-impl<S: SRDFBasic> From<&CompiledComponent<S>> for IriS {
+impl<S: Rdf> From<&CompiledComponent<S>> for IriS {
     fn from(value: &CompiledComponent<S>) -> Self {
         match value {
             CompiledComponent::Class(_) => iri!(SH_CLASS_STR),

--- a/shacl_ast/src/compiled/mod.rs
+++ b/shacl_ast/src/compiled/mod.rs
@@ -5,7 +5,7 @@ use srdf::lang::Lang;
 use srdf::literal::Literal;
 use srdf::Object;
 use srdf::RDFNode;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 
 use crate::value::Value;
 use crate::Schema;
@@ -19,20 +19,20 @@ pub mod severity;
 pub mod shape;
 pub mod target;
 
-fn convert_iri_ref<S: SRDFBasic>(iri_ref: IriRef) -> Result<S::IRI, CompiledShaclError> {
+fn convert_iri_ref<S: Rdf>(iri_ref: IriRef) -> Result<S::IRI, CompiledShaclError> {
     let iri_s = iri_ref
         .get_iri()
         .map_err(|_| CompiledShaclError::IriRefConversion)?;
     Ok(S::iri_s2iri(&iri_s))
 }
 
-fn convert_lang<S: SRDFBasic>(lang: Lang) -> Result<S::Literal, CompiledShaclError> {
+fn convert_lang<S: Rdf>(lang: Lang) -> Result<S::Literal, CompiledShaclError> {
     let object = RDFNode::literal(Literal::str(&lang.value()));
     let term = S::object_as_term(&object);
     S::term_as_literal(&term).ok_or(CompiledShaclError::LiteralConversion)
 }
 
-fn compile_shape<S: SRDFBasic>(
+fn compile_shape<S: Rdf>(
     shape: Object,
     schema: &Schema,
 ) -> Result<CompiledShape<S>, CompiledShaclError> {
@@ -42,7 +42,7 @@ fn compile_shape<S: SRDFBasic>(
     CompiledShape::compile(shape.to_owned(), schema)
 }
 
-fn compile_shapes<S: SRDFBasic>(
+fn compile_shapes<S: Rdf>(
     shapes: Vec<Object>,
     schema: &Schema,
 ) -> Result<Vec<CompiledShape<S>>, CompiledShaclError> {
@@ -53,7 +53,7 @@ fn compile_shapes<S: SRDFBasic>(
     Ok(compiled_shapes)
 }
 
-fn convert_value<S: SRDFBasic>(value: Value) -> Result<S::Term, CompiledShaclError> {
+fn convert_value<S: Rdf>(value: Value) -> Result<S::Term, CompiledShaclError> {
     let ans = match value {
         Value::Iri(iri_ref) => {
             let iri_ref = convert_iri_ref::<S>(iri_ref)?;

--- a/shacl_ast/src/compiled/node_shape.rs
+++ b/shacl_ast/src/compiled/node_shape.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use srdf::SRDFBasic;
+use srdf::Rdf;
 
 use crate::node_shape::NodeShape;
 use crate::Schema;
@@ -13,7 +13,7 @@ use super::shape::CompiledShape;
 use super::target::CompiledTarget;
 
 #[derive(Debug)]
-pub struct CompiledNodeShape<S: SRDFBasic> {
+pub struct CompiledNodeShape<S: Rdf> {
     id: S::Term,
     components: Vec<CompiledComponent<S>>,
     targets: Vec<CompiledTarget<S>>,
@@ -29,7 +29,7 @@ pub struct CompiledNodeShape<S: SRDFBasic> {
     // source_iri: S::IRI,
 }
 
-impl<S: SRDFBasic> CompiledNodeShape<S> {
+impl<S: Rdf> CompiledNodeShape<S> {
     pub fn new(
         id: S::Term,
         components: Vec<CompiledComponent<S>>,
@@ -82,7 +82,7 @@ impl<S: SRDFBasic> CompiledNodeShape<S> {
     }
 }
 
-impl<S: SRDFBasic> CompiledNodeShape<S> {
+impl<S: Rdf> CompiledNodeShape<S> {
     pub fn compile(shape: Box<NodeShape>, schema: &Schema) -> Result<Self, CompiledShaclError> {
         let id = S::object_as_term(shape.id());
         let closed = shape.is_closed().to_owned();

--- a/shacl_ast/src/compiled/property_shape.rs
+++ b/shacl_ast/src/compiled/property_shape.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 
 use srdf::SHACLPath;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 
 use crate::property_shape::PropertyShape;
 use crate::Schema;
@@ -14,7 +14,7 @@ use super::shape::CompiledShape;
 use super::target::CompiledTarget;
 
 #[derive(Debug)]
-pub struct CompiledPropertyShape<S: SRDFBasic> {
+pub struct CompiledPropertyShape<S: Rdf> {
     id: S::Term,
     path: SHACLPath,
     components: Vec<CompiledComponent<S>>,
@@ -33,7 +33,7 @@ pub struct CompiledPropertyShape<S: SRDFBasic> {
     // annotations: Vec<(S::IRI, S::Term)>,
 }
 
-impl<S: SRDFBasic> CompiledPropertyShape<S> {
+impl<S: Rdf> CompiledPropertyShape<S> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: S::Term,
@@ -93,7 +93,7 @@ impl<S: SRDFBasic> CompiledPropertyShape<S> {
     }
 }
 
-impl<S: SRDFBasic> CompiledPropertyShape<S> {
+impl<S: Rdf> CompiledPropertyShape<S> {
     pub fn compile(shape: PropertyShape, schema: &Schema) -> Result<Self, CompiledShaclError> {
         let id = S::object_as_term(shape.id());
         let path = shape.path().to_owned();

--- a/shacl_ast/src/compiled/schema.rs
+++ b/shacl_ast/src/compiled/schema.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use prefixmap::PrefixMap;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 
 use crate::Schema;
 
@@ -9,7 +9,7 @@ use super::compiled_shacl_error::CompiledShaclError;
 use super::shape::CompiledShape;
 
 #[derive(Debug)]
-pub struct CompiledSchema<S: SRDFBasic> {
+pub struct CompiledSchema<S: Rdf> {
     // imports: Vec<IriS>,
     // entailments: Vec<IriS>,
     shapes: HashMap<S::Term, CompiledShape<S>>,
@@ -17,7 +17,7 @@ pub struct CompiledSchema<S: SRDFBasic> {
     base: Option<S::IRI>,
 }
 
-impl<S: SRDFBasic> CompiledSchema<S> {
+impl<S: Rdf> CompiledSchema<S> {
     pub fn new(
         shapes: HashMap<S::Term, CompiledShape<S>>,
         prefixmap: PrefixMap,
@@ -47,7 +47,7 @@ impl<S: SRDFBasic> CompiledSchema<S> {
     }
 }
 
-impl<S: SRDFBasic> TryFrom<Schema> for CompiledSchema<S> {
+impl<S: Rdf> TryFrom<Schema> for CompiledSchema<S> {
     type Error = CompiledShaclError;
 
     fn try_from(schema: Schema) -> Result<Self, Self::Error> {

--- a/shacl_ast/src/compiled/severity.rs
+++ b/shacl_ast/src/compiled/severity.rs
@@ -1,6 +1,6 @@
 use iri_s::iri;
 use iri_s::IriS;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 
 use crate::severity::Severity;
 use crate::*;
@@ -9,14 +9,14 @@ use super::compiled_shacl_error::CompiledShaclError;
 use super::convert_iri_ref;
 
 #[derive(Hash, PartialEq, Eq, Debug)]
-pub enum CompiledSeverity<S: SRDFBasic> {
+pub enum CompiledSeverity<S: Rdf> {
     Violation,
     Warning,
     Info,
     Generic(S::IRI),
 }
 
-impl<S: SRDFBasic> CompiledSeverity<S> {
+impl<S: Rdf> CompiledSeverity<S> {
     pub fn compile(severity: Option<Severity>) -> Result<Option<Self>, CompiledShaclError> {
         let ans = match severity {
             Some(severity) => {
@@ -37,7 +37,7 @@ impl<S: SRDFBasic> CompiledSeverity<S> {
     }
 }
 
-impl<S: SRDFBasic> From<&CompiledSeverity<S>> for IriS {
+impl<S: Rdf> From<&CompiledSeverity<S>> for IriS {
     fn from(value: &CompiledSeverity<S>) -> Self {
         match value {
             CompiledSeverity::Violation => iri!(SH_VIOLATION_STR),

--- a/shacl_ast/src/compiled/shape.rs
+++ b/shacl_ast/src/compiled/shape.rs
@@ -1,4 +1,4 @@
-use srdf::SRDFBasic;
+use srdf::Rdf;
 
 use crate::shape::Shape;
 use crate::Schema;
@@ -10,12 +10,12 @@ use super::property_shape::CompiledPropertyShape;
 use super::target::CompiledTarget;
 
 #[derive(Debug)]
-pub enum CompiledShape<S: SRDFBasic> {
+pub enum CompiledShape<S: Rdf> {
     NodeShape(CompiledNodeShape<S>),
     PropertyShape(CompiledPropertyShape<S>),
 }
 
-impl<S: SRDFBasic> CompiledShape<S> {
+impl<S: Rdf> CompiledShape<S> {
     pub fn is_deactivated(&self) -> &bool {
         match self {
             CompiledShape::NodeShape(ns) => ns.is_deactivated(),
@@ -75,7 +75,7 @@ impl<S: SRDFBasic> CompiledShape<S> {
     }
 }
 
-impl<S: SRDFBasic> CompiledShape<S> {
+impl<S: Rdf> CompiledShape<S> {
     pub fn compile(shape: Shape, schema: &Schema) -> Result<Self, CompiledShaclError> {
         let shape = match shape {
             Shape::NodeShape(node_shape) => {

--- a/shacl_ast/src/compiled/target.rs
+++ b/shacl_ast/src/compiled/target.rs
@@ -1,4 +1,4 @@
-use srdf::SRDFBasic;
+use srdf::Rdf;
 
 use crate::target::Target;
 
@@ -6,14 +6,14 @@ use super::compiled_shacl_error::CompiledShaclError;
 use super::convert_iri_ref;
 
 #[derive(Debug)]
-pub enum CompiledTarget<S: SRDFBasic> {
+pub enum CompiledTarget<S: Rdf> {
     TargetNode(S::Term),
     TargetClass(S::Term),
     TargetSubjectsOf(S::IRI),
     TargetObjectsOf(S::IRI),
 }
 
-impl<S: SRDFBasic> CompiledTarget<S> {
+impl<S: Rdf> CompiledTarget<S> {
     pub fn compile(target: Target) -> Result<Self, CompiledShaclError> {
         let ans = match target {
             Target::TargetNode(object) => CompiledTarget::TargetNode(S::object_as_term(&object)),

--- a/shacl_ast/src/converter/rdf_to_shacl/shacl_parser.rs
+++ b/shacl_ast/src/converter/rdf_to_shacl/shacl_parser.rs
@@ -3,7 +3,7 @@ use srdf::{
     combine_parsers, combine_vec, has_type, not, ok, optional, parse_nodes, property_bool,
     property_value, property_values, property_values_int, property_values_iri,
     property_values_non_empty, rdf_list, term, FocusRDF, Object, PResult, RDFNode, RDFNodeParse,
-    RDFParseError, RDFParser, SHACLPath, SRDFBasic, Triple, RDF_TYPE,
+    RDFParseError, RDFParser, Rdf, SHACLPath, Triple, RDF_TYPE,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -369,7 +369,7 @@ fn parse_xone_values<RDF: FocusRDF>() -> impl RDFNodeParse<RDF, Output = Compone
 
 fn cnv_xone_list<RDF>(ls: Vec<RDF::Term>) -> PResult<Component>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     let shapes: Vec<_> = ls.iter().map(RDF::term_as_object).collect();
     Ok(Component::Xone { shapes })
@@ -381,7 +381,7 @@ fn parse_and_values<RDF: FocusRDF>() -> impl RDFNodeParse<RDF, Output = Componen
 
 fn cnv_and_list<RDF>(ls: Vec<RDF::Term>) -> PResult<Component>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     let shapes: Vec<_> = ls.iter().map(RDF::term_as_object).collect();
     Ok(Component::And { shapes })
@@ -397,7 +397,7 @@ fn parse_node_value<RDF: FocusRDF>() -> impl RDFNodeParse<RDF, Output = Componen
 
 fn cnv_node<RDF>(t: RDF::Term) -> PResult<Component>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     let shape = RDF::term_as_object(&t);
     Ok(Component::Node { shape })
@@ -405,7 +405,7 @@ where
 
 fn cnv_not<RDF>(t: RDF::Term) -> PResult<Component>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     let shape = RDF::term_as_object(&t);
     Ok(Component::Not { shape })
@@ -417,7 +417,7 @@ fn parse_or_values<RDF: FocusRDF>() -> impl RDFNodeParse<RDF, Output = Component
 
 fn cnv_or_list<RDF>(ls: Vec<RDF::Term>) -> PResult<Component>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     let shapes: Vec<_> = ls.iter().map(RDF::term_as_object).collect();
     Ok(Component::Or { shapes })
@@ -574,7 +574,7 @@ where
 
 fn cnv_has_value<RDF>(term: RDF::Term) -> std::result::Result<Component, RDFParseError>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     let value = term_to_value::<RDF>(&term)?;
     Ok(Component::HasValue { value })
@@ -582,7 +582,7 @@ where
 
 fn term_to_value<RDF>(term: &RDF::Term) -> std::result::Result<Value, RDFParseError>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     match RDF::term_as_object(term) {
         Object::Iri(iri) => Ok(Value::Iri(IriRef::Iri(iri))),
@@ -595,7 +595,7 @@ where
 
 fn cnv_in_list<RDF>(ls: Vec<RDF::Term>) -> std::result::Result<Component, RDFParseError>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     let values = ls.iter().flat_map(term_to_value::<RDF>).collect();
     Ok(Component::In { values })
@@ -653,7 +653,7 @@ where
 
 fn term_to_node_kind<RDF>(term: &RDF::Term) -> Result<NodeKind>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     match RDF::term_as_iri(term) {
         Some(iri) => {

--- a/shacl_testsuite/src/helper/srdf.rs
+++ b/shacl_testsuite/src/helper/srdf.rs
@@ -1,10 +1,10 @@
 use std::collections::HashSet;
 
-use srdf::{SRDFBasic, SRDF};
+use srdf::{Rdf, SRDF};
 
 use super::helper_error::HelperError;
 
-pub(crate) fn get_object_for<S: SRDF + SRDFBasic>(
+pub(crate) fn get_object_for<S: SRDF + Rdf>(
     store: &S,
     subject: &S::Term,
     predicate: &S::IRI,
@@ -18,7 +18,7 @@ pub(crate) fn get_object_for<S: SRDF + SRDFBasic>(
     }
 }
 
-pub(crate) fn get_objects_for<S: SRDF + SRDFBasic>(
+pub(crate) fn get_objects_for<S: SRDF + Rdf>(
     store: &S,
     subject: &S::Term,
     predicate: &S::IRI,

--- a/shacl_testsuite/src/manifest.rs
+++ b/shacl_testsuite/src/manifest.rs
@@ -9,7 +9,7 @@ use shacl_validation::store::Store;
 use shacl_validation::validation_report::report::ValidationReport;
 use sparql_service::RdfData;
 use srdf::RDFFormat;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 
 use crate::helper::srdf::get_object_for;
@@ -17,7 +17,7 @@ use crate::helper::srdf::get_objects_for;
 use crate::manifest_error::ManifestError;
 use crate::ShaclTest;
 
-pub trait Manifest<S: SRDF + SRDFBasic> {
+pub trait Manifest<S: SRDF + Rdf> {
     fn new(base: String, store: S, includes: Vec<Self>, entries: HashSet<S::Term>) -> Self
     where
         Self: Sized;

--- a/shacl_validation/src/constraints/core/cardinality/max_count.rs
+++ b/shacl_validation/src/constraints/core/cardinality/max_count.rs
@@ -2,7 +2,7 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::MaxCount;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
@@ -19,7 +19,7 @@ use crate::validation_report::result::ValidationResult;
 use crate::value_nodes::FocusNodeIteration;
 use crate::value_nodes::ValueNodes;
 
-impl<S: SRDFBasic + Debug> Validator<S> for MaxCount {
+impl<S: Rdf + Debug> Validator<S> for MaxCount {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/cardinality/min_count.rs
+++ b/shacl_validation/src/constraints/core/cardinality/min_count.rs
@@ -15,11 +15,11 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::MinCount;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for MinCount {
+impl<S: Rdf + Debug> Validator<S> for MinCount {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/logical/and.rs
+++ b/shacl_validation/src/constraints/core/logical/and.rs
@@ -17,11 +17,11 @@ use shacl_ast::compiled::component::And;
 use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for And<S> {
+impl<S: Rdf + Debug> Validator<S> for And<S> {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/logical/not.rs
+++ b/shacl_validation/src/constraints/core/logical/not.rs
@@ -15,11 +15,11 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::Not;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for Not<S> {
+impl<S: Rdf + Debug> Validator<S> for Not<S> {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/logical/or.rs
+++ b/shacl_validation/src/constraints/core/logical/or.rs
@@ -17,11 +17,11 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::Or;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for Or<S> {
+impl<S: Rdf + Debug> Validator<S> for Or<S> {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/logical/xone.rs
+++ b/shacl_validation/src/constraints/core/logical/xone.rs
@@ -2,7 +2,7 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::Xone;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
@@ -20,7 +20,7 @@ use crate::validation_report::result::ValidationResult;
 use crate::value_nodes::ValueNodeIteration;
 use crate::value_nodes::ValueNodes;
 
-impl<S: SRDFBasic + Debug> Validator<S> for Xone<S> {
+impl<S: Rdf + Debug> Validator<S> for Xone<S> {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/other/closed.rs
+++ b/shacl_validation/src/constraints/core/other/closed.rs
@@ -11,11 +11,11 @@ use shacl_ast::compiled::component::Closed;
 use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for Closed<S> {
+impl<S: Rdf + Debug> Validator<S> for Closed<S> {
     fn validate(
         &self,
         _component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/other/has_value.rs
+++ b/shacl_validation/src/constraints/core/other/has_value.rs
@@ -14,11 +14,11 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::HasValue;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for HasValue<S> {
+impl<S: Rdf + Debug> Validator<S> for HasValue<S> {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/other/in.rs
+++ b/shacl_validation/src/constraints/core/other/in.rs
@@ -12,11 +12,11 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::In;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for In<S> {
+impl<S: Rdf + Debug> Validator<S> for In<S> {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/property_pair/equals.rs
+++ b/shacl_validation/src/constraints/core/property_pair/equals.rs
@@ -11,11 +11,11 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::Equals;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for Equals<S> {
+impl<S: Rdf + Debug> Validator<S> for Equals<S> {
     fn validate(
         &self,
         _component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/shape_based/node.rs
+++ b/shacl_validation/src/constraints/core/shape_based/node.rs
@@ -15,11 +15,11 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::Node;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for Node<S> {
+impl<S: Rdf + Debug> Validator<S> for Node<S> {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/shape_based/qualified_value_shape.rs
+++ b/shacl_validation/src/constraints/core/shape_based/qualified_value_shape.rs
@@ -11,11 +11,11 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::QualifiedValueShape;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for QualifiedValueShape<S> {
+impl<S: Rdf + Debug> Validator<S> for QualifiedValueShape<S> {
     fn validate(
         &self,
         _component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/string_based/language_in.rs
+++ b/shacl_validation/src/constraints/core/string_based/language_in.rs
@@ -2,7 +2,7 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::LanguageIn;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
@@ -18,7 +18,7 @@ use crate::validation_report::result::ValidationResult;
 use crate::value_nodes::ValueNodeIteration;
 use crate::value_nodes::ValueNodes;
 
-impl<S: SRDFBasic + Debug> Validator<S> for LanguageIn<S> {
+impl<S: Rdf + Debug> Validator<S> for LanguageIn<S> {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/string_based/unique_lang.rs
+++ b/shacl_validation/src/constraints/core/string_based/unique_lang.rs
@@ -16,11 +16,11 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::UniqueLang;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for UniqueLang {
+impl<S: Rdf + Debug> Validator<S> for UniqueLang {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/core/value/datatype.rs
+++ b/shacl_validation/src/constraints/core/value/datatype.rs
@@ -13,11 +13,11 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::component::Datatype;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
-impl<S: SRDFBasic + Debug> Validator<S> for Datatype<S> {
+impl<S: Rdf + Debug> Validator<S> for Datatype<S> {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/constraints/mod.rs
+++ b/shacl_validation/src/constraints/mod.rs
@@ -2,7 +2,7 @@ use constraint_error::ConstraintError;
 use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDF;
 use std::fmt::Debug;
 
@@ -13,7 +13,7 @@ use crate::value_nodes::ValueNodes;
 pub mod constraint_error;
 pub mod core;
 
-pub trait Validator<S: SRDFBasic + Debug> {
+pub trait Validator<S: Rdf + Debug> {
     fn validate(
         &self,
         component: &CompiledComponent<S>,

--- a/shacl_validation/src/engine/mod.rs
+++ b/shacl_validation/src/engine/mod.rs
@@ -2,8 +2,8 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::property_shape::CompiledPropertyShape;
 use shacl_ast::compiled::shape::CompiledShape;
 use shacl_ast::compiled::target::CompiledTarget;
+use srdf::Rdf;
 use srdf::SHACLPath;
-use srdf::SRDFBasic;
 
 use crate::focus_nodes::FocusNodes;
 use crate::validate_error::ValidateError;
@@ -13,7 +13,7 @@ use crate::value_nodes::ValueNodes;
 pub mod native;
 pub mod sparql;
 
-pub trait Engine<S: SRDFBasic> {
+pub trait Engine<S: Rdf> {
     fn evaluate(
         &self,
         store: &S,

--- a/shacl_validation/src/focus_nodes.rs
+++ b/shacl_validation/src/focus_nodes.rs
@@ -1,11 +1,11 @@
 use std::collections::HashSet;
 
-use srdf::SRDFBasic;
+use srdf::Rdf;
 
 #[derive(Debug)]
-pub struct FocusNodes<S: SRDFBasic>(HashSet<S::Term>);
+pub struct FocusNodes<S: Rdf>(HashSet<S::Term>);
 
-impl<S: SRDFBasic> FocusNodes<S> {
+impl<S: Rdf> FocusNodes<S> {
     pub fn new(iter: impl Iterator<Item = S::Term>) -> Self {
         Self(HashSet::from_iter(iter))
     }
@@ -23,19 +23,19 @@ impl<S: SRDFBasic> FocusNodes<S> {
     }
 }
 
-impl<S: SRDFBasic> Clone for FocusNodes<S> {
+impl<S: Rdf> Clone for FocusNodes<S> {
     fn clone(&self) -> Self {
         Self(self.0.clone())
     }
 }
 
-impl<S: SRDFBasic> Default for FocusNodes<S> {
+impl<S: Rdf> Default for FocusNodes<S> {
     fn default() -> Self {
         Self(Default::default())
     }
 }
 
-impl<S: SRDFBasic> IntoIterator for FocusNodes<S> {
+impl<S: Rdf> IntoIterator for FocusNodes<S> {
     type Item = S::Term;
     type IntoIter = std::collections::hash_set::IntoIter<S::Term>;
 

--- a/shacl_validation/src/helpers/constraint.rs
+++ b/shacl_validation/src/helpers/constraint.rs
@@ -2,7 +2,7 @@ use shacl_ast::compiled::component::CompiledComponent;
 use shacl_ast::compiled::shape::CompiledShape;
 use srdf::Object;
 use srdf::QuerySRDF;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 
 use crate::constraints::constraint_error::ConstraintError;
 use crate::validation_report::result::ValidationResult;
@@ -10,7 +10,7 @@ use crate::value_nodes::IterationStrategy;
 use crate::value_nodes::ValueNodeIteration;
 use crate::value_nodes::ValueNodes;
 
-fn apply<S: SRDFBasic, I: IterationStrategy<S>>(
+fn apply<S: Rdf, I: IterationStrategy<S>>(
     component: &CompiledComponent<S>,
     shape: &CompiledShape<S>,
     value_nodes: &ValueNodes<S>,
@@ -38,7 +38,7 @@ fn apply<S: SRDFBasic, I: IterationStrategy<S>>(
     Ok(results)
 }
 
-pub fn validate_with<S: SRDFBasic, I: IterationStrategy<S>>(
+pub fn validate_with<S: Rdf, I: IterationStrategy<S>>(
     component: &CompiledComponent<S>,
     shape: &CompiledShape<S>,
     value_nodes: &ValueNodes<S>,

--- a/shacl_validation/src/shacl_processor.rs
+++ b/shacl_validation/src/shacl_processor.rs
@@ -3,7 +3,7 @@ use prefixmap::PrefixMap;
 use shacl_ast::compiled::schema::CompiledSchema;
 use sparql_service::RdfData;
 use srdf::RDFFormat;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDFSparql;
 use std::fmt::Debug;
 use std::path::Path;
@@ -38,7 +38,7 @@ pub enum ShaclValidationMode {
 /// Validation algorithm. For this, first, the validation report is initiliazed
 /// to empty, and, for each shape in the schema, the target nodes are
 /// selected, and then, each validator for each constraint is applied.
-pub trait ShaclProcessor<S: SRDFBasic + Debug> {
+pub trait ShaclProcessor<S: Rdf + Debug> {
     fn store(&self) -> &S;
     fn runner(&self) -> &dyn Engine<S>;
 

--- a/shacl_validation/src/shape.rs
+++ b/shacl_validation/src/shape.rs
@@ -6,11 +6,11 @@ use crate::value_nodes::ValueNodes;
 use shacl_ast::compiled::node_shape::CompiledNodeShape;
 use shacl_ast::compiled::property_shape::CompiledPropertyShape;
 use shacl_ast::compiled::shape::CompiledShape;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use std::fmt::Debug;
 
 /// Validate RDF data using SHACL
-pub trait Validate<S: SRDFBasic> {
+pub trait Validate<S: Rdf> {
     fn validate(
         &self,
         store: &S,
@@ -19,7 +19,7 @@ pub trait Validate<S: SRDFBasic> {
     ) -> Result<Vec<ValidationResult>, ValidateError>;
 }
 
-impl<S: SRDFBasic + Debug> Validate<S> for CompiledShape<S> {
+impl<S: Rdf + Debug> Validate<S> for CompiledShape<S> {
     fn validate(
         &self,
         store: &S,
@@ -69,11 +69,11 @@ impl<S: SRDFBasic + Debug> Validate<S> for CompiledShape<S> {
     }
 }
 
-pub trait FocusNodesOps<S: SRDFBasic> {
+pub trait FocusNodesOps<S: Rdf> {
     fn focus_nodes(&self, store: &S, runner: &dyn Engine<S>) -> FocusNodes<S>;
 }
 
-impl<S: SRDFBasic> FocusNodesOps<S> for CompiledShape<S> {
+impl<S: Rdf> FocusNodesOps<S> for CompiledShape<S> {
     fn focus_nodes(&self, store: &S, runner: &dyn Engine<S>) -> FocusNodes<S> {
         runner
             .focus_nodes(store, self, self.targets())
@@ -81,7 +81,7 @@ impl<S: SRDFBasic> FocusNodesOps<S> for CompiledShape<S> {
     }
 }
 
-pub trait ValueNodesOps<S: SRDFBasic> {
+pub trait ValueNodesOps<S: Rdf> {
     fn value_nodes(
         &self,
         store: &S,
@@ -90,7 +90,7 @@ pub trait ValueNodesOps<S: SRDFBasic> {
     ) -> ValueNodes<S>;
 }
 
-impl<S: SRDFBasic> ValueNodesOps<S> for CompiledShape<S> {
+impl<S: Rdf> ValueNodesOps<S> for CompiledShape<S> {
     fn value_nodes(
         &self,
         store: &S,
@@ -104,7 +104,7 @@ impl<S: SRDFBasic> ValueNodesOps<S> for CompiledShape<S> {
     }
 }
 
-impl<S: SRDFBasic> ValueNodesOps<S> for CompiledNodeShape<S> {
+impl<S: Rdf> ValueNodesOps<S> for CompiledNodeShape<S> {
     fn value_nodes(&self, _: &S, focus_nodes: &FocusNodes<S>, _: &dyn Engine<S>) -> ValueNodes<S> {
         let value_nodes = focus_nodes.iter().map(|focus_node| {
             (
@@ -116,7 +116,7 @@ impl<S: SRDFBasic> ValueNodesOps<S> for CompiledNodeShape<S> {
     }
 }
 
-impl<S: SRDFBasic> ValueNodesOps<S> for CompiledPropertyShape<S> {
+impl<S: Rdf> ValueNodesOps<S> for CompiledPropertyShape<S> {
     fn value_nodes(
         &self,
         store: &S,

--- a/shacl_validation/src/store/mod.rs
+++ b/shacl_validation/src/store/mod.rs
@@ -2,7 +2,7 @@ use shacl_ast::compiled::schema::CompiledSchema;
 use shacl_ast::ShaclParser;
 use srdf::RDFFormat;
 use srdf::ReaderMode;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDFGraph;
 use std::io::BufRead;
 
@@ -18,7 +18,7 @@ pub trait Store<S> {
 pub struct ShaclDataManager;
 
 impl ShaclDataManager {
-    pub fn load<S: SRDFBasic, R: BufRead>(
+    pub fn load<S: Rdf, R: BufRead>(
         reader: R,
         rdf_format: RDFFormat,
         base: Option<&str>,

--- a/shacl_validation/src/value_nodes.rs
+++ b/shacl_validation/src/value_nodes.rs
@@ -1,18 +1,18 @@
 use std::collections::HashMap;
 
-use srdf::SRDFBasic;
+use srdf::Rdf;
 
 use crate::focus_nodes::FocusNodes;
 
-pub struct ValueNodes<S: SRDFBasic>(HashMap<S::Term, FocusNodes<S>>);
+pub struct ValueNodes<S: Rdf>(HashMap<S::Term, FocusNodes<S>>);
 
-impl<S: SRDFBasic> ValueNodes<S> {
+impl<S: Rdf> ValueNodes<S> {
     pub fn new(iter: impl Iterator<Item = (S::Term, FocusNodes<S>)>) -> Self {
         Self(HashMap::from_iter(iter))
     }
 }
 
-pub trait IterationStrategy<S: SRDFBasic> {
+pub trait IterationStrategy<S: Rdf> {
     type Item;
 
     fn iterate<'a>(
@@ -23,7 +23,7 @@ pub trait IterationStrategy<S: SRDFBasic> {
 
 pub struct FocusNodeIteration;
 
-impl<S: SRDFBasic> IterationStrategy<S> for FocusNodeIteration {
+impl<S: Rdf> IterationStrategy<S> for FocusNodeIteration {
     type Item = FocusNodes<S>;
 
     fn iterate<'a>(
@@ -36,7 +36,7 @@ impl<S: SRDFBasic> IterationStrategy<S> for FocusNodeIteration {
 
 pub struct ValueNodeIteration;
 
-impl<S: SRDFBasic> IterationStrategy<S> for ValueNodeIteration {
+impl<S: Rdf> IterationStrategy<S> for ValueNodeIteration {
     type Item = S::Term;
 
     fn iterate<'a>(

--- a/sparql_service/src/srdf_data/rdf_data.rs
+++ b/sparql_service/src/srdf_data/rdf_data.rs
@@ -24,7 +24,7 @@ use srdf::QuerySolution;
 use srdf::QuerySolutions;
 use srdf::RDFFormat;
 use srdf::ReaderMode;
-use srdf::SRDFBasic;
+use srdf::Rdf;
 use srdf::SRDFBuilder;
 use srdf::SRDFGraph;
 use srdf::SRDFSparql;
@@ -199,7 +199,7 @@ impl Default for RdfData {
     }
 }
 
-impl SRDFBasic for RdfData {
+impl Rdf for RdfData {
     type IRI = OxNamedNode;
     type BNode = OxBlankNode;
     type Literal = OxLiteral;

--- a/srdf/src/query_srdf.rs
+++ b/srdf/src/query_srdf.rs
@@ -1,8 +1,8 @@
 use std::fmt::Display;
 
-use crate::SRDFBasic;
+use crate::Rdf;
 
-pub trait QuerySRDF: SRDFBasic {
+pub trait QuerySRDF: Rdf {
     fn query_select(&self, query: &str) -> Result<QuerySolutions<Self>, Self::Err>
     where
         Self: Sized;
@@ -35,25 +35,25 @@ impl From<String> for VarName {
     }
 }
 
-pub trait VariableSolutionIndex<S: SRDFBasic> {
+pub trait VariableSolutionIndex<S: Rdf> {
     fn index(self, solution: &QuerySolution<S>) -> Option<usize>;
 }
 
-impl<S: SRDFBasic> VariableSolutionIndex<S> for usize {
+impl<S: Rdf> VariableSolutionIndex<S> for usize {
     #[inline]
     fn index(self, _: &QuerySolution<S>) -> Option<usize> {
         Some(self)
     }
 }
 
-impl<S: SRDFBasic> VariableSolutionIndex<S> for &str {
+impl<S: Rdf> VariableSolutionIndex<S> for &str {
     #[inline]
     fn index(self, solution: &QuerySolution<S>) -> Option<usize> {
         solution.variables.iter().position(|v| v.str == self)
     }
 }
 
-impl<S: SRDFBasic> VariableSolutionIndex<S> for &VarName {
+impl<S: Rdf> VariableSolutionIndex<S> for &VarName {
     #[inline]
     fn index(self, solution: &QuerySolution<S>) -> Option<usize> {
         solution.variables.iter().position(|v| *v.str == self.str)
@@ -62,12 +62,12 @@ impl<S: SRDFBasic> VariableSolutionIndex<S> for &VarName {
 
 /// Represents one query solution
 #[derive(Debug, Clone)]
-pub struct QuerySolution<S: SRDFBasic> {
+pub struct QuerySolution<S: Rdf> {
     variables: Vec<VarName>,
     values: Vec<Option<S::Term>>,
 }
 
-impl<S: SRDFBasic> QuerySolution<S> {
+impl<S: Rdf> QuerySolution<S> {
     pub fn new(variables: Vec<VarName>, values: Vec<Option<S::Term>>) -> QuerySolution<S> {
         QuerySolution { variables, values }
     }
@@ -83,7 +83,7 @@ impl<S: SRDFBasic> QuerySolution<S> {
         self.variables.iter()
     }
 
-    pub fn convert<T: SRDFBasic, F>(&self, cnv_term: F) -> QuerySolution<T>
+    pub fn convert<T: Rdf, F>(&self, cnv_term: F) -> QuerySolution<T>
     where
         F: Fn(&S::Term) -> T::Term,
     {
@@ -111,7 +111,7 @@ impl<S: SRDFBasic> QuerySolution<S> {
     }
 }
 
-impl<S: SRDFBasic, V: Into<Vec<VarName>>, T: Into<Vec<Option<S::Term>>>> From<(V, T)>
+impl<S: Rdf, V: Into<Vec<VarName>>, T: Into<Vec<Option<S::Term>>>> From<(V, T)>
     for QuerySolution<S>
 {
     #[inline]
@@ -125,11 +125,11 @@ impl<S: SRDFBasic, V: Into<Vec<VarName>>, T: Into<Vec<Option<S::Term>>>> From<(V
 
 /// Represent a list of query solutions
 #[derive(Debug, Clone)]
-pub struct QuerySolutions<S: SRDFBasic> {
+pub struct QuerySolutions<S: Rdf> {
     solutions: Vec<QuerySolution<S>>,
 }
 
-impl<S: SRDFBasic> QuerySolutions<S> {
+impl<S: Rdf> QuerySolutions<S> {
     pub fn empty() -> QuerySolutions<S> {
         QuerySolutions {
             solutions: Vec::new(),
@@ -153,7 +153,7 @@ impl<S: SRDFBasic> QuerySolutions<S> {
     }
 }
 
-impl<S: SRDFBasic> IntoIterator for QuerySolutions<S> {
+impl<S: Rdf> IntoIterator for QuerySolutions<S> {
     type Item = QuerySolution<S>;
     type IntoIter = std::vec::IntoIter<QuerySolution<S>>;
 

--- a/srdf/src/srdf.rs
+++ b/srdf/src/srdf.rs
@@ -1,7 +1,7 @@
 use std::collections::{HashMap, HashSet};
 //use std::hash::Hash;
 
-use crate::{SRDFBasic, Triple};
+use crate::{Rdf, Triple};
 
 pub type ListOfIriAndTerms<I, T> = Vec<(I, HashSet<T>)>;
 pub type HasMapOfIriAndItem<I, T> = HashMap<I, HashSet<T>>;
@@ -11,7 +11,7 @@ type OutgoingArcs<I, T> = (HasMapOfIriAndItem<I, T>, Vec<I>);
 /// This trait contains functions to handle Simple RDF graphs, which are basically to get the neighbourhood of RDF nodes
 ///
 /// TODO: Consider alternative names: RDFGraphOps
-pub trait SRDF: SRDFBasic {
+pub trait SRDF: Rdf {
     fn predicates_for_subject(
         &self,
         subject: &Self::Subject,

--- a/srdf/src/srdf_basic.rs
+++ b/srdf/src/srdf_basic.rs
@@ -8,9 +8,7 @@ use prefixmap::{PrefixMap, PrefixMapError};
 use crate::Object;
 
 /// Types that implement this trait contain basic comparisons and conversions between nodes in RDF graphs
-///
-/// TODO: Consider splitting this trait in two traits: RDFNodeComparison, RDFNodeConversion
-pub trait SRDFBasic {
+pub trait Rdf {
     /// RDF subjects
     type Subject: Debug + Display + PartialEq + Clone + Eq + Hash;
 

--- a/srdf/src/srdf_graph/srdfgraph.rs
+++ b/srdf/src/srdf_graph/srdfgraph.rs
@@ -6,7 +6,7 @@ use tracing::debug;
 use crate::async_srdf::AsyncSRDF;
 use crate::literal::Literal;
 use crate::numeric_literal::NumericLiteral;
-use crate::{FocusRDF, RDFFormat, SRDFBasic, SRDFBuilder, Triple as STriple, RDF_TYPE_STR, SRDF};
+use crate::{FocusRDF, RDFFormat, Rdf, SRDFBuilder, Triple as STriple, RDF_TYPE_STR, SRDF};
 use oxrdfio::{RdfFormat, RdfSerializer};
 use oxrdfxml::RdfXmlParser;
 use rust_decimal::Decimal;
@@ -234,7 +234,7 @@ impl SRDFGraph {
     }
 }
 
-impl SRDFBasic for SRDFGraph {
+impl Rdf for SRDFGraph {
     type IRI = OxNamedNode;
     type BNode = OxBlankNode;
     type Literal = OxLiteral;
@@ -776,13 +776,13 @@ mod tests {
         "#;
 
         let graph = SRDFGraph::from_str(s, &RDFFormat::Turtle, None, &ReaderMode::Strict).unwrap();
-        let x = <SRDFGraph as SRDFBasic>::iri_s2subject(&iri!("http://example.org/x"));
-        let p = <SRDFGraph as SRDFBasic>::iri_s2iri(&iri!("http://example.org/p"));
+        let x = <SRDFGraph as Rdf>::iri_s2subject(&iri!("http://example.org/x"));
+        let p = <SRDFGraph as Rdf>::iri_s2iri(&iri!("http://example.org/p"));
         let terms = srdf::SRDF::objects_for_subject_predicate(&graph, &x, &p).unwrap();
         let term = terms.iter().next().unwrap().clone();
-        let subject = <SRDFGraph as SRDFBasic>::term_as_subject(&term).unwrap();
+        let subject = <SRDFGraph as Rdf>::term_as_subject(&term).unwrap();
         let outgoing = graph.outgoing_arcs(&subject).unwrap();
-        let one = <SRDFGraph as SRDFBasic>::object_as_term(&Object::Literal(int!(1)));
+        let one = <SRDFGraph as Rdf>::object_as_term(&Object::Literal(int!(1)));
         assert_eq!(outgoing.get(&p), Some(&HashSet::from([one])))
     }
 
@@ -795,14 +795,14 @@ mod tests {
         "#;
 
         let graph = SRDFGraph::from_str(s, &RDFFormat::Turtle, None, &ReaderMode::Strict).unwrap();
-        let x = <SRDFGraph as SRDFBasic>::iri_s2subject(&iri!("http://example.org/x"));
-        let p = <SRDFGraph as SRDFBasic>::iri_s2iri(&iri!("http://example.org/p"));
+        let x = <SRDFGraph as Rdf>::iri_s2subject(&iri!("http://example.org/x"));
+        let p = <SRDFGraph as Rdf>::iri_s2iri(&iri!("http://example.org/p"));
         let terms = srdf::SRDF::objects_for_subject_predicate(&graph, &x, &p).unwrap();
         let term = terms.iter().next().unwrap().clone();
-        let bnode = <SRDFGraph as SRDFBasic>::term_as_bnode(&term).unwrap();
-        let subject = <SRDFGraph as SRDFBasic>::bnode_id2subject(bnode.as_str());
+        let bnode = <SRDFGraph as Rdf>::term_as_bnode(&term).unwrap();
+        let subject = <SRDFGraph as Rdf>::bnode_id2subject(bnode.as_str());
         let outgoing = graph.outgoing_arcs(&subject).unwrap();
-        let one = <SRDFGraph as SRDFBasic>::object_as_term(&Object::Literal(int!(1)));
+        let one = <SRDFGraph as Rdf>::object_as_term(&Object::Literal(int!(1)));
         assert_eq!(outgoing.get(&p), Some(&HashSet::from([one])))
     }
 
@@ -990,7 +990,7 @@ mod tests {
     #[test]
     fn test_rdf_parser_macro() {
         use crate::SRDFGraph;
-        use crate::{rdf_parser, satisfy, RDFNodeParse, SRDFBasic};
+        use crate::{rdf_parser, satisfy, RDFNodeParse, Rdf};
         use iri_s::iri;
 
         rdf_parser! {
@@ -1008,7 +1008,7 @@ mod tests {
         let graph =
             SRDFGraph::from_str(s, &RDFFormat::Turtle, None, &ReaderMode::default()).unwrap();
         let x = iri!("http://example.org/x");
-        let term = <SRDFGraph as SRDFBasic>::iri_s2term(&x);
+        let term = <SRDFGraph as Rdf>::iri_s2term(&x);
         let mut parser = is_term(&term);
         let result = parser.parse(&x, graph);
         assert!(result.is_ok())
@@ -1094,9 +1094,9 @@ fn test_add_triple() {
     use iri_s::iri;
 
     let mut graph = SRDFGraph::new();
-    let alice = <SRDFGraph as SRDFBasic>::iri_s2subject(&iri!("http://example.org/alice"));
-    let knows = <SRDFGraph as SRDFBasic>::iri_s2iri(&iri!("http://example.org/knows"));
-    let bob = <SRDFGraph as SRDFBasic>::iri_s2term(&iri!("http://example.org/bob"));
+    let alice = <SRDFGraph as Rdf>::iri_s2subject(&iri!("http://example.org/alice"));
+    let knows = <SRDFGraph as Rdf>::iri_s2iri(&iri!("http://example.org/knows"));
+    let bob = <SRDFGraph as Rdf>::iri_s2term(&iri!("http://example.org/bob"));
 
     graph.add_triple(&alice, &knows, &bob).unwrap();
 

--- a/srdf/src/srdf_parser/rdf_node_parser.rs
+++ b/srdf/src/srdf_parser/rdf_node_parser.rs
@@ -7,7 +7,7 @@ use iri_s::IriS;
 use std::fmt::Debug;
 
 use crate::{
-    literal::Literal, rdf_parser, FocusRDF, Object, PResult, RDFParseError, SRDFBasic, RDF_FIRST,
+    literal::Literal, rdf_parser, FocusRDF, Object, PResult, RDFParseError, Rdf, RDF_FIRST,
     RDF_NIL, RDF_NIL_STR, RDF_REST, RDF_TYPE, SRDF,
 };
 
@@ -1075,7 +1075,7 @@ where
 
 fn terms_to_ints<RDF>(terms: HashSet<RDF::Term>) -> Result<HashSet<isize>, RDFParseError>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     let ints: HashSet<_> = terms.iter().flat_map(|t| term_to_int::<RDF>(t)).collect();
     Ok(ints)
@@ -1083,7 +1083,7 @@ where
 
 fn term_to_int<RDF>(term: &RDF::Term) -> Result<isize, RDFParseError>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     let n = RDF::term_as_integer(term).ok_or_else(|| RDFParseError::ExpectedInteger {
         term: format!("{term}"),
@@ -1093,7 +1093,7 @@ where
 
 fn term_to_iri<RDF>(term: &RDF::Term) -> Result<IriS, RDFParseError>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     let iri = RDF::term_as_iri(term).ok_or_else(|| RDFParseError::ExpectedIRI {
         term: format!("{term}"),
@@ -1103,7 +1103,7 @@ where
 
 fn term_to_string<RDF>(term: &RDF::Term) -> Result<String, RDFParseError>
 where
-    RDF: SRDFBasic,
+    RDF: Rdf,
 {
     let n = RDF::term_as_string(term).ok_or_else(|| RDFParseError::ExpectedString {
         term: format!("{term}"),

--- a/srdf/src/srdf_sparql/srdfsparql.rs
+++ b/srdf/src/srdf_sparql/srdfsparql.rs
@@ -1,5 +1,5 @@
 use crate::{lang::Lang, literal::Literal, Object, SRDFSparqlError};
-use crate::{AsyncSRDF, QuerySRDF, QuerySolution, QuerySolutions, SRDFBasic, VarName, SRDF};
+use crate::{AsyncSRDF, QuerySRDF, QuerySolution, QuerySolutions, Rdf, VarName, SRDF};
 use async_trait::async_trait;
 use colored::*;
 use iri_s::IriS;
@@ -99,7 +99,7 @@ impl FromStr for SRDFSparql {
     }
 }
 
-impl SRDFBasic for SRDFSparql {
+impl Rdf for SRDFSparql {
     type IRI = OxNamedNode;
     type BNode = OxBlankNode;
     type Literal = OxLiteral;

--- a/srdf/src/triple.rs
+++ b/srdf/src/triple.rs
@@ -1,10 +1,10 @@
 use std::fmt::Display;
 
-use crate::SRDFBasic;
+use crate::Rdf;
 
 pub struct Triple<S>
 where
-    S: SRDFBasic + ?Sized,
+    S: Rdf + ?Sized,
 {
     subj: S::Subject,
     pred: S::IRI,
@@ -13,7 +13,7 @@ where
 
 impl<S> Triple<S>
 where
-    S: SRDFBasic,
+    S: Rdf,
 {
     pub fn new(subj: S::Subject, pred: S::IRI, obj: S::Term) -> Self {
         Triple { subj, pred, obj }
@@ -31,7 +31,7 @@ where
         self.obj.clone()
     }
 
-    pub fn cnv<T: SRDFBasic>(self) -> Triple<T>
+    pub fn cnv<T: Rdf>(self) -> Triple<T>
     where
         T::Subject: From<S::Subject>,
         T::Term: From<S::Term>,
@@ -47,7 +47,7 @@ where
 
 impl<S> Display for Triple<S>
 where
-    S: SRDFBasic,
+    S: Rdf,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "<{},{},{}>", self.subj, self.pred, self.obj)


### PR DESCRIPTION
This pull request aims to solve the issue #241. The idea is that the naming conventions are improved:

- SRDFBasic to Rdf
- SRDF to Query
- SRDFSparql to Sparql