### PR TITLE
Refactor shacl ir

### DIFF
--- a/dctap/src/tap_config.rs
+++ b/dctap/src/tap_config.rs
@@ -142,7 +142,7 @@ impl FromStr for TapConfig {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        toml::from_str(s).map_err(|e| format!("Failed to parse TapConfig: {}", e))
+        toml::from_str(s).map_err(|e| format!("Failed to parse TapConfig: {e}"))
     }
 }
 

--- a/examples/shacl/min_length.ttl
+++ b/examples/shacl/min_length.ttl
@@ -1,4 +1,5 @@
 @prefix :     <http://example.org/> .
+@prefix ex:     <http://example.org/> .
 @prefix sh:     <http://www.w3.org/ns/shacl#> .
 @prefix xsd:    <http://www.w3.org/2001/XMLSchema#> .
         

--- a/iri_s/src/iris.rs
+++ b/iri_s/src/iris.rs
@@ -62,9 +62,9 @@ impl IriS {
     pub fn extend(&self, str: &str) -> Result<Self, IriSError> {
         let current_str = self.iri.as_str();
         let extended_str = if current_str.ends_with('/') || current_str.ends_with('#') {
-            format!("{}{}", current_str, str)
+            format!("{current_str}{str}")
         } else {
-            format!("{}/{}", current_str, str)
+            format!("{current_str}/{str}")
         };
         let iri = NamedNode::new(extended_str.as_str()).map_err(|e| IriSError::IriParseError {
             str: extended_str,

--- a/prefixmap/src/prefixmap.rs
+++ b/prefixmap/src/prefixmap.rs
@@ -272,9 +272,7 @@ impl PrefixMap {
                 Some(color) => ":".color(color),
                 None => ColoredString::from(":"),
             };
-            Some(format!(
-                "{prefix_colored}{semicolon_colored}{rest_colored}"
-            ))
+            Some(format!("{prefix_colored}{semicolon_colored}{rest_colored}"))
         } else {
             None
         };

--- a/prefixmap/src/prefixmap.rs
+++ b/prefixmap/src/prefixmap.rs
@@ -273,8 +273,7 @@ impl PrefixMap {
                 None => ColoredString::from(":"),
             };
             Some(format!(
-                "{}{}{}",
-                prefix_colored, semicolon_colored, rest_colored
+                "{prefix_colored}{semicolon_colored}{rest_colored}"
             ))
         } else {
             None
@@ -334,7 +333,7 @@ impl PrefixMap {
             };
             let length = prefix_colored.len() + 1 + rest_colored.len();
             (
-                format!("{}{}{}", prefix_colored, semicolon_colored, rest_colored),
+                format!("{prefix_colored}{semicolon_colored}{rest_colored}"),
                 length,
             )
         } else {

--- a/python/src/pyrudof_lib.rs
+++ b/python/src/pyrudof_lib.rs
@@ -6,7 +6,7 @@ use pyo3::{
 use rudof_lib::{
     iri, DCTAPFormat, PrefixMap, QueryShapeMap, QuerySolution, QuerySolutions, RDFFormat, RdfData,
     ReaderMode, ResultShapeMap, Rudof, RudofConfig, RudofError, ShExFormat, ShExFormatter,
-    ShExSchema, ShaclFormat, ShaclSchema, ShaclValidationMode, ShapeMapFormat, ShapeMapFormatter,
+    ShExSchema, ShaclFormat, ShaclSchemaIR, ShaclValidationMode, ShapeMapFormat, ShapeMapFormatter,
     ShapesGraphSource, UmlGenerationMode, ValidationReport, ValidationStatus, VarName, DCTAP,
 };
 use std::{ffi::OsStr, fs::File, io::BufReader, path::Path};
@@ -121,7 +121,7 @@ impl PyRudof {
     /// Obtains the current SHACL schema
     #[pyo3(signature = ())]
     pub fn get_shacl(&self) -> Option<PyShaclSchema> {
-        let shacl_schema = self.inner.get_shacl();
+        let shacl_schema = self.inner.get_shacl_ir();
         shacl_schema.map(|s| PyShaclSchema { inner: s.clone() })
     }
 
@@ -683,7 +683,7 @@ impl PyQueryShapeMap {
 
 #[pyclass(name = "ShaclSchema")]
 pub struct PyShaclSchema {
-    inner: ShaclSchema,
+    inner: ShaclSchemaIR,
 }
 
 #[pymethods]

--- a/rbe/src/bag.rs
+++ b/rbe/src/bag.rs
@@ -57,7 +57,7 @@ where
         let v: Vec<String> = self
             .bag
             .set_iter()
-            .map(|(t, n)| format!("{}/{}", t, n))
+            .map(|(t, n)| format!("{t}/{n}"))
             .collect();
         write!(f, "Bag [{}]", v.join(", "))
     }
@@ -77,7 +77,7 @@ where
         let v: Vec<String> = self
             .bag
             .set_iter()
-            .map(|(t, n)| format!("{:?}/{}", t, n))
+            .map(|(t, n)| format!("{t:?}/{n}"))
             .collect();
         write!(f, "Bag [{}]", v.join(", "))
     }

--- a/rbe/src/max.rs
+++ b/rbe/src/max.rs
@@ -104,8 +104,7 @@ impl Visitor<'_> for MaxVisitor {
     {
         if value < -1 {
             Err(E::custom(format!(
-                "value of type i64 {} should be -1 or positive",
-                value
+                "value of type i64 {value} should be -1 or positive"
             )))
         } else {
             match value {

--- a/rbe/src/min.rs
+++ b/rbe/src/min.rs
@@ -74,8 +74,7 @@ impl Visitor<'_> for MinVisitor {
     {
         if value < -1 {
             Err(E::custom(format!(
-                "value of type i8 {} should be -1 or positive",
-                value
+                "value of type i8 {value} should be -1 or positive"
             )))
         } else {
             let n = Min::from(value);
@@ -89,8 +88,7 @@ impl Visitor<'_> for MinVisitor {
     {
         if value < -1 {
             Err(E::custom(format!(
-                "value of type i32 {} should be -1 or positive",
-                value
+                "value of type i32 {value} should be -1 or positive"
             )))
         } else {
             Ok(Min::from(value))
@@ -103,8 +101,7 @@ impl Visitor<'_> for MinVisitor {
     {
         if value < -1 {
             Err(E::custom(format!(
-                "value of type i64 {} should be -1 or positive",
-                value
+                "value of type i64 {value} should be -1 or positive"
             )))
         } else {
             Ok(Min::from(value))

--- a/rbe/src/pending.rs
+++ b/rbe/src/pending.rs
@@ -188,9 +188,9 @@ where
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "Pending {{")?;
         for (v, r) in self.pending_map.iter() {
-            write!(f, "{}@", v)?;
+            write!(f, "{v}@")?;
             for r in r.iter() {
-                write!(f, "{} ", r)?;
+                write!(f, "{r} ")?;
             }
             write!(f, "| ")?;
         }

--- a/rudof_cli/src/input_spec.rs
+++ b/rudof_cli/src/input_spec.rs
@@ -30,7 +30,7 @@ impl Display for InputSpec {
             InputSpec::Path(path_buf) => write!(f, "Path: {}", path_buf.display()),
             InputSpec::Stdin => write!(f, "Stdin"),
             InputSpec::Url(url_spec) => write!(f, "Url: {url_spec}"),
-            InputSpec::Str(s) => write!(f, "String: {}", s),
+            InputSpec::Str(s) => write!(f, "String: {s}"),
         }
     }
 }

--- a/rudof_cli/src/main.rs
+++ b/rudof_cli/src/main.rs
@@ -1489,13 +1489,13 @@ fn show_result<W: Write>(
                         prefixmap.qualify_and_length(&IriS::from_named_node(named_node));
                     format!("{}     ", str)
                 }
-                oxrdf::Term::BlankNode(blank_node) => format!("  {}", blank_node),
-                oxrdf::Term::Literal(literal) => format!("  {}", literal),
-                oxrdf::Term::Triple(triple) => format!("  {}", triple),
+                oxrdf::Term::BlankNode(blank_node) => format!("  {blank_node}"),
+                oxrdf::Term::Literal(literal) => format!("  {literal}"),
+                oxrdf::Term::Triple(triple) => format!("  {triple}"),
             },
             None => String::new(),
         };
-        write!(writer, "{:15}", str)?;
+        write!(writer, "{str:15}")?;
     }
     writeln!(writer)?;
     Ok(())

--- a/rudof_cli/src/main.rs
+++ b/rudof_cli/src/main.rs
@@ -519,7 +519,7 @@ fn run_shex(
         writeln!(io::stdout(), "\nDependencies:")?;
         if let Some(shex_ir) = rudof.get_shex_ir() {
             for (source, posneg, target) in shex_ir.dependencies() {
-                writeln!(io::stdout(), "{}-{}->{}", source, posneg, target)?;
+                writeln!(io::stdout(), "{source}-{posneg}->{target}")?;
             }
         } else {
             bail!("Internal error: No ShEx schema read")
@@ -1057,7 +1057,7 @@ fn run_shex2sparql(
         let converter = ShEx2Sparql::new(&config.shex2sparql_config());
         let sparql = converter.convert(schema, shape)?;
         let (mut writer, _color) = get_writer(output, force_overwrite)?;
-        write!(writer, "{}", sparql)?;
+        write!(writer, "{sparql}")?;
     }
     Ok(())
 }
@@ -1469,8 +1469,8 @@ fn show_variables<'a, W: Write>(
     vars: impl Iterator<Item = &'a VarName>,
 ) -> Result<()> {
     for var in vars {
-        let str = format!("{}", var);
-        write!(writer, "{:15}", str)?;
+        let str = format!("{var}");
+        write!(writer, "{str:15}")?;
     }
     writeln!(writer)?;
     Ok(())
@@ -1487,7 +1487,7 @@ fn show_result<W: Write>(
                 oxrdf::Term::NamedNode(named_node) => {
                     let (str, _length) =
                         prefixmap.qualify_and_length(&IriS::from_named_node(named_node));
-                    format!("{}     ", str)
+                    format!("{str}     ")
                 }
                 oxrdf::Term::BlankNode(blank_node) => format!("  {blank_node}"),
                 oxrdf::Term::Literal(literal) => format!("  {literal}"),

--- a/rudof_lib/src/lib.rs
+++ b/rudof_lib/src/lib.rs
@@ -10,7 +10,7 @@ pub use oxrdf;
 pub use rudof::*;
 pub use rudof_config::*;
 pub use rudof_error::*;
-pub use shacl_ast;
+pub use shacl_ir;
 pub use shacl_validation;
 pub use shapes_graph_source::*;
 pub use srdf;

--- a/rudof_lib/src/rudof.rs
+++ b/rudof_lib/src/rudof.rs
@@ -40,7 +40,7 @@ pub use sparql_service::RdfData;
 pub struct Rudof {
     config: RudofConfig,
     rdf_data: RdfData,
-    shacl_schema: Option<ShaclSchema>, // TODO: Should we store a compiled schema to avoid compiling it for each validation request?
+    shacl_schema: Option<ShaclSchema<RdfData>>, // TODO: Should we store a compiled schema to avoid compiling it for each validation request?
     shex_schema: Option<ShExSchema>,
     shex_schema_ir: Option<SchemaIR>,
     resolved_shex_schema: Option<SchemaWithoutImports>,

--- a/rudof_lib/src/rudof.rs
+++ b/rudof_lib/src/rudof.rs
@@ -486,7 +486,7 @@ impl Rudof {
             ShExValidator::new(schema, &self.config.validator_config()).map_err(|e| {
                 RudofError::ShExValidatorCreationError {
                     error: format!("{e}"),
-                    schema: format!("{}", schema_json),
+                    schema: format!("{schema_json}"),
                 }
             })?;
         self.shex_validator = Some(validator);

--- a/rudof_lib/src/rudof_config.rs
+++ b/rudof_lib/src/rudof_config.rs
@@ -156,7 +156,7 @@ impl FromStr for RudofConfig {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        toml::from_str(s).map_err(|e| format!("Failed to parse RudofConfig: {}", e))
+        toml::from_str(s).map_err(|e| format!("Failed to parse RudofConfig: {e}"))
     }
 }
 

--- a/rudof_lib/src/rudof_error.rs
+++ b/rudof_lib/src/rudof_error.rs
@@ -2,11 +2,16 @@ use std::io;
 
 use iri_s::IriS;
 use shacl_ast::Schema;
+use shacl_ir::compiled_shacl_error::CompiledShaclError;
+use sparql_service::RdfData;
 use srdf::SRDFSparql;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum RudofError {
+    #[error("Compiling SHACL: {error}")]
+    ShaclCompilation { error: Box<CompiledShaclError> },
+
     #[error("Error reading config file from path {path}: {error}")]
     RudofConfigFromPathError { path: String, error: io::Error },
 

--- a/rudof_lib/src/rudof_error.rs
+++ b/rudof_lib/src/rudof_error.rs
@@ -92,10 +92,16 @@ pub enum RudofError {
     SHACLParseError { error: String },
 
     #[error("SHACL Compilation from schema {schema} error: {error}")]
-    SHACLCompilationError { error: String, schema: Box<Schema> },
+    SHACLCompilationError {
+        error: String,
+        schema: Box<Schema<RdfData>>,
+    },
 
     #[error("SHACL Validation from schema {schema} error: {error}")]
-    SHACLValidationError { error: String, schema: Box<Schema> },
+    SHACLValidationError {
+        error: String,
+        schema: Box<Schema<RdfData>>,
+    },
 
     #[error("Creating Endpoint validation for SHACL from endpoint {endpoint:?}. error: {error}")]
     SHACLEndpointValidationCreation {

--- a/shacl_ast/src/ast/node_shape.rs
+++ b/shacl_ast/src/ast/node_shape.rs
@@ -184,7 +184,7 @@ impl<RDF: Rdf> Display for NodeShape<RDF> {
 
 impl<RDF:Rdf> Clone for NodeShape<RDF> {
     fn clone(&self) -> Self {
-        Self { id: self.id.clone(), components: self.components.clone(), targets: self.targets.clone(), property_shapes: self.property_shapes.clone(), closed: self.closed.clone(), deactivated: self.deactivated.clone(), severity: self.severity.clone(), name: self.name.clone(), description: self.description.clone(), group: self.group.clone() }
+        Self { id: self.id.clone(), components: self.components.clone(), targets: self.targets.clone(), property_shapes: self.property_shapes.clone(), closed: self.closed, deactivated: self.deactivated, severity: self.severity.clone(), name: self.name.clone(), description: self.description.clone(), group: self.group.clone() }
     }
 }
 

--- a/shacl_ast/src/ast/node_shape.rs
+++ b/shacl_ast/src/ast/node_shape.rs
@@ -7,8 +7,10 @@ use srdf::{BuildRDF, RDFNode, Rdf};
 use std::fmt::Display;
 
 #[derive(Debug)]
-pub struct NodeShape<RDF: Rdf> 
- where RDF::Term: Clone {
+pub struct NodeShape<RDF: Rdf>
+where
+    RDF::Term: Clone,
+{
     id: RDFNode,
     components: Vec<Component>,
     targets: Vec<Target<RDF>>,
@@ -182,14 +184,34 @@ impl<RDF: Rdf> Display for NodeShape<RDF> {
     }
 }
 
-impl<RDF:Rdf> Clone for NodeShape<RDF> {
+impl<RDF: Rdf> Clone for NodeShape<RDF> {
     fn clone(&self) -> Self {
-        Self { id: self.id.clone(), components: self.components.clone(), targets: self.targets.clone(), property_shapes: self.property_shapes.clone(), closed: self.closed, deactivated: self.deactivated, severity: self.severity.clone(), name: self.name.clone(), description: self.description.clone(), group: self.group.clone() }
+        Self {
+            id: self.id.clone(),
+            components: self.components.clone(),
+            targets: self.targets.clone(),
+            property_shapes: self.property_shapes.clone(),
+            closed: self.closed,
+            deactivated: self.deactivated,
+            severity: self.severity.clone(),
+            name: self.name.clone(),
+            description: self.description.clone(),
+            group: self.group.clone(),
+        }
     }
 }
 
-impl<RDF:Rdf> PartialEq for NodeShape<RDF> {
+impl<RDF: Rdf> PartialEq for NodeShape<RDF> {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id && self.components == other.components && self.targets == other.targets && self.property_shapes == other.property_shapes && self.closed == other.closed && self.deactivated == other.deactivated && self.severity == other.severity && self.name == other.name && self.description == other.description && self.group == other.group
+        self.id == other.id
+            && self.components == other.components
+            && self.targets == other.targets
+            && self.property_shapes == other.property_shapes
+            && self.closed == other.closed
+            && self.deactivated == other.deactivated
+            && self.severity == other.severity
+            && self.name == other.name
+            && self.description == other.description
+            && self.group == other.group
     }
 }

--- a/shacl_ast/src/ast/property_shape.rs
+++ b/shacl_ast/src/ast/property_shape.rs
@@ -274,7 +274,7 @@ impl<RDF: Rdf> Display for PropertyShape<RDF> {
 
 impl<RDF:Rdf> Clone for PropertyShape<RDF> {
     fn clone(&self) -> Self {
-        Self { id: self.id.clone(), path: self.path.clone(), components: self.components.clone(), targets: self.targets.clone(), property_shapes: self.property_shapes.clone(), closed: self.closed.clone(), deactivated: self.deactivated.clone(), severity: self.severity.clone(), name: self.name.clone(), description: self.description.clone(), order: self.order.clone(), group: self.group.clone() }
+        Self { id: self.id.clone(), path: self.path.clone(), components: self.components.clone(), targets: self.targets.clone(), property_shapes: self.property_shapes.clone(), closed: self.closed, deactivated: self.deactivated, severity: self.severity.clone(), name: self.name.clone(), description: self.description.clone(), order: self.order.clone(), group: self.group.clone() }
     }
 }
 

--- a/shacl_ast/src/ast/property_shape.rs
+++ b/shacl_ast/src/ast/property_shape.rs
@@ -272,14 +272,38 @@ impl<RDF: Rdf> Display for PropertyShape<RDF> {
     }
 }
 
-impl<RDF:Rdf> Clone for PropertyShape<RDF> {
+impl<RDF: Rdf> Clone for PropertyShape<RDF> {
     fn clone(&self) -> Self {
-        Self { id: self.id.clone(), path: self.path.clone(), components: self.components.clone(), targets: self.targets.clone(), property_shapes: self.property_shapes.clone(), closed: self.closed, deactivated: self.deactivated, severity: self.severity.clone(), name: self.name.clone(), description: self.description.clone(), order: self.order.clone(), group: self.group.clone() }
+        Self {
+            id: self.id.clone(),
+            path: self.path.clone(),
+            components: self.components.clone(),
+            targets: self.targets.clone(),
+            property_shapes: self.property_shapes.clone(),
+            closed: self.closed,
+            deactivated: self.deactivated,
+            severity: self.severity.clone(),
+            name: self.name.clone(),
+            description: self.description.clone(),
+            order: self.order.clone(),
+            group: self.group.clone(),
+        }
     }
 }
 
-impl<RDF:Rdf> PartialEq for PropertyShape<RDF> {
+impl<RDF: Rdf> PartialEq for PropertyShape<RDF> {
     fn eq(&self, other: &Self) -> bool {
-        self.id == other.id && self.path == other.path && self.components == other.components && self.targets == other.targets && self.property_shapes == other.property_shapes && self.closed == other.closed && self.deactivated == other.deactivated && self.severity == other.severity && self.name == other.name && self.description == other.description && self.order == other.order && self.group == other.group
+        self.id == other.id
+            && self.path == other.path
+            && self.components == other.components
+            && self.targets == other.targets
+            && self.property_shapes == other.property_shapes
+            && self.closed == other.closed
+            && self.deactivated == other.deactivated
+            && self.severity == other.severity
+            && self.name == other.name
+            && self.description == other.description
+            && self.order == other.order
+            && self.group == other.group
     }
 }

--- a/shacl_ast/src/ast/schema.rs
+++ b/shacl_ast/src/ast/schema.rs
@@ -6,7 +6,10 @@ use prefixmap::PrefixMap;
 use srdf::{RDFNode, Rdf};
 
 #[derive(Debug, Clone, Default)]
-pub struct Schema<RDF: Rdf> where RDF::Term: Clone {
+pub struct Schema<RDF: Rdf>
+where
+    RDF::Term: Clone,
+{
     // imports: Vec<IriS>,
     // entailments: Vec<IriS>,
     shapes: HashMap<RDFNode, Shape<RDF>>,
@@ -19,7 +22,7 @@ impl<RDF: Rdf> Schema<RDF> {
         Schema {
             shapes: HashMap::new(),
             prefixmap: PrefixMap::new(),
-            base: None
+            base: None,
         }
     }
 

--- a/shacl_ast/src/ast/shape.rs
+++ b/shacl_ast/src/ast/shape.rs
@@ -51,9 +51,9 @@ impl<RDF: Rdf> Clone for Shape<RDF> {
             Self::PropertyShape(ps) => Self::PropertyShape((*ps).clone()),
         }
     }
-} 
+}
 
-impl <RDF:Rdf> PartialEq for Shape<RDF> {
+impl<RDF: Rdf> PartialEq for Shape<RDF> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::NodeShape(l0), Self::NodeShape(r0)) => l0 == r0,
@@ -70,12 +70,12 @@ mod tests {
 
     use crate::{node_shape::NodeShape, shape::Shape};
 
-
     #[test]
     fn test_clone() {
-        let ns: NodeShape<SRDFGraph> = NodeShape::new(srdf::Object::Iri(iri!("http://example.org/id")));
+        let ns: NodeShape<SRDFGraph> =
+            NodeShape::new(srdf::Object::Iri(iri!("http://example.org/id")));
         let s1 = Shape::node_shape(ns);
         let s2 = s1.clone();
-        assert_eq!(s1,s2)
+        assert_eq!(s1, s2)
     }
 }

--- a/shacl_ast/src/ast/target.rs
+++ b/shacl_ast/src/ast/target.rs
@@ -9,7 +9,9 @@ use srdf::{rdf_type, rdfs_class, BuildRDF, RDFNode, Rdf};
 /// Represents target declarations
 #[derive(Debug)]
 pub enum Target<S: Rdf>
- where S::Term: Clone {
+where
+    S::Term: Clone,
+{
     TargetNode(RDFNode), // TODO: Shacl12: Extend to Node Expressions
     TargetClass(RDFNode),
     TargetSubjectsOf(IriRef),
@@ -21,11 +23,10 @@ pub enum Target<S: Rdf>
     WrongTargetClass(S::Term),
     WrongSubjectsOf(S::Term),
     WrongObjectsOf(S::Term),
-    WrongImplicitClass(S::Term)
-
+    WrongImplicitClass(S::Term),
 }
 
-impl<S:Rdf> Target<S> {
+impl<S: Rdf> Target<S> {
     pub fn target_node(node: RDFNode) -> Self {
         Target::TargetNode(node)
     }
@@ -48,25 +49,25 @@ impl<S:Rdf> Target<S> {
         let node: RDF::Subject = rdf_node.clone().try_into().map_err(|_| unreachable!())?;
         match self {
             Target::TargetNode(target_rdf_node) => {
-                        rdf.add_triple(node, sh_target_node().clone(), target_rdf_node.clone())
-                    }
+                rdf.add_triple(node, sh_target_node().clone(), target_rdf_node.clone())
+            }
             Target::TargetClass(node_class) => {
-                        rdf.add_triple(node, sh_target_class().clone(), node_class.clone())
-                    }
+                rdf.add_triple(node, sh_target_class().clone(), node_class.clone())
+            }
             Target::TargetSubjectsOf(iri_ref) => rdf.add_triple(
-                        node,
-                        sh_target_subjects_of().clone(),
-                        iri_ref.get_iri().unwrap().clone(),
-                    ),
+                node,
+                sh_target_subjects_of().clone(),
+                iri_ref.get_iri().unwrap().clone(),
+            ),
             Target::TargetObjectsOf(iri_ref) => rdf.add_triple(
-                        node,
-                        sh_target_objects_of().clone(),
-                        iri_ref.get_iri().unwrap().clone(),
-                    ),
+                node,
+                sh_target_objects_of().clone(),
+                iri_ref.get_iri().unwrap().clone(),
+            ),
             Target::TargetImplicitClass(_class) => {
-                        // TODO: Review this code and in SHACL 1.2, add sh_shape_class ?
-                        rdf.add_triple(node, rdf_type().clone(), rdfs_class().clone())
-                    }
+                // TODO: Review this code and in SHACL 1.2, add sh_shape_class ?
+                rdf.add_triple(node, rdf_type().clone(), rdfs_class().clone())
+            }
             Target::WrongTargetNode(_) => todo!(),
             Target::WrongTargetClass(_) => todo!(),
             Target::WrongSubjectsOf(_) => todo!(),
@@ -76,7 +77,7 @@ impl<S:Rdf> Target<S> {
     }
 }
 
-impl<S:Rdf> Display for Target<S> {
+impl<S: Rdf> Display for Target<S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Target::TargetNode(node) => write!(f, "targetNode({node})"),
@@ -93,7 +94,7 @@ impl<S:Rdf> Display for Target<S> {
     }
 }
 
-impl <RDF: Rdf> Clone for Target<RDF> {
+impl<RDF: Rdf> Clone for Target<RDF> {
     fn clone(&self) -> Self {
         match self {
             Self::TargetNode(arg0) => Self::TargetNode(arg0.clone()),
@@ -110,7 +111,7 @@ impl <RDF: Rdf> Clone for Target<RDF> {
     }
 }
 
-impl<RDF:Rdf> PartialEq for Target<RDF> {
+impl<RDF: Rdf> PartialEq for Target<RDF> {
     fn eq(&self, other: &Self) -> bool {
         match (self, other) {
             (Self::TargetNode(l0), Self::TargetNode(r0)) => l0 == r0,

--- a/shacl_ir/src/compiled/component.rs
+++ b/shacl_ir/src/compiled/component.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use super::compile_shape;
 use super::compile_shapes;
 use super::compiled_shacl_error::CompiledShaclError;
@@ -65,7 +63,7 @@ impl CompiledComponent {
                 CompiledComponent::Class(Class::new(class_rule))
             }
             Component::Datatype(iri_ref) => {
-                let iri_ref = convert_iri_ref::<S>(iri_ref)?;
+                let iri_ref = convert_iri_ref(iri_ref)?;
                 CompiledComponent::Datatype(Datatype::new(iri_ref))
             }
             Component::NodeKind(node_kind) => CompiledComponent::NodeKind(Nodekind::new(node_kind)),
@@ -93,19 +91,19 @@ impl CompiledComponent {
                 CompiledComponent::LanguageIn(LanguageIn::new(langs))
             }
             Component::Equals(iri_ref) => {
-                let iri_ref = convert_iri_ref::<S>(iri_ref)?;
+                let iri_ref = convert_iri_ref(iri_ref)?;
                 CompiledComponent::Equals(Equals::new(iri_ref))
             }
             Component::Disjoint(iri_ref) => {
-                let iri_ref = convert_iri_ref::<S>(iri_ref)?;
+                let iri_ref = convert_iri_ref(iri_ref)?;
                 CompiledComponent::Disjoint(Disjoint::new(iri_ref))
             }
             Component::LessThan(iri_ref) => {
-                let iri_ref = convert_iri_ref::<S>(iri_ref)?;
+                let iri_ref = convert_iri_ref(iri_ref)?;
                 CompiledComponent::LessThan(LessThan::new(iri_ref))
             }
             Component::LessThanOrEquals(iri_ref) => {
-                let iri_ref = convert_iri_ref::<S>(iri_ref)?;
+                let iri_ref = convert_iri_ref(iri_ref)?;
                 CompiledComponent::LessThanOrEquals(LessThanOrEquals::new(iri_ref))
             }
             Component::Or { shapes } => {
@@ -127,7 +125,7 @@ impl CompiledComponent {
             } => {
                 let properties = ignored_properties
                     .into_iter()
-                    .map(|prop| convert_iri_ref::<S>(prop))
+                    .map(|prop| convert_iri_ref(prop))
                     .collect::<Result<Vec<_>, _>>()?;
                 CompiledComponent::Closed(Closed::new(is_closed, properties))
             }
@@ -136,13 +134,13 @@ impl CompiledComponent {
                 CompiledComponent::Node(Node::new(shape))
             }
             Component::HasValue { value } => {
-                let term = convert_value::<S>(value)?;
+                let term = convert_value(value)?;
                 CompiledComponent::HasValue(HasValue::new(term))
             }
             Component::In { values } => {
                 let terms = values
                     .into_iter()
-                    .map(|value| convert_value::<S>(value))
+                    .map(|value| convert_value(value))
                     .collect::<Result<Vec<_>, _>>()?;
                 CompiledComponent::In(In::new(terms))
             }
@@ -638,16 +636,16 @@ impl UniqueLang {
 ///
 /// https://www.w3.org/TR/shacl/#ClassConstraintComponent
 #[derive(Debug)]
-pub struct Class<S: Rdf> {
-    class_rule: S::Term,
+pub struct Class {
+    class_rule: RDFNode,
 }
 
-impl<S: Rdf> Class<S> {
-    pub fn new(class_rule: S::Term) -> Self {
+impl Class {
+    pub fn new(class_rule: RDFNode) -> Self {
         Class { class_rule }
     }
 
-    pub fn class_rule(&self) -> &S::Term {
+    pub fn class_rule(&self) -> &RDFNode {
         &self.class_rule
     }
 }
@@ -657,16 +655,16 @@ impl<S: Rdf> Class<S> {
 ///
 /// https://www.w3.org/TR/shacl/#ClassConstraintComponent
 #[derive(Debug)]
-pub struct Datatype<S: Rdf> {
-    datatype: S::IRI,
+pub struct Datatype {
+    datatype: IriS,
 }
 
-impl<S: Rdf> Datatype<S> {
-    pub fn new(datatype: S::IRI) -> Self {
+impl Datatype {
+    pub fn new(datatype: IriS) -> Self {
         Datatype { datatype }
     }
 
-    pub fn datatype(&self) -> &S::IRI {
+    pub fn datatype(&self) -> &IriS {
         &self.datatype
     }
 }
@@ -692,16 +690,14 @@ impl Nodekind {
 
 /// https://www.w3.org/TR/shacl/#MaxExclusiveConstraintComponent
 #[derive(Debug)]
-pub struct MaxExclusive<S> {
+pub struct MaxExclusive {
     max_exclusive: SLiteral,
-    _marker: PhantomData<S>,
 }
 
-impl<S> MaxExclusive<S> {
+impl MaxExclusive {
     pub fn new(literal: SLiteral) -> Self {
         MaxExclusive {
             max_exclusive: literal,
-            _marker: PhantomData,
         }
     }
 
@@ -712,16 +708,14 @@ impl<S> MaxExclusive<S> {
 
 /// https://www.w3.org/TR/shacl/#MaxInclusiveConstraintComponent
 #[derive(Debug)]
-pub struct MaxInclusive<S> {
+pub struct MaxInclusive {
     max_inclusive: SLiteral,
-    _marker: PhantomData<S>,
 }
 
-impl<S: Rdf> MaxInclusive<S> {
+impl MaxInclusive {
     pub fn new(literal: SLiteral) -> Self {
         MaxInclusive {
             max_inclusive: literal,
-            _marker: PhantomData,
         }
     }
 
@@ -732,16 +726,14 @@ impl<S: Rdf> MaxInclusive<S> {
 
 /// https://www.w3.org/TR/shacl/#MinExclusiveConstraintComponent
 #[derive(Debug)]
-pub struct MinExclusive<S> {
+pub struct MinExclusive {
     min_exclusive: SLiteral,
-    _marker: PhantomData<S>,
 }
 
-impl<S> MinExclusive<S> {
+impl MinExclusive {
     pub fn new(literal: SLiteral) -> Self {
         MinExclusive {
             min_exclusive: literal,
-            _marker: PhantomData,
         }
     }
 
@@ -752,16 +744,14 @@ impl<S> MinExclusive<S> {
 
 /// https://www.w3.org/TR/shacl/#MinInclusiveConstraintComponent
 #[derive(Debug)]
-pub struct MinInclusive<S> {
+pub struct MinInclusive {
     min_inclusive: SLiteral,
-    _marker: PhantomData<S>,
 }
 
-impl<S> MinInclusive<S> {
+impl MinInclusive {
     pub fn new(literal: SLiteral) -> Self {
         MinInclusive {
             min_inclusive: literal,
-            _marker: PhantomData,
         }
     }
 
@@ -770,8 +760,8 @@ impl<S> MinInclusive<S> {
     }
 }
 
-impl<S: Rdf> From<&CompiledComponent<S>> for IriS {
-    fn from(value: &CompiledComponent<S>) -> Self {
+impl From<&CompiledComponent> for IriS {
+    fn from(value: &CompiledComponent) -> Self {
         match value {
             CompiledComponent::Class(_) => sh_class().clone(),
             CompiledComponent::Datatype(_) => sh_datatype().clone(),

--- a/shacl_ir/src/compiled/component.rs
+++ b/shacl_ir/src/compiled/component.rs
@@ -59,7 +59,7 @@ impl CompiledComponent {
     ) -> Result<Self, CompiledShaclError> {
         let component = match component {
             Component::Class(object) => {
-                let class_rule = object.into();
+                let class_rule = object;
                 CompiledComponent::Class(Class::new(class_rule))
             }
             Component::Datatype(iri_ref) => {
@@ -125,7 +125,7 @@ impl CompiledComponent {
             } => {
                 let properties = ignored_properties
                     .into_iter()
-                    .map(|prop| convert_iri_ref(prop))
+                    .map(convert_iri_ref)
                     .collect::<Result<Vec<_>, _>>()?;
                 CompiledComponent::Closed(Closed::new(is_closed, properties))
             }
@@ -140,7 +140,7 @@ impl CompiledComponent {
             Component::In { values } => {
                 let terms = values
                     .into_iter()
-                    .map(|value| convert_value(value))
+                    .map(convert_value)
                     .collect::<Result<Vec<_>, _>>()?;
                 CompiledComponent::In(In::new(terms))
             }

--- a/shacl_ir/src/compiled/component.rs
+++ b/shacl_ir/src/compiled/component.rs
@@ -21,7 +21,7 @@ use srdf::RDFNode;
 use srdf::Rdf;
 use srdf::SLiteral;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CompiledComponent {
     Class(Class),
     Datatype(Datatype),
@@ -170,7 +170,7 @@ impl CompiledComponent {
 /// - IRI: https://www.w3.org/TR/shacl/#MaxCountConstraintComponent
 /// - DEF: If the number of value nodes is greater than $maxCount, there is a
 ///   validation result.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MaxCount {
     max_count: usize,
 }
@@ -194,7 +194,7 @@ impl MaxCount {
 /// - IRI: https://www.w3.org/TR/shacl/#MinCountConstraintComponent
 /// - DEF: If the number of value nodes is less than $minCount, there is a
 ///   validation result.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MinCount {
     min_count: usize,
 }
@@ -215,7 +215,7 @@ impl MinCount {
 /// shapes. This is comparable to conjunction and the logical "and" operator.
 ///
 /// https://www.w3.org/TR/shacl/#AndConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct And {
     shapes: Vec<CompiledShape>,
 }
@@ -234,7 +234,7 @@ impl And {
 /// given shape. This is comparable to negation and the logical "not" operator.
 ///
 /// https://www.w3.org/TR/shacl/#NotConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Not {
     shape: Box<CompiledShape>,
 }
@@ -257,7 +257,7 @@ impl Not {
 ///
 /// https://www.w3.org/TR/shacl/#AndConstraintComponent
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Or {
     shapes: Vec<CompiledShape>,
 }
@@ -277,7 +277,7 @@ impl Or {
 /// "or" operator.
 ///
 /// https://www.w3.org/TR/shacl/#XoneConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Xone {
     shapes: Vec<CompiledShape>,
 }
@@ -303,7 +303,7 @@ impl Xone {
 /// shapes specified for the shape via sh:property.
 ///
 /// https://www.w3.org/TR/shacl/#ClosedConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Closed {
     is_closed: bool,
     ignored_properties: Vec<IriS>,
@@ -330,7 +330,7 @@ impl Closed {
 ///  the given RDF term.
 ///
 /// https://www.w3.org/TR/shacl/#HasValueConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct HasValue {
     value: RDFNode,
 }
@@ -349,7 +349,7 @@ impl HasValue {
 /// SHACL list.
 ///
 /// https://www.w3.org/TR/shacl/#InConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct In {
     values: Vec<RDFNode>,
 }
@@ -369,7 +369,7 @@ impl In {
 /// and the value of sh:disjoint as predicate.
 ///
 /// https://www.w3.org/TR/shacl/#DisjointConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Disjoint {
     iri: IriS,
 }
@@ -389,7 +389,7 @@ impl Disjoint {
 /// the value of sh:equals as predicate.
 ///
 /// https://www.w3.org/TR/shacl/#EqualsConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Equals {
     iri: IriS,
 }
@@ -411,7 +411,7 @@ impl Equals {
 /// as subject and the value of sh:lessThanOrEquals as predicate.
 ///
 /// https://www.w3.org/TR/shacl/#LessThanOrEqualsConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LessThanOrEquals {
     iri: IriS,
 }
@@ -431,7 +431,7 @@ impl LessThanOrEquals {
 /// value of sh:lessThan as predicate.
 ///
 /// https://www.w3.org/TR/shacl/#LessThanConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LessThan {
     iri: IriS,
 }
@@ -450,7 +450,7 @@ impl LessThan {
 /// node shape.
 ///
 /// https://www.w3.org/TR/shacl/#NodeShapeComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Node {
     shape: Box<CompiledShape>,
 }
@@ -475,7 +475,7 @@ impl Node {
 ///  sh:qualifiedMaxCount or, one value for each, at the same subject.
 ///
 /// https://www.w3.org/TR/shacl/#QualifiedValueShapeConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct QualifiedValueShape {
     shape: Box<CompiledShape>,
     qualified_min_count: Option<isize>,
@@ -519,7 +519,7 @@ impl QualifiedValueShape {
 /// for each value node are limited by a given list of language tags.
 ///
 /// https://www.w3.org/TR/shacl/#LanguageInConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LanguageIn {
     langs: Vec<Lang>,
 }
@@ -539,7 +539,7 @@ impl LanguageIn {
 /// not to blank nodes.
 ///
 /// https://www.w3.org/TR/shacl/#MaxLengthConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MaxLength {
     max_length: isize,
 }
@@ -559,7 +559,7 @@ impl MaxLength {
 /// not to blank nodes.
 ///
 /// https://www.w3.org/TR/shacl/#MinLengthConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MinLength {
     min_length: isize,
 }
@@ -578,7 +578,7 @@ impl MinLength {
 /// shape.
 ///
 /// https://www.w3.org/TR/shacl/#PropertyShapeComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Pattern {
     pattern: String,
     flags: Option<String>,
@@ -616,7 +616,7 @@ impl Pattern {
 ///  value nodes may use the same language tag.
 ///
 /// https://www.w3.org/TR/shacl/#UniqueLangConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UniqueLang {
     unique_lang: bool,
 }
@@ -635,7 +635,7 @@ impl UniqueLang {
 /// instance of a given type.
 ///
 /// https://www.w3.org/TR/shacl/#ClassConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Class {
     class_rule: RDFNode,
 }
@@ -654,7 +654,7 @@ impl Class {
 /// datatype of each value node.
 ///
 /// https://www.w3.org/TR/shacl/#ClassConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Datatype {
     datatype: IriS,
 }
@@ -673,7 +673,7 @@ impl Datatype {
 /// each value node.
 ///
 /// https://www.w3.org/TR/shacl/#NodeKindConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Nodekind {
     node_kind: NodeKind,
 }
@@ -689,7 +689,7 @@ impl Nodekind {
 }
 
 /// https://www.w3.org/TR/shacl/#MaxExclusiveConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MaxExclusive {
     max_exclusive: SLiteral,
 }
@@ -707,7 +707,7 @@ impl MaxExclusive {
 }
 
 /// https://www.w3.org/TR/shacl/#MaxInclusiveConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MaxInclusive {
     max_inclusive: SLiteral,
 }
@@ -725,7 +725,7 @@ impl MaxInclusive {
 }
 
 /// https://www.w3.org/TR/shacl/#MinExclusiveConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MinExclusive {
     min_exclusive: SLiteral,
 }
@@ -743,7 +743,7 @@ impl MinExclusive {
 }
 
 /// https://www.w3.org/TR/shacl/#MinInclusiveConstraintComponent
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MinInclusive {
     min_inclusive: SLiteral,
 }

--- a/shacl_ir/src/compiled/mod.rs
+++ b/shacl_ir/src/compiled/mod.rs
@@ -50,7 +50,7 @@ fn convert_value(value: Value) -> Result<RDFNode, CompiledShaclError> {
     let ans = match value {
         Value::Iri(iri_ref) => {
             let iri = convert_iri_ref(iri_ref)?;
-            
+
             RDFNode::iri(iri)
         }
         Value::Literal(literal) => RDFNode::literal(literal),

--- a/shacl_ir/src/compiled/mod.rs
+++ b/shacl_ir/src/compiled/mod.rs
@@ -1,7 +1,9 @@
 use compiled_shacl_error::CompiledShaclError;
+use iri_s::IriS;
 use prefixmap::IriRef;
 use shape::CompiledShape;
 use srdf::Object;
+use srdf::RDFNode;
 use srdf::Rdf;
 
 use shacl_ast::value::Value;
@@ -16,11 +18,10 @@ pub mod severity;
 pub mod shape;
 pub mod target;
 
-fn convert_iri_ref<S: Rdf>(iri_ref: IriRef) -> Result<S::IRI, CompiledShaclError> {
+fn convert_iri_ref(iri_ref: IriRef) -> Result<IriS, CompiledShaclError> {
     let iri = iri_ref
         .get_iri()
-        .map_err(|_| CompiledShaclError::IriRefConversion)?
-        .into();
+        .map_err(|_| CompiledShaclError::IriRefConversion)?;
     Ok(iri)
 }
 
@@ -45,18 +46,14 @@ fn compile_shapes<S: Rdf>(
     Ok(compiled_shapes)
 }
 
-fn convert_value<S: Rdf>(value: Value) -> Result<S::Term, CompiledShaclError> {
+fn convert_value(value: Value) -> Result<RDFNode, CompiledShaclError> {
     let ans = match value {
         Value::Iri(iri_ref) => {
-            let iri = convert_iri_ref::<S>(iri_ref)?;
-            let term: S::Term = <S::Term as From<S::IRI>>::from(iri);
+            let iri = convert_iri_ref(iri_ref)?;
+            let term = RDFNode::iri(iri);
             term
         }
-        Value::Literal(literal) => {
-            let literal: S::Literal = literal.into();
-            let term: S::Term = <S::Term as From<S::Literal>>::from(literal);
-            term
-        }
+        Value::Literal(literal) => RDFNode::literal(literal),
     };
     Ok(ans)
 }

--- a/shacl_ir/src/compiled/mod.rs
+++ b/shacl_ir/src/compiled/mod.rs
@@ -27,7 +27,7 @@ fn convert_iri_ref<S: Rdf>(iri_ref: IriRef) -> Result<S::IRI, CompiledShaclError
 fn compile_shape<S: Rdf>(
     shape: Object,
     schema: &Schema<S>,
-) -> Result<CompiledShape<S>, CompiledShaclError> {
+) -> Result<CompiledShape, CompiledShaclError> {
     let shape = schema
         .get_shape(&shape)
         .ok_or(CompiledShaclError::ShapeNotFound)?;
@@ -37,7 +37,7 @@ fn compile_shape<S: Rdf>(
 fn compile_shapes<S: Rdf>(
     shapes: Vec<Object>,
     schema: &Schema<S>,
-) -> Result<Vec<CompiledShape<S>>, CompiledShaclError> {
+) -> Result<Vec<CompiledShape>, CompiledShaclError> {
     let compiled_shapes = shapes
         .into_iter()
         .map(|shape| compile_shape::<S>(shape, schema))

--- a/shacl_ir/src/compiled/mod.rs
+++ b/shacl_ir/src/compiled/mod.rs
@@ -50,8 +50,8 @@ fn convert_value(value: Value) -> Result<RDFNode, CompiledShaclError> {
     let ans = match value {
         Value::Iri(iri_ref) => {
             let iri = convert_iri_ref(iri_ref)?;
-            let term = RDFNode::iri(iri);
-            term
+            
+            RDFNode::iri(iri)
         }
         Value::Literal(literal) => RDFNode::literal(literal),
     };

--- a/shacl_ir/src/compiled/node_shape.rs
+++ b/shacl_ir/src/compiled/node_shape.rs
@@ -87,7 +87,7 @@ impl CompiledNodeShape {
         shape: Box<NodeShape<S>>,
         schema: &Schema<S>,
     ) -> Result<Self, CompiledShaclError> {
-        let id = shape.id().clone().into();
+        let id = shape.id().clone();
         let closed = shape.is_closed().to_owned();
         let deactivated = shape.is_deactivated().to_owned();
         let severity = CompiledSeverity::compile(shape.severity())?;

--- a/shacl_ir/src/compiled/node_shape.rs
+++ b/shacl_ir/src/compiled/node_shape.rs
@@ -13,31 +13,31 @@ use super::shape::CompiledShape;
 use super::target::CompiledTarget;
 
 #[derive(Debug)]
-pub struct CompiledNodeShape<S: Rdf> {
+pub struct CompiledNodeShape {
     id: S::Term,
-    components: Vec<CompiledComponent<S>>,
-    targets: Vec<CompiledTarget<S>>,
-    property_shapes: Vec<CompiledShape<S>>,
+    components: Vec<CompiledComponent>,
+    targets: Vec<CompiledTarget>,
+    property_shapes: Vec<CompiledShape>,
     closed: bool,
     // ignored_properties: Vec<S::IRI>,
     deactivated: bool,
     // message: MessageMap,
-    severity: Option<CompiledSeverity<S>>,
+    severity: Option<CompiledSeverity>,
     // name: MessageMap,
     // description: MessageMap,
     // group: S::Term,
     // source_iri: S::IRI,
 }
 
-impl<S: Rdf> CompiledNodeShape<S> {
+impl CompiledNodeShape {
     pub fn new(
         id: S::Term,
-        components: Vec<CompiledComponent<S>>,
-        targets: Vec<CompiledTarget<S>>,
-        property_shapes: Vec<CompiledShape<S>>,
+        components: Vec<CompiledComponent>,
+        targets: Vec<CompiledTarget>,
+        property_shapes: Vec<CompiledShape>,
         closed: bool,
         deactivated: bool,
-        severity: Option<CompiledSeverity<S>>,
+        severity: Option<CompiledSeverity>,
     ) -> Self {
         CompiledNodeShape {
             id,
@@ -50,7 +50,7 @@ impl<S: Rdf> CompiledNodeShape<S> {
         }
     }
 
-    pub fn id(&self) -> &S::Term {
+    pub fn id(&self) -> &RDFNode {
         &self.id
     }
 
@@ -58,22 +58,22 @@ impl<S: Rdf> CompiledNodeShape<S> {
         &self.deactivated
     }
 
-    pub fn severity(&self) -> &CompiledSeverity<S> {
+    pub fn severity(&self) -> &CompiledSeverity {
         match &self.severity {
             Some(severity) => severity,
             None => &CompiledSeverity::Violation,
         }
     }
 
-    pub fn components(&self) -> &Vec<CompiledComponent<S>> {
+    pub fn components(&self) -> &Vec<CompiledComponent> {
         &self.components
     }
 
-    pub fn targets(&self) -> &Vec<CompiledTarget<S>> {
+    pub fn targets(&self) -> &Vec<CompiledTarget> {
         &self.targets
     }
 
-    pub fn property_shapes(&self) -> &Vec<CompiledShape<S>> {
+    pub fn property_shapes(&self) -> &Vec<CompiledShape> {
         &self.property_shapes
     }
 
@@ -82,8 +82,11 @@ impl<S: Rdf> CompiledNodeShape<S> {
     }
 }
 
-impl<S: Rdf> CompiledNodeShape<S> {
-    pub fn compile(shape: Box<NodeShape<S>>, schema: &Schema<S>) -> Result<Self, CompiledShaclError> {
+impl CompiledNodeShape {
+    pub fn compile<S: Rdf>(
+        shape: Box<NodeShape<S>>,
+        schema: &Schema<S>,
+    ) -> Result<Self, CompiledShaclError> {
         let id = shape.id().clone().into();
         let closed = shape.is_closed().to_owned();
         let deactivated = shape.is_deactivated().to_owned();

--- a/shacl_ir/src/compiled/node_shape.rs
+++ b/shacl_ir/src/compiled/node_shape.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use srdf::Rdf;
+use srdf::{RDFNode, Rdf};
 
 use shacl_ast::node_shape::NodeShape;
 use shacl_ast::Schema;
@@ -14,7 +14,7 @@ use super::target::CompiledTarget;
 
 #[derive(Debug)]
 pub struct CompiledNodeShape {
-    id: S::Term,
+    id: RDFNode,
     components: Vec<CompiledComponent>,
     targets: Vec<CompiledTarget>,
     property_shapes: Vec<CompiledShape>,
@@ -31,7 +31,7 @@ pub struct CompiledNodeShape {
 
 impl CompiledNodeShape {
     pub fn new(
-        id: S::Term,
+        id: RDFNode,
         components: Vec<CompiledComponent>,
         targets: Vec<CompiledTarget>,
         property_shapes: Vec<CompiledShape>,

--- a/shacl_ir/src/compiled/node_shape.rs
+++ b/shacl_ir/src/compiled/node_shape.rs
@@ -12,7 +12,7 @@ use super::severity::CompiledSeverity;
 use super::shape::CompiledShape;
 use super::target::CompiledTarget;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CompiledNodeShape {
     id: RDFNode,
     components: Vec<CompiledComponent>,

--- a/shacl_ir/src/compiled/property_shape.rs
+++ b/shacl_ir/src/compiled/property_shape.rs
@@ -16,7 +16,7 @@ use super::target::CompiledTarget;
 
 #[derive(Debug)]
 pub struct CompiledPropertyShape {
-    id: S::Term,
+    id: RDFNode,
     path: SHACLPath,
     components: Vec<CompiledComponent>,
     targets: Vec<CompiledTarget>,
@@ -37,7 +37,7 @@ pub struct CompiledPropertyShape {
 impl CompiledPropertyShape {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        id: S::Term,
+        id: RDFNode,
         path: SHACLPath,
         components: Vec<CompiledComponent>,
         targets: Vec<CompiledTarget>,
@@ -94,8 +94,8 @@ impl CompiledPropertyShape {
     }
 }
 
-impl<S: Rdf> CompiledPropertyShape<S> {
-    pub fn compile(
+impl CompiledPropertyShape {
+    pub fn compile<S: Rdf>(
         shape: PropertyShape<S>,
         schema: &Schema<S>,
     ) -> Result<Self, CompiledShaclError> {

--- a/shacl_ir/src/compiled/property_shape.rs
+++ b/shacl_ir/src/compiled/property_shape.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use srdf::RDFNode;
 use srdf::Rdf;
 use srdf::SHACLPath;
 
@@ -14,17 +15,17 @@ use super::shape::CompiledShape;
 use super::target::CompiledTarget;
 
 #[derive(Debug)]
-pub struct CompiledPropertyShape<S: Rdf> {
+pub struct CompiledPropertyShape {
     id: S::Term,
     path: SHACLPath,
-    components: Vec<CompiledComponent<S>>,
-    targets: Vec<CompiledTarget<S>>,
-    property_shapes: Vec<CompiledShape<S>>,
+    components: Vec<CompiledComponent>,
+    targets: Vec<CompiledTarget>,
+    property_shapes: Vec<CompiledShape>,
     closed: bool,
     // ignored_properties: Vec<S::IRI>,
     deactivated: bool,
     // message: MessageMap,
-    severity: Option<CompiledSeverity<S>>,
+    severity: Option<CompiledSeverity>,
     // name: MessageMap,
     // description: MessageMap,
     // order: Option<NumericLiteral>,
@@ -33,17 +34,17 @@ pub struct CompiledPropertyShape<S: Rdf> {
     // annotations: Vec<(S::IRI, S::Term)>,
 }
 
-impl<S: Rdf> CompiledPropertyShape<S> {
+impl CompiledPropertyShape {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: S::Term,
         path: SHACLPath,
-        components: Vec<CompiledComponent<S>>,
-        targets: Vec<CompiledTarget<S>>,
-        property_shapes: Vec<CompiledShape<S>>,
+        components: Vec<CompiledComponent>,
+        targets: Vec<CompiledTarget>,
+        property_shapes: Vec<CompiledShape>,
         closed: bool,
         deactivated: bool,
-        severity: Option<CompiledSeverity<S>>,
+        severity: Option<CompiledSeverity>,
     ) -> Self {
         CompiledPropertyShape {
             id,
@@ -57,7 +58,7 @@ impl<S: Rdf> CompiledPropertyShape<S> {
         }
     }
 
-    pub fn id(&self) -> &S::Term {
+    pub fn id(&self) -> &RDFNode {
         &self.id
     }
 
@@ -73,28 +74,31 @@ impl<S: Rdf> CompiledPropertyShape<S> {
         &self.deactivated
     }
 
-    pub fn severity(&self) -> &CompiledSeverity<S> {
+    pub fn severity(&self) -> &CompiledSeverity {
         match &self.severity {
             Some(severity) => severity,
             None => &CompiledSeverity::Violation,
         }
     }
 
-    pub fn components(&self) -> &Vec<CompiledComponent<S>> {
+    pub fn components(&self) -> &Vec<CompiledComponent> {
         &self.components
     }
 
-    pub fn targets(&self) -> &Vec<CompiledTarget<S>> {
+    pub fn targets(&self) -> &Vec<CompiledTarget> {
         &self.targets
     }
 
-    pub fn property_shapes(&self) -> &Vec<CompiledShape<S>> {
+    pub fn property_shapes(&self) -> &Vec<CompiledShape> {
         &self.property_shapes
     }
 }
 
 impl<S: Rdf> CompiledPropertyShape<S> {
-    pub fn compile(shape: PropertyShape<S>, schema: &Schema<S>) -> Result<Self, CompiledShaclError> {
+    pub fn compile(
+        shape: PropertyShape<S>,
+        schema: &Schema<S>,
+    ) -> Result<Self, CompiledShaclError> {
         let id = shape.id().clone().into();
         let path = shape.path().to_owned();
         let closed = shape.is_closed().to_owned();

--- a/shacl_ir/src/compiled/property_shape.rs
+++ b/shacl_ir/src/compiled/property_shape.rs
@@ -99,7 +99,7 @@ impl CompiledPropertyShape {
         shape: PropertyShape<S>,
         schema: &Schema<S>,
     ) -> Result<Self, CompiledShaclError> {
-        let id = shape.id().clone().into();
+        let id = shape.id().clone();
         let path = shape.path().to_owned();
         let closed = shape.is_closed().to_owned();
         let deactivated = shape.is_deactivated().to_owned();

--- a/shacl_ir/src/compiled/property_shape.rs
+++ b/shacl_ir/src/compiled/property_shape.rs
@@ -14,7 +14,7 @@ use super::severity::CompiledSeverity;
 use super::shape::CompiledShape;
 use super::target::CompiledTarget;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct CompiledPropertyShape {
     id: RDFNode,
     path: SHACLPath,

--- a/shacl_ir/src/compiled/schema.rs
+++ b/shacl_ir/src/compiled/schema.rs
@@ -44,7 +44,7 @@ impl SchemaIR {
         let schema = ShaclParser::new(rdf)
             .parse()
             .map_err(CompiledShaclError::ShaclParserError)?;
-        let schema_ir: SchemaIR = Self::compile(&schema)?;
+        let schema_ir: SchemaIR = schema.try_into()?;
         Ok(schema_ir)
     }
 
@@ -65,7 +65,7 @@ impl SchemaIR {
         &self.base
     }
 
-    pub fn iter(&self) -> impl Iterator<Item = (&IriS, &CompiledShape)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&RDFNode, &CompiledShape)> {
         self.shapes.iter()
     }
 
@@ -149,7 +149,7 @@ mod tests {
             ] .
     "#;
 
-    fn load_schema(shacl_schema: &str) -> SchemaIR<SRDFGraph> {
+    fn load_schema(shacl_schema: &str) -> SchemaIR {
         let reader = Cursor::new(shacl_schema);
         let rdf_format = RDFFormat::Turtle;
         let base = None;

--- a/shacl_ir/src/compiled/schema.rs
+++ b/shacl_ir/src/compiled/schema.rs
@@ -84,14 +84,14 @@ impl SchemaIR {
         let mut shapes = HashMap::default();
 
         for (rdf_node, shape) in schema.iter() {
-            let term = rdf_node.clone().into();
-            let shape = CompiledShape::compile(shape.to_owned(), &schema)?;
+            let term = rdf_node.clone();
+            let shape = CompiledShape::compile(shape.to_owned(), schema)?;
             shapes.insert(term, shape);
         }
 
         let prefixmap = schema.prefix_map();
 
-        let base = schema.base().map(Into::into);
+        let base = schema.base();
 
         Ok(SchemaIR::new(shapes, prefixmap, base))
     }

--- a/shacl_ir/src/compiled/schema.rs
+++ b/shacl_ir/src/compiled/schema.rs
@@ -3,6 +3,7 @@ use prefixmap::PrefixMap;
 use shacl_rdf::ShaclParser;
 use srdf::{RDFFormat, RDFNode, Rdf, ReaderMode, SRDFGraph};
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::io;
 
 use shacl_ast::Schema;
@@ -10,7 +11,7 @@ use shacl_ast::Schema;
 use super::compiled_shacl_error::CompiledShaclError;
 use super::shape::CompiledShape;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct SchemaIR {
     // imports: Vec<IriS>,
     // entailments: Vec<IriS>,
@@ -110,6 +111,16 @@ impl<RDF: Rdf> TryFrom<&Schema<RDF>> for SchemaIR {
 
     fn try_from(schema: &Schema<RDF>) -> Result<Self, Self::Error> {
         Self::compile(schema)
+    }
+}
+
+impl Display for SchemaIR {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "SHACL shapes graph",)?;
+        for (node, shape) in self.shapes.iter() {
+            writeln!(f, "{node} -> {shape}")?;
+        }
+        Ok(())
     }
 }
 

--- a/shacl_ir/src/compiled/schema.rs
+++ b/shacl_ir/src/compiled/schema.rs
@@ -79,12 +79,8 @@ impl SchemaIR {
     pub fn get_shape(&self, sref: &RDFNode) -> Option<&CompiledShape> {
         self.shapes.get(sref)
     }
-}
 
-impl<RDF: Rdf> TryFrom<Schema<RDF>> for SchemaIR {
-    type Error = CompiledShaclError;
-
-    fn try_from(schema: Schema<RDF>) -> Result<Self, Self::Error> {
+    pub fn compile<RDF: Rdf>(schema: &Schema<RDF>) -> Result<SchemaIR, CompiledShaclError> {
         let mut shapes = HashMap::default();
 
         for (rdf_node, shape) in schema.iter() {
@@ -98,6 +94,22 @@ impl<RDF: Rdf> TryFrom<Schema<RDF>> for SchemaIR {
         let base = schema.base().map(Into::into);
 
         Ok(SchemaIR::new(shapes, prefixmap, base))
+    }
+}
+
+impl<RDF: Rdf> TryFrom<Schema<RDF>> for SchemaIR {
+    type Error = CompiledShaclError;
+
+    fn try_from(schema: Schema<RDF>) -> Result<Self, Self::Error> {
+        Self::compile(&schema)
+    }
+}
+
+impl<RDF: Rdf> TryFrom<&Schema<RDF>> for SchemaIR {
+    type Error = CompiledShaclError;
+
+    fn try_from(schema: &Schema<RDF>) -> Result<Self, Self::Error> {
+        Self::compile(schema)
     }
 }
 

--- a/shacl_ir/src/compiled/severity.rs
+++ b/shacl_ir/src/compiled/severity.rs
@@ -5,7 +5,7 @@ use shacl_ast::severity::Severity;
 
 use super::compiled_shacl_error::CompiledShaclError;
 
-#[derive(Hash, PartialEq, Eq, Debug)]
+#[derive(Hash, Clone, PartialEq, Eq, Debug)]
 pub enum CompiledSeverity {
     Violation,
     Warning,

--- a/shacl_ir/src/compiled/severity.rs
+++ b/shacl_ir/src/compiled/severity.rs
@@ -1,11 +1,9 @@
 use iri_s::IriS;
 use shacl_ast::shacl_vocab::{sh_info, sh_violation, sh_warning};
-use srdf::Rdf;
 
 use shacl_ast::severity::Severity;
 
 use super::compiled_shacl_error::CompiledShaclError;
-use super::convert_iri_ref;
 
 #[derive(Hash, PartialEq, Eq, Debug)]
 pub enum CompiledSeverity {

--- a/shacl_ir/src/compiled/severity.rs
+++ b/shacl_ir/src/compiled/severity.rs
@@ -8,14 +8,14 @@ use super::compiled_shacl_error::CompiledShaclError;
 use super::convert_iri_ref;
 
 #[derive(Hash, PartialEq, Eq, Debug)]
-pub enum CompiledSeverity<S: Rdf> {
+pub enum CompiledSeverity {
     Violation,
     Warning,
     Info,
-    Generic(S::IRI),
+    Generic(IriS),
 }
 
-impl<S: Rdf> CompiledSeverity<S> {
+impl CompiledSeverity {
     pub fn compile(severity: Option<Severity>) -> Result<Option<Self>, CompiledShaclError> {
         let ans = match severity {
             Some(severity) => {
@@ -24,7 +24,10 @@ impl<S: Rdf> CompiledSeverity<S> {
                     Severity::Warning => CompiledSeverity::Warning,
                     Severity::Info => CompiledSeverity::Info,
                     Severity::Generic(iri_ref) => {
-                        CompiledSeverity::Generic(convert_iri_ref::<S>(iri_ref)?)
+                        let iri = iri_ref
+                            .get_iri()
+                            .map_err(|_| CompiledShaclError::IriRefConversion)?;
+                        CompiledSeverity::Generic(iri)
                     }
                 };
                 Some(severity)
@@ -36,8 +39,8 @@ impl<S: Rdf> CompiledSeverity<S> {
     }
 }
 
-impl<S: Rdf> From<&CompiledSeverity<S>> for IriS {
-    fn from(value: &CompiledSeverity<S>) -> Self {
+impl From<&CompiledSeverity> for IriS {
+    fn from(value: &CompiledSeverity) -> Self {
         match value {
             CompiledSeverity::Violation => sh_violation().clone(),
             CompiledSeverity::Warning => sh_warning().clone(),

--- a/shacl_ir/src/compiled/severity.rs
+++ b/shacl_ir/src/compiled/severity.rs
@@ -43,7 +43,7 @@ impl From<&CompiledSeverity> for IriS {
             CompiledSeverity::Violation => sh_violation().clone(),
             CompiledSeverity::Warning => sh_warning().clone(),
             CompiledSeverity::Info => sh_info().clone(),
-            CompiledSeverity::Generic(iri) => iri.clone().into(),
+            CompiledSeverity::Generic(iri) => iri.clone(),
         }
     }
 }

--- a/shacl_ir/src/compiled/shape.rs
+++ b/shacl_ir/src/compiled/shape.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use iri_s::IriS;
 use srdf::{RDFNode, Rdf, SHACLPath};
 
@@ -10,7 +12,7 @@ use super::node_shape::CompiledNodeShape;
 use super::property_shape::CompiledPropertyShape;
 use super::target::CompiledTarget;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CompiledShape {
     NodeShape(Box<CompiledNodeShape>),
     PropertyShape(Box<CompiledPropertyShape>),
@@ -90,5 +92,14 @@ impl CompiledShape {
         };
 
         Ok(shape)
+    }
+}
+
+impl Display for CompiledShape {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CompiledShape::NodeShape(_shape) => write!(f, "NodeShape"),
+            CompiledShape::PropertyShape(_shape) => write!(f, "PropertyShape"),
+        }
     }
 }

--- a/shacl_ir/src/compiled/shape.rs
+++ b/shacl_ir/src/compiled/shape.rs
@@ -1,5 +1,5 @@
 use iri_s::IriS;
-use srdf::{Rdf, SHACLPath};
+use srdf::{RDFNode, Rdf, SHACLPath};
 
 use shacl_ast::shape::Shape;
 use shacl_ast::Schema;
@@ -11,12 +11,12 @@ use super::property_shape::CompiledPropertyShape;
 use super::target::CompiledTarget;
 
 #[derive(Debug)]
-pub enum CompiledShape<RDF: Rdf> {
-    NodeShape(Box<CompiledNodeShape<RDF>>),
-    PropertyShape(Box<CompiledPropertyShape<RDF>>),
+pub enum CompiledShape {
+    NodeShape(Box<CompiledNodeShape>),
+    PropertyShape(Box<CompiledPropertyShape>),
 }
 
-impl<RDF: Rdf> CompiledShape<RDF> {
+impl CompiledShape {
     pub fn is_deactivated(&self) -> &bool {
         match self {
             CompiledShape::NodeShape(ns) => ns.is_deactivated(),
@@ -24,28 +24,28 @@ impl<RDF: Rdf> CompiledShape<RDF> {
         }
     }
 
-    pub fn id(&self) -> &RDF::Term {
+    pub fn id(&self) -> &RDFNode {
         match self {
             CompiledShape::NodeShape(ns) => ns.id(),
             CompiledShape::PropertyShape(ps) => ps.id(),
         }
     }
 
-    pub fn targets(&self) -> &Vec<CompiledTarget<RDF>> {
+    pub fn targets(&self) -> &Vec<CompiledTarget> {
         match self {
             CompiledShape::NodeShape(ns) => ns.targets(),
             CompiledShape::PropertyShape(ps) => ps.targets(),
         }
     }
 
-    pub fn components(&self) -> &Vec<CompiledComponent<RDF>> {
+    pub fn components(&self) -> &Vec<CompiledComponent> {
         match self {
             CompiledShape::NodeShape(ns) => ns.components(),
             CompiledShape::PropertyShape(ps) => ps.components(),
         }
     }
 
-    pub fn property_shapes(&self) -> &Vec<CompiledShape<RDF>> {
+    pub fn property_shapes(&self) -> &Vec<CompiledShape> {
         match self {
             CompiledShape::NodeShape(ns) => ns.property_shapes(),
             CompiledShape::PropertyShape(ps) => ps.property_shapes(),
@@ -74,7 +74,10 @@ impl<RDF: Rdf> CompiledShape<RDF> {
         iri_s
     }
 
-    pub fn compile(shape: Shape<RDF>, schema: &Schema<RDF>) -> Result<Self, CompiledShaclError> {
+    pub fn compile<RDF: Rdf>(
+        shape: Shape<RDF>,
+        schema: &Schema<RDF>,
+    ) -> Result<Self, CompiledShaclError> {
         let shape = match shape {
             Shape::NodeShape(node_shape) => {
                 let node_shape = CompiledNodeShape::compile(node_shape, schema)?;

--- a/shacl_ir/src/compiled/target.rs
+++ b/shacl_ir/src/compiled/target.rs
@@ -5,22 +5,22 @@ use srdf::{RDFNode, Rdf};
 
 /// Represents compiled target declarations
 #[derive(Debug)]
-pub enum CompiledTarget<S: Rdf> {
+pub enum CompiledTarget {
     Node(RDFNode),
     Class(RDFNode),
     SubjectsOf(IriS),
     ObjectsOf(IriS),
     ImplicitClass(RDFNode),
-    // The following target declarations always return violation errors 
-    WrongTargetNode(S::Term),
-    WrongTargetClass(S::Term),
-    WrongSubjectsOf(S::Term),
-    WrongObjectsOf(S::Term),
-    WrongImplicitClass(S::Term)
+    // The following target declarations always return violation errors
+    WrongTargetNode(RDFNode),
+    WrongTargetClass(RDFNode),
+    WrongSubjectsOf(RDFNode),
+    WrongObjectsOf(RDFNode),
+    WrongImplicitClass(RDFNode),
 }
 
-impl<S: Rdf> CompiledTarget<S> {
-    pub fn compile(target: Target<S>) -> Result<Self, CompiledShaclError> {
+impl CompiledTarget {
+    pub fn compile<S: Rdf>(target: Target<S>) -> Result<Self, CompiledShaclError> {
         let ans = match target {
             Target::TargetNode(object) => CompiledTarget::Node(object),
             Target::TargetClass(object) => CompiledTarget::Class(object),

--- a/shacl_ir/src/compiled/target.rs
+++ b/shacl_ir/src/compiled/target.rs
@@ -4,7 +4,7 @@ use shacl_ast::target::Target;
 use srdf::{RDFNode, Rdf};
 
 /// Represents compiled target declarations
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CompiledTarget {
     Node(RDFNode),
     Class(RDFNode),

--- a/shacl_validation/examples/endpoint_validation.rs
+++ b/shacl_validation/examples/endpoint_validation.rs
@@ -30,9 +30,7 @@ fn main() -> Result<(), ValidateError> {
             ] .
     "#;
 
-    let schema: SchemaIR<SRDFGraph> =
-        ShaclDataManager::load(Cursor::new(shacl), RDFFormat::Turtle, None)?;
-    let schema_endpoint: SchemaIR<SRDFSparql> = schema.map_terms();
+    let schema: SchemaIR = ShaclDataManager::load(Cursor::new(shacl), RDFFormat::Turtle, None)?;
 
     let endpoint_validation = EndpointValidation::new(
         "https://query.wikidata.org/sparql",
@@ -40,7 +38,7 @@ fn main() -> Result<(), ValidateError> {
         ShaclValidationMode::Native,
     )?;
 
-    let report = endpoint_validation.validate(&schema_endpoint)?;
+    let report = endpoint_validation.validate(&schema)?;
 
     println!("{report}");
 

--- a/shacl_validation/examples/endpoint_validation.rs
+++ b/shacl_validation/examples/endpoint_validation.rs
@@ -8,8 +8,6 @@ use shacl_validation::shacl_processor::ShaclValidationMode;
 use shacl_validation::store::ShaclDataManager;
 use shacl_validation::validate_error::ValidateError;
 use srdf::RDFFormat;
-use srdf::SRDFGraph;
-use srdf::SRDFSparql;
 
 fn main() -> Result<(), ValidateError> {
     let shacl = r#"

--- a/shacl_validation/src/constraints/core/cardinality/max_count.rs
+++ b/shacl_validation/src/constraints/core/cardinality/max_count.rs
@@ -23,12 +23,12 @@ use crate::value_nodes::ValueNodes;
 impl<S: Rdf + Debug> Validator<S> for MaxCount {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _: &S,
         _: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let max_count = |targets: &FocusNodes<S>| targets.len() > self.max_count();
@@ -48,11 +48,11 @@ impl<S: Rdf + Debug> Validator<S> for MaxCount {
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxCount {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -70,11 +70,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxCount {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MaxCount {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/cardinality/min_count.rs
+++ b/shacl_validation/src/constraints/core/cardinality/min_count.rs
@@ -23,12 +23,12 @@ use std::fmt::Debug;
 impl<S: Rdf + Debug> Validator<S> for MinCount {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _: &S,
         _: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         tracing::debug!("Validating minCount with shape {}", shape.id());
@@ -53,11 +53,11 @@ impl<S: Rdf + Debug> Validator<S> for MinCount {
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinCount {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         tracing::debug!("Validate native minCount with shape: {}", shape.id());
@@ -76,11 +76,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinCount {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MinCount {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/logical/and.rs
+++ b/shacl_validation/src/constraints/core/logical/and.rs
@@ -22,15 +22,15 @@ use srdf::Rdf;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: Rdf + Debug> Validator<S> for And<S> {
+impl<S: Rdf + Debug> Validator<S> for And {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         engine: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let and = |value_node: &S::Term| {
@@ -59,14 +59,14 @@ impl<S: Rdf + Debug> Validator<S> for And<S> {
     }
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for And<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for And {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -81,14 +81,14 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for And<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for And<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for And {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/logical/not.rs
+++ b/shacl_validation/src/constraints/core/logical/not.rs
@@ -20,15 +20,15 @@ use srdf::Rdf;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: Rdf + Debug> Validator<S> for Not<S> {
+impl<S: Rdf + Debug> Validator<S> for Not {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         engine: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let not = |value_node: &S::Term| {
@@ -52,14 +52,14 @@ impl<S: Rdf + Debug> Validator<S> for Not<S> {
     }
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Not<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Not {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -74,14 +74,14 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Not<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Not<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Not {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/logical/or.rs
+++ b/shacl_validation/src/constraints/core/logical/or.rs
@@ -22,15 +22,15 @@ use srdf::Rdf;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: Rdf + Debug> Validator<S> for Or<S> {
+impl<S: Rdf + Debug> Validator<S> for Or {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         engine: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let or = |value_node: &S::Term| {
@@ -63,14 +63,14 @@ impl<S: Rdf + Debug> Validator<S> for Or<S> {
     }
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Or<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Or {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -85,14 +85,14 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Or<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Or<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Or {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/logical/xone.rs
+++ b/shacl_validation/src/constraints/core/logical/xone.rs
@@ -21,15 +21,15 @@ use crate::validation_report::result::ValidationResult;
 use crate::value_nodes::ValueNodeIteration;
 use crate::value_nodes::ValueNodes;
 
-impl<S: Rdf + Debug> Validator<S> for Xone<S> {
+impl<S: Rdf + Debug> Validator<S> for Xone {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         engine: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let xone = |value_node: &S::Term| {
@@ -59,14 +59,14 @@ impl<S: Rdf + Debug> Validator<S> for Xone<S> {
     }
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Xone<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Xone {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -81,14 +81,14 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Xone<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Xone<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Xone {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/other/closed.rs
+++ b/shacl_validation/src/constraints/core/other/closed.rs
@@ -16,29 +16,29 @@ use srdf::Rdf;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: Rdf + Debug> Validator<S> for Closed<S> {
+impl<S: Rdf + Debug> Validator<S> for Closed {
     fn validate(
         &self,
-        _component: &CompiledComponent<S>,
-        _shape: &CompiledShape<S>,
+        _component: &CompiledComponent,
+        _shape: &CompiledShape,
         _store: &S,
         _engine: impl Engine<S>,
         _value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         _maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         Err(ConstraintError::NotImplemented("Closed".to_string()))
     }
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Closed<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Closed {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -53,14 +53,14 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Closed<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Closed<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Closed {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/other/has_value.rs
+++ b/shacl_validation/src/constraints/core/other/has_value.rs
@@ -30,8 +30,10 @@ impl<S: Rdf + Debug> Validator<S> for HasValue {
         _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
-        let has_value =
-            |targets: &FocusNodes<S>| !targets.iter().any(|value| value == self.value());
+        let has_value = |targets: &FocusNodes<S>| {
+            let value_term = &S::object_as_term(self.value());
+            !targets.iter().any(|value| value == value_term)
+        };
         let message = format!("HasValue({}) not satisfied", self.value());
         validate_with(
             component,

--- a/shacl_validation/src/constraints/core/other/has_value.rs
+++ b/shacl_validation/src/constraints/core/other/has_value.rs
@@ -19,15 +19,15 @@ use srdf::Rdf;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: Rdf + Debug> Validator<S> for HasValue<S> {
+impl<S: Rdf + Debug> Validator<S> for HasValue {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _: &S,
         _: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let has_value =
@@ -45,14 +45,14 @@ impl<S: Rdf + Debug> Validator<S> for HasValue<S> {
     }
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for HasValue<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for HasValue {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -67,14 +67,14 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for HasValue<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for HasValue<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for HasValue {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/other/in.rs
+++ b/shacl_validation/src/constraints/core/other/in.rs
@@ -17,15 +17,15 @@ use srdf::Rdf;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: Rdf + Debug> Validator<S> for In<S> {
+impl<S: Rdf + Debug> Validator<S> for In {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _: &S,
         _: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let r#in = |value_node: &S::Term| !self.values().contains(value_node);
@@ -48,11 +48,11 @@ impl<S: Rdf + Debug> Validator<S> for In<S> {
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for In<S> {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -70,11 +70,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for In<S> {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for In<S> {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/other/in.rs
+++ b/shacl_validation/src/constraints/core/other/in.rs
@@ -28,7 +28,14 @@ impl<S: Rdf + Debug> Validator<S> for In {
         _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
-        let r#in = |value_node: &S::Term| !self.values().contains(value_node);
+        let check = |value_node: &S::Term| {
+            let values: Vec<_> = self
+                .values()
+                .iter()
+                .map(|node| S::object_as_term(node))
+                .collect();
+            !values.contains(value_node)
+        };
         let message = format!(
             "In constraint not satisfied. Expected one of: {:?}",
             self.values()
@@ -38,14 +45,14 @@ impl<S: Rdf + Debug> Validator<S> for In {
             shape,
             value_nodes,
             ValueNodeIteration,
-            r#in,
+            check,
             &message,
             maybe_path,
         )
     }
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for In<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for In {
     fn validate_native(
         &self,
         component: &CompiledComponent,
@@ -67,7 +74,7 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for In<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for In<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for In {
     fn validate_sparql(
         &self,
         component: &CompiledComponent,

--- a/shacl_validation/src/constraints/core/property_pair/disjoint.rs
+++ b/shacl_validation/src/constraints/core/property_pair/disjoint.rs
@@ -11,28 +11,28 @@ use srdf::QueryRDF;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Disjoint<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Disjoint {
     fn validate_native(
         &self,
-        _component: &CompiledComponent<S>,
-        _shape: &CompiledShape<S>,
+        _component: &CompiledComponent,
+        _shape: &CompiledShape,
         _store: &S,
         _value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         _maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         Err(ConstraintError::NotImplemented("Disjoint".to_string()))
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Disjoint<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Disjoint {
     fn validate_sparql(
         &self,
-        _component: &CompiledComponent<S>,
-        _shape: &CompiledShape<S>,
+        _component: &CompiledComponent,
+        _shape: &CompiledShape,
         _store: &S,
         _value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         _maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         Err(ConstraintError::NotImplemented("Disjoint".to_string()))

--- a/shacl_validation/src/constraints/core/property_pair/equals.rs
+++ b/shacl_validation/src/constraints/core/property_pair/equals.rs
@@ -16,29 +16,29 @@ use srdf::Rdf;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: Rdf + Debug> Validator<S> for Equals<S> {
+impl<S: Rdf + Debug> Validator<S> for Equals {
     fn validate(
         &self,
-        _component: &CompiledComponent<S>,
-        _shape: &CompiledShape<S>,
+        _component: &CompiledComponent,
+        _shape: &CompiledShape,
         _store: &S,
         _engine: impl Engine<S>,
         _value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         _maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         Err(ConstraintError::NotImplemented("Equals".to_string()))
     }
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Equals<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Equals {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -53,14 +53,14 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Equals<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Equals<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Equals {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/property_pair/less_than.rs
+++ b/shacl_validation/src/constraints/core/property_pair/less_than.rs
@@ -11,28 +11,28 @@ use srdf::QueryRDF;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for LessThan<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for LessThan {
     fn validate_native(
         &self,
-        _component: &CompiledComponent<S>,
-        _shape: &CompiledShape<S>,
+        _component: &CompiledComponent,
+        _shape: &CompiledShape,
         _store: &S,
         _value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         _maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         Err(ConstraintError::NotImplemented("LessThan".to_string()))
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for LessThan<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for LessThan {
     fn validate_sparql(
         &self,
-        _component: &CompiledComponent<S>,
-        _shape: &CompiledShape<S>,
+        _component: &CompiledComponent,
+        _shape: &CompiledShape,
         _store: &S,
         _value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         _maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         Err(ConstraintError::NotImplemented("LessThan".to_string()))

--- a/shacl_validation/src/constraints/core/property_pair/less_than_or_equals.rs
+++ b/shacl_validation/src/constraints/core/property_pair/less_than_or_equals.rs
@@ -11,14 +11,14 @@ use srdf::QueryRDF;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for LessThanOrEquals<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for LessThanOrEquals {
     fn validate_native(
         &self,
-        _component: &CompiledComponent<S>,
-        _shape: &CompiledShape<S>,
+        _component: &CompiledComponent,
+        _shape: &CompiledShape,
         _store: &S,
         _value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         _maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         Err(ConstraintError::NotImplemented(
@@ -27,14 +27,14 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for LessThanOrEquals<S> 
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for LessThanOrEquals<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for LessThanOrEquals {
     fn validate_sparql(
         &self,
-        _component: &CompiledComponent<S>,
-        _shape: &CompiledShape<S>,
+        _component: &CompiledComponent,
+        _shape: &CompiledShape,
         _store: &S,
         _value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         _maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         Err(ConstraintError::NotImplemented(

--- a/shacl_validation/src/constraints/core/shape_based/node.rs
+++ b/shacl_validation/src/constraints/core/shape_based/node.rs
@@ -20,15 +20,15 @@ use srdf::Rdf;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: Rdf + Debug> Validator<S> for Node<S> {
+impl<S: Rdf + Debug> Validator<S> for Node {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         engine: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let node = |value_node: &S::Term| {
@@ -52,14 +52,14 @@ impl<S: Rdf + Debug> Validator<S> for Node<S> {
     }
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Node<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Node {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -74,14 +74,14 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Node<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Node<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Node {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/shape_based/qualified_value_shape.rs
+++ b/shacl_validation/src/constraints/core/shape_based/qualified_value_shape.rs
@@ -16,15 +16,15 @@ use srdf::Rdf;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: Rdf + Debug> Validator<S> for QualifiedValueShape<S> {
+impl<S: Rdf + Debug> Validator<S> for QualifiedValueShape {
     fn validate(
         &self,
-        _component: &CompiledComponent<S>,
-        _shape: &CompiledShape<S>,
+        _component: &CompiledComponent,
+        _shape: &CompiledShape,
         _store: &S,
         _engine: impl Engine<S>,
         _value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         _maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         Err(ConstraintError::NotImplemented(
@@ -33,14 +33,14 @@ impl<S: Rdf + Debug> Validator<S> for QualifiedValueShape<S> {
     }
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for QualifiedValueShape<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for QualifiedValueShape {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -55,14 +55,14 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for QualifiedValueShape<
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for QualifiedValueShape<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for QualifiedValueShape {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/string_based/language_in.rs
+++ b/shacl_validation/src/constraints/core/string_based/language_in.rs
@@ -24,12 +24,12 @@ use crate::value_nodes::ValueNodes;
 impl<S: Rdf + Debug> Validator<S> for LanguageIn {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _: &S,
         _: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let language_in = |value_node: &S::Term| {
@@ -61,11 +61,11 @@ impl<S: Rdf + Debug> Validator<S> for LanguageIn {
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for LanguageIn {
     fn validate_native<'a>(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -83,11 +83,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for LanguageIn {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for LanguageIn {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/string_based/max_length.rs
+++ b/shacl_validation/src/constraints/core/string_based/max_length.rs
@@ -21,11 +21,11 @@ use std::fmt::Debug;
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxLength {
     fn validate_native<'a>(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let max_length = |value_node: &S::Term| {
@@ -64,11 +64,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxLength {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MaxLength {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let max_length_value = self.max_length();

--- a/shacl_validation/src/constraints/core/string_based/min_length.rs
+++ b/shacl_validation/src/constraints/core/string_based/min_length.rs
@@ -21,11 +21,11 @@ use std::fmt::Debug;
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinLength {
     fn validate_native<'a>(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let min_length = |value_node: &S::Term| {
@@ -64,11 +64,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinLength {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MinLength {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let min_length_value = self.min_length();

--- a/shacl_validation/src/constraints/core/string_based/min_length.rs
+++ b/shacl_validation/src/constraints/core/string_based/min_length.rs
@@ -80,7 +80,7 @@ impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MinLength {
             }
         };
 
-        let message = format!("MinLength({}) not satisfied", min_length_value);
+        let message = format!("MinLength({min_length_value}) not satisfied");
         validate_ask_with(
             component,
             shape,

--- a/shacl_validation/src/constraints/core/string_based/pattern.rs
+++ b/shacl_validation/src/constraints/core/string_based/pattern.rs
@@ -19,11 +19,11 @@ use std::fmt::Debug;
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Pattern {
     fn validate_native<'a>(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let pattern = |value_node: &S::Term| {
@@ -50,11 +50,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Pattern {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Pattern {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let flags = self.flags().clone();

--- a/shacl_validation/src/constraints/core/string_based/unique_lang.rs
+++ b/shacl_validation/src/constraints/core/string_based/unique_lang.rs
@@ -24,12 +24,12 @@ use std::fmt::Debug;
 impl<S: Rdf + Debug> Validator<S> for UniqueLang {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _: &S,
         _: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         if !self.unique_lang() {
@@ -67,11 +67,11 @@ impl<S: Rdf + Debug> Validator<S> for UniqueLang {
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for UniqueLang {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -89,11 +89,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for UniqueLang {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for UniqueLang {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/value/class.rs
+++ b/shacl_validation/src/constraints/core/value/class.rs
@@ -33,15 +33,16 @@ impl<S: NeighsRDF + 'static> NativeValidator<S> for Class {
             if value_node.is_literal() {
                 return true;
             }
+            let class_term = &S::object_as_term(self.class_rule());
 
             let is_class_valid = get_objects_for(store, value_node, &rdf_type().clone().into())
                 .unwrap_or_default()
                 .iter()
                 .any(|ctype| {
-                    ctype == self.class_rule()
+                    ctype == class_term
                         || get_objects_for(store, ctype, &rdfs_subclass_of().clone().into())
                             .unwrap_or_default()
-                            .contains(self.class_rule())
+                            .contains(class_term)
                 });
 
             !is_class_valid

--- a/shacl_validation/src/constraints/core/value/class.rs
+++ b/shacl_validation/src/constraints/core/value/class.rs
@@ -19,14 +19,14 @@ use srdf::SHACLPath;
 use srdf::Term;
 use std::fmt::Debug;
 
-impl<S: NeighsRDF + 'static> NativeValidator<S> for Class<S> {
+impl<S: NeighsRDF + 'static> NativeValidator<S> for Class {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let class = |value_node: &S::Term| {
@@ -63,14 +63,14 @@ impl<S: NeighsRDF + 'static> NativeValidator<S> for Class<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Class<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Class {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let class_value = self.class_rule().clone();

--- a/shacl_validation/src/constraints/core/value/datatype.rs
+++ b/shacl_validation/src/constraints/core/value/datatype.rs
@@ -23,12 +23,12 @@ use std::fmt::Debug;
 impl<S: Rdf + Debug> Validator<S> for Datatype<S> {
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _: &S,
         _: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let datatype = |value_node: &S::Term| {
@@ -58,11 +58,11 @@ impl<S: Rdf + Debug> Validator<S> for Datatype<S> {
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Datatype<S> {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(
@@ -80,11 +80,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Datatype<S> {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Datatype<S> {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         self.validate(

--- a/shacl_validation/src/constraints/core/value/datatype.rs
+++ b/shacl_validation/src/constraints/core/value/datatype.rs
@@ -12,7 +12,6 @@ use crate::value_nodes::ValueNodes;
 use shacl_ir::compiled::component::CompiledComponent;
 use shacl_ir::compiled::component::Datatype;
 use shacl_ir::compiled::shape::CompiledShape;
-use srdf::Iri;
 use srdf::Literal as _;
 use srdf::NeighsRDF;
 use srdf::QueryRDF;
@@ -20,7 +19,7 @@ use srdf::Rdf;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: Rdf + Debug> Validator<S> for Datatype<S> {
+impl<S: Rdf + Debug> Validator<S> for Datatype {
     fn validate(
         &self,
         component: &CompiledComponent,
@@ -55,7 +54,7 @@ impl<S: Rdf + Debug> Validator<S> for Datatype<S> {
     }
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Datatype<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Datatype {
     fn validate_native(
         &self,
         component: &CompiledComponent,
@@ -77,7 +76,7 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Datatype<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Datatype<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Datatype {
     fn validate_sparql(
         &self,
         component: &CompiledComponent,

--- a/shacl_validation/src/constraints/core/value/node_kind.rs
+++ b/shacl_validation/src/constraints/core/value/node_kind.rs
@@ -22,11 +22,11 @@ use std::fmt::Debug;
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Nodekind {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let node_kind = |value_node: &S::Term| {
@@ -71,11 +71,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for Nodekind {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for Nodekind {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let node_kind = self.node_kind().clone();

--- a/shacl_validation/src/constraints/core/value_range/max_exclusive.rs
+++ b/shacl_validation/src/constraints/core/value_range/max_exclusive.rs
@@ -15,7 +15,7 @@ use srdf::QueryRDF;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxExclusive<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxExclusive {
     fn validate_native(
         &self,
         component: &CompiledComponent,
@@ -45,7 +45,7 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxExclusive<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MaxExclusive<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MaxExclusive {
     fn validate_sparql(
         &self,
         component: &CompiledComponent,

--- a/shacl_validation/src/constraints/core/value_range/max_exclusive.rs
+++ b/shacl_validation/src/constraints/core/value_range/max_exclusive.rs
@@ -18,11 +18,11 @@ use std::fmt::Debug;
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxExclusive<S> {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let max_exclusive = |node: &S::Term| match S::term_as_sliteral(node) {
@@ -48,11 +48,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxExclusive<S> {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MaxExclusive<S> {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let max_exclusive_value = self.max_exclusive().clone();

--- a/shacl_validation/src/constraints/core/value_range/max_inclusive.rs
+++ b/shacl_validation/src/constraints/core/value_range/max_inclusive.rs
@@ -15,7 +15,7 @@ use srdf::QueryRDF;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxInclusive<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxInclusive {
     fn validate_native(
         &self,
         component: &CompiledComponent,
@@ -45,7 +45,7 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxInclusive<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MaxInclusive<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MaxInclusive {
     fn validate_sparql(
         &self,
         component: &CompiledComponent,

--- a/shacl_validation/src/constraints/core/value_range/max_inclusive.rs
+++ b/shacl_validation/src/constraints/core/value_range/max_inclusive.rs
@@ -18,11 +18,11 @@ use std::fmt::Debug;
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxInclusive<S> {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let max_inclusive = |node: &S::Term| match S::term_as_sliteral(node) {
@@ -48,11 +48,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MaxInclusive<S> {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MaxInclusive<S> {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let max_inclusive_value = self.max_inclusive().clone();

--- a/shacl_validation/src/constraints/core/value_range/min_exclusive.rs
+++ b/shacl_validation/src/constraints/core/value_range/min_exclusive.rs
@@ -15,7 +15,7 @@ use srdf::QueryRDF;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinExclusive<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinExclusive {
     fn validate_native(
         &self,
         component: &CompiledComponent,
@@ -45,7 +45,7 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinExclusive<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MinExclusive<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MinExclusive {
     fn validate_sparql(
         &self,
         component: &CompiledComponent,

--- a/shacl_validation/src/constraints/core/value_range/min_exclusive.rs
+++ b/shacl_validation/src/constraints/core/value_range/min_exclusive.rs
@@ -18,11 +18,11 @@ use std::fmt::Debug;
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinExclusive<S> {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let min_exclusive = |node: &S::Term| match S::term_as_sliteral(node) {
@@ -48,11 +48,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinExclusive<S> {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MinExclusive<S> {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let min_exclusive_value = self.min_exclusive().clone();

--- a/shacl_validation/src/constraints/core/value_range/min_inclusive.rs
+++ b/shacl_validation/src/constraints/core/value_range/min_inclusive.rs
@@ -18,11 +18,11 @@ use std::fmt::Debug;
 impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinInclusive<S> {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         _store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let min_inclusive = |node: &S::Term| match S::term_as_sliteral(node) {
@@ -48,11 +48,11 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinInclusive<S> {
 impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MinInclusive<S> {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        _source_shape: Option<&CompiledShape<S>>,
+        _source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError> {
         let min_inclusive_value = self.min_inclusive_value().clone();

--- a/shacl_validation/src/constraints/core/value_range/min_inclusive.rs
+++ b/shacl_validation/src/constraints/core/value_range/min_inclusive.rs
@@ -15,7 +15,7 @@ use srdf::QueryRDF;
 use srdf::SHACLPath;
 use std::fmt::Debug;
 
-impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinInclusive<S> {
+impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinInclusive {
     fn validate_native(
         &self,
         component: &CompiledComponent,
@@ -45,7 +45,7 @@ impl<S: NeighsRDF + Debug + 'static> NativeValidator<S> for MinInclusive<S> {
     }
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MinInclusive<S> {
+impl<S: QueryRDF + Debug + 'static> SparqlValidator<S> for MinInclusive {
     fn validate_sparql(
         &self,
         component: &CompiledComponent,

--- a/shacl_validation/src/constraints/mod.rs
+++ b/shacl_validation/src/constraints/mod.rs
@@ -88,7 +88,7 @@ impl<'a, S> ShaclComponent<'a, S> {
     }
 }
 
-impl<'a, S: NeighsRDF + Debug + 'static> NativeDeref for ShaclComponent<'a, S> {
+impl<S: NeighsRDF + Debug + 'static> NativeDeref for ShaclComponent<'_, S> {
     type Target = dyn NativeValidator<S>;
 
     fn deref(&self) -> &Self::Target {
@@ -161,7 +161,7 @@ pub trait SparqlDeref {
     fn deref(&self) -> &Self::Target;
 }
 
-impl<'a, S: QueryRDF + Debug + 'static> SparqlDeref for ShaclComponent<'a, S> {
+impl<S: QueryRDF + Debug + 'static> SparqlDeref for ShaclComponent<'_, S> {
     type Target = dyn SparqlValidator<S>;
 
     fn deref(&self) -> &Self::Target {

--- a/shacl_validation/src/constraints/mod.rs
+++ b/shacl_validation/src/constraints/mod.rs
@@ -84,7 +84,7 @@ impl<'a, S> ShaclComponent<'a, S> {
     }
 
     pub fn component(&self) -> &CompiledComponent {
-        &self.component
+        self.component
     }
 }
 

--- a/shacl_validation/src/constraints/mod.rs
+++ b/shacl_validation/src/constraints/mod.rs
@@ -6,6 +6,7 @@ use srdf::QueryRDF;
 use srdf::Rdf;
 use srdf::SHACLPath;
 use std::fmt::Debug;
+use std::marker::PhantomData;
 
 use crate::engine::Engine;
 use crate::validation_report::result::ValidationResult;
@@ -56,24 +57,73 @@ pub trait SparqlValidator<S: QueryRDF + Debug> {
 macro_rules! generate_deref_fn {
     ($enum_name:ident, $($variant:ident),+) => {
         fn deref(&self) -> &Self::Target {
-            match self {
+            match self.component() {
                 $( $enum_name::$variant(inner) => inner, )+
             }
         }
     };
-}
-*/
+}*/
+
 pub trait NativeDeref {
     type Target: ?Sized;
 
     fn deref(&self) -> &Self::Target;
 }
 
-/*
-impl<S: NeighsRDF + Debug + 'static> NativeDeref for CompiledComponent {
+pub struct ShaclComponent<'a, S> {
+    component: &'a CompiledComponent,
+    _marker: PhantomData<S>,
+}
+
+impl<'a, S> ShaclComponent<'a, S> {
+    pub fn new(component: &'a CompiledComponent) -> Self {
+        ShaclComponent {
+            component: component,
+            _marker: PhantomData,
+        }
+    }
+
+    pub fn component(&self) -> &CompiledComponent {
+        &self.component
+    }
+}
+
+impl<'a, S: NeighsRDF + Debug + 'static> NativeDeref for ShaclComponent<'a, S> {
     type Target = dyn NativeValidator<S>;
 
-    generate_deref_fn!(
+    fn deref(&self) -> &Self::Target {
+        match self.component() {
+            CompiledComponent::Class(inner) => inner,
+            CompiledComponent::Datatype(inner) => inner,
+            CompiledComponent::NodeKind(inner) => inner,
+            CompiledComponent::MinCount(inner) => inner,
+            CompiledComponent::MaxCount(inner) => inner,
+            CompiledComponent::MinExclusive(inner) => inner,
+            CompiledComponent::MaxExclusive(inner) => inner,
+            CompiledComponent::MinInclusive(inner) => inner,
+            CompiledComponent::MaxInclusive(inner) => inner,
+            CompiledComponent::MinLength(inner) => inner,
+            CompiledComponent::MaxLength(inner) => inner,
+            CompiledComponent::Pattern(inner) => inner,
+            CompiledComponent::UniqueLang(inner) => inner,
+            CompiledComponent::LanguageIn(inner) => inner,
+            CompiledComponent::Equals(inner) => inner,
+            CompiledComponent::Disjoint(inner) => inner,
+            CompiledComponent::LessThan(inner) => inner,
+            CompiledComponent::LessThanOrEquals(inner) => inner,
+            CompiledComponent::Or(inner) => inner,
+            CompiledComponent::And(inner) => inner,
+            CompiledComponent::Not(inner) => inner,
+            CompiledComponent::Xone(inner) => inner,
+            CompiledComponent::Closed(inner) => inner,
+            CompiledComponent::Node(inner) => inner,
+            CompiledComponent::HasValue(inner) => inner,
+            CompiledComponent::In(inner) => inner,
+            CompiledComponent::QualifiedValueShape(inner) => inner,
+        }
+    }
+
+    /*generate_deref_fn!(
         CompiledComponent,
         Class,
         Datatype,
@@ -102,20 +152,51 @@ impl<S: NeighsRDF + Debug + 'static> NativeDeref for CompiledComponent {
         HasValue,
         In,
         QualifiedValueShape
-    );
+    );*/
 }
-*/
+
 pub trait SparqlDeref {
     type Target: ?Sized;
 
     fn deref(&self) -> &Self::Target;
 }
 
-/*
-impl<S: QueryRDF + Debug + 'static> SparqlDeref for CompiledComponent {
+impl<'a, S: QueryRDF + Debug + 'static> SparqlDeref for ShaclComponent<'a, S> {
     type Target = dyn SparqlValidator<S>;
 
-    generate_deref_fn!(
+    fn deref(&self) -> &Self::Target {
+        match self.component() {
+            CompiledComponent::Class(inner) => inner,
+            CompiledComponent::Datatype(inner) => inner,
+            CompiledComponent::NodeKind(inner) => inner,
+            CompiledComponent::MinCount(inner) => inner,
+            CompiledComponent::MaxCount(inner) => inner,
+            CompiledComponent::MinExclusive(inner) => inner,
+            CompiledComponent::MaxExclusive(inner) => inner,
+            CompiledComponent::MinInclusive(inner) => inner,
+            CompiledComponent::MaxInclusive(inner) => inner,
+            CompiledComponent::MinLength(inner) => inner,
+            CompiledComponent::MaxLength(inner) => inner,
+            CompiledComponent::Pattern(inner) => inner,
+            CompiledComponent::UniqueLang(inner) => inner,
+            CompiledComponent::LanguageIn(inner) => inner,
+            CompiledComponent::Equals(inner) => inner,
+            CompiledComponent::Disjoint(inner) => inner,
+            CompiledComponent::LessThan(inner) => inner,
+            CompiledComponent::LessThanOrEquals(inner) => inner,
+            CompiledComponent::Or(inner) => inner,
+            CompiledComponent::And(inner) => inner,
+            CompiledComponent::Not(inner) => inner,
+            CompiledComponent::Xone(inner) => inner,
+            CompiledComponent::Closed(inner) => inner,
+            CompiledComponent::Node(inner) => inner,
+            CompiledComponent::HasValue(inner) => inner,
+            CompiledComponent::In(inner) => inner,
+            CompiledComponent::QualifiedValueShape(inner) => inner,
+        }
+    }
+
+    /*   generate_deref_fn!(
         CompiledComponent,
         Class,
         Datatype,
@@ -144,6 +225,5 @@ impl<S: QueryRDF + Debug + 'static> SparqlDeref for CompiledComponent {
         HasValue,
         In,
         QualifiedValueShape
-    );
+    ); */
 }
-*/

--- a/shacl_validation/src/constraints/mod.rs
+++ b/shacl_validation/src/constraints/mod.rs
@@ -78,7 +78,7 @@ pub struct ShaclComponent<'a, S> {
 impl<'a, S> ShaclComponent<'a, S> {
     pub fn new(component: &'a CompiledComponent) -> Self {
         ShaclComponent {
-            component: component,
+            component,
             _marker: PhantomData,
         }
     }

--- a/shacl_validation/src/constraints/mod.rs
+++ b/shacl_validation/src/constraints/mod.rs
@@ -18,12 +18,12 @@ pub trait Validator<S: Rdf + Debug> {
     #[allow(clippy::too_many_arguments)]
     fn validate(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         engine: impl Engine<S>,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError>;
 }
@@ -31,11 +31,11 @@ pub trait Validator<S: Rdf + Debug> {
 pub trait NativeValidator<S: NeighsRDF> {
     fn validate_native(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError>;
 }
@@ -43,15 +43,16 @@ pub trait NativeValidator<S: NeighsRDF> {
 pub trait SparqlValidator<S: QueryRDF + Debug> {
     fn validate_sparql(
         &self,
-        component: &CompiledComponent<S>,
-        shape: &CompiledShape<S>,
+        component: &CompiledComponent,
+        shape: &CompiledShape,
         store: &S,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ConstraintError>;
 }
 
+/*
 macro_rules! generate_deref_fn {
     ($enum_name:ident, $($variant:ident),+) => {
         fn deref(&self) -> &Self::Target {
@@ -61,14 +62,15 @@ macro_rules! generate_deref_fn {
         }
     };
 }
-
+*/
 pub trait NativeDeref {
     type Target: ?Sized;
 
     fn deref(&self) -> &Self::Target;
 }
 
-impl<S: NeighsRDF + Debug + 'static> NativeDeref for CompiledComponent<S> {
+/*
+impl<S: NeighsRDF + Debug + 'static> NativeDeref for CompiledComponent {
     type Target = dyn NativeValidator<S>;
 
     generate_deref_fn!(
@@ -102,14 +104,15 @@ impl<S: NeighsRDF + Debug + 'static> NativeDeref for CompiledComponent<S> {
         QualifiedValueShape
     );
 }
-
+*/
 pub trait SparqlDeref {
     type Target: ?Sized;
 
     fn deref(&self) -> &Self::Target;
 }
 
-impl<S: QueryRDF + Debug + 'static> SparqlDeref for CompiledComponent<S> {
+/*
+impl<S: QueryRDF + Debug + 'static> SparqlDeref for CompiledComponent {
     type Target = dyn SparqlValidator<S>;
 
     generate_deref_fn!(
@@ -143,3 +146,4 @@ impl<S: QueryRDF + Debug + 'static> SparqlDeref for CompiledComponent<S> {
         QualifiedValueShape
     );
 }
+*/

--- a/shacl_validation/src/engine/mod.rs
+++ b/shacl_validation/src/engine/mod.rs
@@ -19,17 +19,17 @@ pub trait Engine<S: Rdf> {
     fn evaluate(
         &self,
         store: &S,
-        shape: &CompiledShape<S>,
-        component: &CompiledComponent<S>,
+        shape: &CompiledShape,
+        component: &CompiledComponent,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ValidateError>;
 
     fn focus_nodes(
         &self,
         store: &S,
-        targets: &[CompiledTarget<S>],
+        targets: &[CompiledTarget],
     ) -> Result<FocusNodes<S>, ValidateError> {
         // TODO: here it would be nice to return an error...
         let targets = targets
@@ -75,7 +75,7 @@ pub trait Engine<S: Rdf> {
     fn path(
         &self,
         store: &S,
-        shape: &CompiledPropertyShape<S>,
+        shape: &CompiledPropertyShape,
         focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
         match shape.path() {
@@ -94,7 +94,7 @@ pub trait Engine<S: Rdf> {
     fn predicate(
         &self,
         store: &S,
-        shape: &CompiledPropertyShape<S>,
+        shape: &CompiledPropertyShape,
         predicate: &S::IRI,
         focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError>;
@@ -102,7 +102,7 @@ pub trait Engine<S: Rdf> {
     fn alternative(
         &self,
         store: &S,
-        shape: &CompiledPropertyShape<S>,
+        shape: &CompiledPropertyShape,
         paths: &[SHACLPath],
         focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError>;
@@ -110,7 +110,7 @@ pub trait Engine<S: Rdf> {
     fn sequence(
         &self,
         store: &S,
-        shape: &CompiledPropertyShape<S>,
+        shape: &CompiledPropertyShape,
         paths: &[SHACLPath],
         focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError>;
@@ -118,7 +118,7 @@ pub trait Engine<S: Rdf> {
     fn inverse(
         &self,
         store: &S,
-        shape: &CompiledPropertyShape<S>,
+        shape: &CompiledPropertyShape,
         path: &SHACLPath,
         focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError>;
@@ -126,7 +126,7 @@ pub trait Engine<S: Rdf> {
     fn zero_or_more(
         &self,
         store: &S,
-        shape: &CompiledPropertyShape<S>,
+        shape: &CompiledPropertyShape,
         path: &SHACLPath,
         focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError>;
@@ -134,7 +134,7 @@ pub trait Engine<S: Rdf> {
     fn one_or_more(
         &self,
         store: &S,
-        shape: &CompiledPropertyShape<S>,
+        shape: &CompiledPropertyShape,
         path: &SHACLPath,
         focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError>;
@@ -142,7 +142,7 @@ pub trait Engine<S: Rdf> {
     fn zero_or_one(
         &self,
         store: &S,
-        shape: &CompiledPropertyShape<S>,
+        shape: &CompiledPropertyShape,
         path: &SHACLPath,
         focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError>;

--- a/shacl_validation/src/engine/native.rs
+++ b/shacl_validation/src/engine/native.rs
@@ -12,6 +12,7 @@ use srdf::Triple;
 
 use super::Engine;
 use crate::constraints::NativeDeref;
+use crate::constraints::ShaclComponent;
 use crate::focus_nodes::FocusNodes;
 use crate::helpers::srdf::get_objects_for;
 use crate::helpers::srdf::get_subjects_for;
@@ -33,7 +34,8 @@ impl<S: NeighsRDF + Debug + 'static> Engine<S> for NativeEngine {
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ValidateError> {
         tracing::debug!("NativeEngine, evaluate with shape {}", shape.id());
-        let validator = component.deref();
+        let shacl_component = ShaclComponent::new(component);
+        let validator = shacl_component.deref();
         Ok(validator.validate_native(
             component,
             shape,

--- a/shacl_validation/src/engine/native.rs
+++ b/shacl_validation/src/engine/native.rs
@@ -26,10 +26,10 @@ impl<S: NeighsRDF + Debug + 'static> Engine<S> for NativeEngine {
     fn evaluate(
         &self,
         store: &S,
-        shape: &CompiledShape<S>,
-        component: &CompiledComponent<S>,
+        shape: &CompiledShape,
+        component: &CompiledComponent,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ValidateError> {
         tracing::debug!("NativeEngine, evaluate with shape {}", shape.id());
@@ -119,7 +119,7 @@ impl<S: NeighsRDF + Debug + 'static> Engine<S> for NativeEngine {
     fn predicate(
         &self,
         store: &S,
-        _: &CompiledPropertyShape<S>,
+        _: &CompiledPropertyShape,
         predicate: &S::IRI,
         focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -131,7 +131,7 @@ impl<S: NeighsRDF + Debug + 'static> Engine<S> for NativeEngine {
     fn alternative(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _paths: &[SHACLPath],
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -143,7 +143,7 @@ impl<S: NeighsRDF + Debug + 'static> Engine<S> for NativeEngine {
     fn sequence(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _paths: &[SHACLPath],
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -155,7 +155,7 @@ impl<S: NeighsRDF + Debug + 'static> Engine<S> for NativeEngine {
     fn inverse(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _path: &SHACLPath,
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -167,7 +167,7 @@ impl<S: NeighsRDF + Debug + 'static> Engine<S> for NativeEngine {
     fn zero_or_more(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _path: &SHACLPath,
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -179,7 +179,7 @@ impl<S: NeighsRDF + Debug + 'static> Engine<S> for NativeEngine {
     fn one_or_more(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _path: &SHACLPath,
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -191,7 +191,7 @@ impl<S: NeighsRDF + Debug + 'static> Engine<S> for NativeEngine {
     fn zero_or_one(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _path: &SHACLPath,
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {

--- a/shacl_validation/src/engine/sparql.rs
+++ b/shacl_validation/src/engine/sparql.rs
@@ -1,4 +1,5 @@
 use super::Engine;
+use crate::constraints::ShaclComponent;
 use crate::constraints::SparqlDeref;
 use crate::focus_nodes::FocusNodes;
 use crate::helpers::sparql::select;
@@ -28,7 +29,8 @@ impl<S: QueryRDF + Debug + 'static> Engine<S> for SparqlEngine {
         source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ValidateError> {
-        let validator = component.deref();
+        let shacl_component = ShaclComponent::new(component);
+        let validator = shacl_component.deref();
         Ok(validator.validate_sparql(
             component,
             shape,

--- a/shacl_validation/src/engine/sparql.rs
+++ b/shacl_validation/src/engine/sparql.rs
@@ -22,10 +22,10 @@ impl<S: QueryRDF + Debug + 'static> Engine<S> for SparqlEngine {
     fn evaluate(
         &self,
         store: &S,
-        shape: &CompiledShape<S>,
-        component: &CompiledComponent<S>,
+        shape: &CompiledShape,
+        component: &CompiledComponent,
         value_nodes: &ValueNodes<S>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
         maybe_path: Option<SHACLPath>,
     ) -> Result<Vec<ValidationResult>, ValidateError> {
         let validator = component.deref();
@@ -135,7 +135,7 @@ impl<S: QueryRDF + Debug + 'static> Engine<S> for SparqlEngine {
     fn predicate(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _predicate: &S::IRI,
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -147,7 +147,7 @@ impl<S: QueryRDF + Debug + 'static> Engine<S> for SparqlEngine {
     fn alternative(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _paths: &[SHACLPath],
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -159,7 +159,7 @@ impl<S: QueryRDF + Debug + 'static> Engine<S> for SparqlEngine {
     fn sequence(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _paths: &[SHACLPath],
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -171,7 +171,7 @@ impl<S: QueryRDF + Debug + 'static> Engine<S> for SparqlEngine {
     fn inverse(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _path: &SHACLPath,
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -183,7 +183,7 @@ impl<S: QueryRDF + Debug + 'static> Engine<S> for SparqlEngine {
     fn zero_or_more(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _path: &SHACLPath,
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -195,7 +195,7 @@ impl<S: QueryRDF + Debug + 'static> Engine<S> for SparqlEngine {
     fn one_or_more(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _path: &SHACLPath,
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {
@@ -207,7 +207,7 @@ impl<S: QueryRDF + Debug + 'static> Engine<S> for SparqlEngine {
     fn zero_or_one(
         &self,
         _store: &S,
-        _shape: &CompiledPropertyShape<S>,
+        _shape: &CompiledPropertyShape,
         _path: &SHACLPath,
         _focus_node: &S::Term,
     ) -> Result<FocusNodes<S>, ValidateError> {

--- a/shacl_validation/src/helpers/constraint.rs
+++ b/shacl_validation/src/helpers/constraint.rs
@@ -12,8 +12,8 @@ use crate::value_nodes::ValueNodeIteration;
 use crate::value_nodes::ValueNodes;
 
 fn apply<S: Rdf, I: IterationStrategy<S>>(
-    component: &CompiledComponent<S>,
-    shape: &CompiledShape<S>,
+    component: &CompiledComponent,
+    shape: &CompiledShape,
     value_nodes: &ValueNodes<S>,
     iteration_strategy: I,
     evaluator: impl Fn(&I::Item) -> Result<bool, ConstraintError>,
@@ -26,14 +26,14 @@ fn apply<S: Rdf, I: IterationStrategy<S>>(
             let focus = S::term_as_object(focus_node).ok()?;
             let component = Object::iri(component.into());
             let severity = Object::iri(shape.severity());
-            let shape_id = S::term_as_object(shape.id()).ok()?;
+            let shape_id = shape.id();
             let source = Some(shape_id);
             let value = iteration_strategy.to_object(item);
             if let Ok(condition) = evaluator(item) {
                 if condition {
                     return Some(
                         ValidationResult::new(focus, component, severity)
-                            .with_source(source)
+                            .with_source(source.cloned())
                             .with_message(message)
                             .with_path(maybe_path.clone())
                             .with_value(value),
@@ -48,8 +48,8 @@ fn apply<S: Rdf, I: IterationStrategy<S>>(
 }
 
 pub fn validate_with<S: Rdf, I: IterationStrategy<S>>(
-    component: &CompiledComponent<S>,
-    shape: &CompiledShape<S>,
+    component: &CompiledComponent,
+    shape: &CompiledShape,
     value_nodes: &ValueNodes<S>,
     iteration_strategy: I,
     evaluator: impl Fn(&I::Item) -> bool,
@@ -68,8 +68,8 @@ pub fn validate_with<S: Rdf, I: IterationStrategy<S>>(
 }
 
 pub fn validate_ask_with<S: QueryRDF>(
-    component: &CompiledComponent<S>,
-    shape: &CompiledShape<S>,
+    component: &CompiledComponent,
+    shape: &CompiledShape,
     store: &S,
     value_nodes: &ValueNodes<S>,
     eval_query: impl Fn(&S::Term) -> String,

--- a/shacl_validation/src/helpers/constraint.rs
+++ b/shacl_validation/src/helpers/constraint.rs
@@ -83,7 +83,7 @@ pub fn validate_ask_with<S: QueryRDF>(
         ValueNodeIteration,
         |value_node| match store.query_ask(&eval_query(value_node)) {
             Ok(ask) => Ok(!ask),
-            Err(err) => Err(ConstraintError::Query(format!("ASK query failed: {}", err))),
+            Err(err) => Err(ConstraintError::Query(format!("ASK query failed: {err}"))),
         },
         message,
         maybe_path,

--- a/shacl_validation/src/shacl_processor.rs
+++ b/shacl_validation/src/shacl_processor.rs
@@ -49,7 +49,7 @@ pub trait ShaclProcessor<S: Rdf + Debug> {
     /// # Arguments
     ///
     /// * `shapes_graph` - A compiled SHACL shapes graph
-    fn validate(&self, shapes_graph: &SchemaIR<S>) -> Result<ValidationReport, ValidateError> {
+    fn validate(&self, shapes_graph: &SchemaIR) -> Result<ValidationReport, ValidateError> {
         // we initialize the validation report to empty
         let mut validation_results = Vec::new();
 

--- a/shacl_validation/src/shape.rs
+++ b/shacl_validation/src/shape.rs
@@ -16,17 +16,17 @@ pub trait Validate<S: Rdf> {
         store: &S,
         runner: &dyn Engine<S>,
         targets: Option<&FocusNodes<S>>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
     ) -> Result<Vec<ValidationResult>, ValidateError>;
 }
 
-impl<S: Rdf + Debug> Validate<S> for CompiledShape<S> {
+impl<S: Rdf + Debug> Validate<S> for CompiledShape {
     fn validate(
         &self,
         store: &S,
         runner: &dyn Engine<S>,
         targets: Option<&FocusNodes<S>>,
-        source_shape: Option<&CompiledShape<S>>,
+        source_shape: Option<&CompiledShape>,
     ) -> Result<Vec<ValidationResult>, ValidateError> {
         tracing::debug!(
             "Shape.validate with shape {} and source shape: {}",
@@ -87,7 +87,7 @@ pub trait FocusNodesOps<S: Rdf> {
     fn focus_nodes(&self, store: &S, runner: &dyn Engine<S>) -> FocusNodes<S>;
 }
 
-impl<S: Rdf> FocusNodesOps<S> for CompiledShape<S> {
+impl<S: Rdf> FocusNodesOps<S> for CompiledShape {
     fn focus_nodes(&self, store: &S, runner: &dyn Engine<S>) -> FocusNodes<S> {
         runner
             .focus_nodes(store, self.targets())
@@ -104,7 +104,7 @@ pub trait ValueNodesOps<S: Rdf> {
     ) -> ValueNodes<S>;
 }
 
-impl<S: Rdf> ValueNodesOps<S> for CompiledShape<S> {
+impl<S: Rdf> ValueNodesOps<S> for CompiledShape {
     fn value_nodes(
         &self,
         store: &S,
@@ -118,7 +118,7 @@ impl<S: Rdf> ValueNodesOps<S> for CompiledShape<S> {
     }
 }
 
-impl<S: Rdf> ValueNodesOps<S> for CompiledNodeShape<S> {
+impl<S: Rdf> ValueNodesOps<S> for CompiledNodeShape {
     fn value_nodes(&self, _: &S, focus_nodes: &FocusNodes<S>, _: &dyn Engine<S>) -> ValueNodes<S> {
         let value_nodes = focus_nodes.iter().map(|focus_node| {
             (
@@ -130,7 +130,7 @@ impl<S: Rdf> ValueNodesOps<S> for CompiledNodeShape<S> {
     }
 }
 
-impl<S: Rdf> ValueNodesOps<S> for CompiledPropertyShape<S> {
+impl<S: Rdf> ValueNodesOps<S> for CompiledPropertyShape {
     fn value_nodes(
         &self,
         store: &S,

--- a/shacl_validation/src/store/mod.rs
+++ b/shacl_validation/src/store/mod.rs
@@ -1,8 +1,6 @@
-use shacl_ast::Schema;
 use shacl_ir::compiled::schema::SchemaIR;
 use shacl_rdf::rdf_to_shacl::ShaclParser;
 use srdf::RDFFormat;
-use srdf::Rdf;
 use srdf::ReaderMode;
 use srdf::SRDFGraph;
 use std::io::BufRead;
@@ -27,10 +25,9 @@ impl ShaclDataManager {
         let rdf = SRDFGraph::from_reader(reader, &rdf_format, base, &ReaderMode::default())?;
         match ShaclParser::new(rdf).parse() {
             Ok(schema) => {
-                let schema_compiled =
-                   schema.try_into()?;
+                let schema_compiled = schema.try_into()?;
                 Ok(schema_compiled)
-            },
+            }
             Err(error) => Err(ValidateError::ShaclParser(error)),
         }
     }

--- a/shacl_validation/src/store/mod.rs
+++ b/shacl_validation/src/store/mod.rs
@@ -21,7 +21,7 @@ impl ShaclDataManager {
         reader: R,
         rdf_format: RDFFormat,
         base: Option<&str>,
-    ) -> Result<SchemaIR<SRDFGraph>, ValidateError> {
+    ) -> Result<SchemaIR, ValidateError> {
         let rdf = SRDFGraph::from_reader(reader, &rdf_format, base, &ReaderMode::default())?;
         match ShaclParser::new(rdf).parse() {
             Ok(schema) => {

--- a/shacl_validation/tests/mod.rs
+++ b/shacl_validation/tests/mod.rs
@@ -32,12 +32,12 @@ mod core;
 
 struct ShaclTest<R: Rdf> {
     data: R,
-    shapes: Schema,
+    shapes: Schema<R>,
     report: ValidationReport,
 }
 
 impl<R: Rdf> ShaclTest<R> {
-    fn new(data: R, shapes: Schema, report: ValidationReport) -> Self {
+    fn new(data: R, shapes: Schema<R>, report: ValidationReport) -> Self {
         ShaclTest {
             data,
             shapes,

--- a/shapes_converter/src/shacl_to_shex/shacl2shex.rs
+++ b/shapes_converter/src/shacl_to_shex/shacl2shex.rs
@@ -141,19 +141,19 @@ impl Shacl2ShEx {
         match target {
             Target::TargetNode(_) => Ok(None),
             Target::TargetClass(cls) => {
-                        let value_set_value = match cls {
-                            Object::Iri(iri) => Ok(ValueSetValue::iri(IriRef::iri(iri.clone()))),
-                            Object::BlankNode(bn) => {
-                                Err(Shacl2ShExError::UnexpectedBlankNodeForTargetClass {
-                                    bnode: bn.clone(),
-                                })
-                            }
-                            Object::Literal(lit) => Err(Shacl2ShExError::UnexpectedLiteralForTargetClass {
-                                literal: lit.clone(),
-                            }),
-                        }?;
-                        Ok(Some(value_set_value))
+                let value_set_value = match cls {
+                    Object::Iri(iri) => Ok(ValueSetValue::iri(IriRef::iri(iri.clone()))),
+                    Object::BlankNode(bn) => {
+                        Err(Shacl2ShExError::UnexpectedBlankNodeForTargetClass {
+                            bnode: bn.clone(),
+                        })
                     }
+                    Object::Literal(lit) => Err(Shacl2ShExError::UnexpectedLiteralForTargetClass {
+                        literal: lit.clone(),
+                    }),
+                }?;
+                Ok(Some(value_set_value))
+            }
             Target::TargetSubjectsOf(_) => Ok(None),
             Target::TargetObjectsOf(_) => Ok(None),
             Target::TargetImplicitClass(_) => Ok(None),

--- a/shapes_converter/src/shacl_to_shex/shacl2shex_error.rs
+++ b/shapes_converter/src/shacl_to_shex/shacl2shex_error.rs
@@ -1,4 +1,3 @@
-use shacl_ast::node_shape::NodeShape;
 use srdf::literal::SLiteral;
 use thiserror::Error;
 
@@ -11,12 +10,12 @@ pub enum Shacl2ShExError {
     RDFNode2LabelLiteral { literal: SLiteral },
 
     #[error("Not expected node shape: {node_shape:?}")]
-    NotExpectedNodeShape { node_shape: Box<NodeShape> },
+    NotExpectedNodeShape { node_shape: String },
 
-    #[error("Unexpected blank node in target class declaration: {bnode:?}")]
+    #[error("Unexpected blank node in target class declaration: {bnode}")]
     UnexpectedBlankNodeForTargetClass { bnode: String },
 
-    #[error("Unexpected literal in target class declaration: {literal:?}")]
+    #[error("Unexpected literal in target class declaration: {literal}")]
     UnexpectedLiteralForTargetClass { literal: SLiteral },
 }
 

--- a/shapes_converter/src/shex_to_sparql/select_query.rs
+++ b/shapes_converter/src/shex_to_sparql/select_query.rs
@@ -44,11 +44,11 @@ impl SelectQuery {
 impl Display for SelectQuery {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(base) = &self.base {
-            writeln!(f, "{}", base)?
+            writeln!(f, "{base}")?
         };
         // TODO: Unify these 2 branches in one...it was giving an move error on prefixmap that I wanted to bypass quickly...
         if let Some(prefixmap) = &self.prefixmap {
-            writeln!(f, "{}", prefixmap)?;
+            writeln!(f, "{prefixmap}")?;
             writeln!(f, "SELECT * WHERE {{")?;
             for pattern in &self.patterns {
                 write!(f, " ")?;

--- a/shapes_converter/src/shex_to_uml/uml.rs
+++ b/shapes_converter/src/shex_to_uml/uml.rs
@@ -221,8 +221,7 @@ fn component2plantuml<W: Write>(
             };
             writeln!(
                 writer,
-                "class \"{}\" as {} <<(S,#FF7700)>> {} {{ ",
-                name, node_id, href
+                "class \"{name}\" as {node_id} <<(S,#FF7700)>> {href} {{ "
             )?;
             for entry in class.entries() {
                 entry2plantuml(entry, config, writer)?;
@@ -254,7 +253,7 @@ fn entry2plantuml<W: Write>(
     let property = name2plantuml(&entry.name, config);
     let value_constraint = value_constraint2plantuml(&entry.value_constraint, config);
     let card = card2plantuml(&entry.card);
-    writeln!(writer, "{} : {} {}", property, value_constraint, card)?;
+    writeln!(writer, "{property} : {value_constraint} {card}")?;
     writeln!(writer, "--")?;
     Ok(())
 }
@@ -270,7 +269,7 @@ fn name2plantuml(name: &Name, config: &ShEx2UmlConfig) -> String {
         name.name()
     };
     if let Some(href) = name.href() {
-        format!("[[{href} {}]]", str)
+        format!("[[{href} {str}]]")
     } else {
         name.name()
     }

--- a/shapes_converter/src/tap_to_shex/tap2shex.rs
+++ b/shapes_converter/src/tap_to_shex/tap2shex.rs
@@ -213,7 +213,7 @@ fn parse_constraint(
             Ok(())
         }
         _ => Err(Tap2ShExError::NotImplemented {
-            msg: format!("ValueConstraint: {:?}", constraint),
+            msg: format!("ValueConstraint: {constraint:?}"),
         }),
     }
 }

--- a/shex_ast/src/ast/iri_or_str.rs
+++ b/shex_ast/src/ast/iri_or_str.rs
@@ -48,7 +48,7 @@ impl Display for IriOrStr {
             IriOrStr::String(s) => s,
             IriOrStr::IriS(iri_s) => iri_s.as_str(),
         };
-        write!(f, "{}", str)
+        write!(f, "{str}")
     }
 }
 

--- a/shex_ast/src/ast/serde_string_or_struct.rs
+++ b/shex_ast/src/ast/serde_string_or_struct.rs
@@ -41,7 +41,7 @@ where
             FromStr::from_str(value).map_err(|err| {
                 // Just convert the underlying error type into a string and
                 // pass it to serde as a custom error.
-                de::Error::custom(format!("{}", err))
+                de::Error::custom(format!("{err}"))
             })
         }
 

--- a/shex_ast/src/ast/shape_expr_label.rs
+++ b/shex_ast/src/ast/shape_expr_label.rs
@@ -104,7 +104,7 @@ impl Display for ShapeExprLabel {
             ShapeExprLabel::BNode { value } => value.to_string(),
             ShapeExprLabel::Start => "START".to_string(),
         };
-        write!(f, "{}", str)
+        write!(f, "{str}")
     }
 }
 

--- a/shex_ast/src/ast/triple_expr_label.rs
+++ b/shex_ast/src/ast/triple_expr_label.rs
@@ -49,7 +49,7 @@ impl Display for TripleExprLabel {
             TripleExprLabel::IriRef { value } => value.to_string(),
             TripleExprLabel::BNode { value } => value.to_string(),
         };
-        write!(f, "{}", str)
+        write!(f, "{str}")
     }
 }
 

--- a/shex_ast/src/ir/ast2ir.rs
+++ b/shex_ast/src/ir/ast2ir.rs
@@ -726,7 +726,7 @@ fn iri_ref_2_shape_label(id: &IriRef) -> CResult<ShapeLabel> {
 fn mk_cond_value_set(value_set: ValueSet) -> Cond {
     MatchCond::single(
         SingleCond::new()
-            .with_name(format!("{}", value_set).as_str())
+            .with_name(format!("{value_set}").as_str())
             .with_cond(move |node: &Node| {
                 if value_set.check_value(node.as_object()) {
                     Ok(Pending::empty())

--- a/shex_ast/src/ir/shape.rs
+++ b/shex_ast/src/ir/shape.rs
@@ -106,7 +106,7 @@ impl Display for Shape {
             self.preds.iter().join(",")
         };
         write!(f, "Shape {extends}{closed}{extra} ")?;
-        writeln!(f, "Preds: {}", preds)?;
+        writeln!(f, "Preds: {preds}")?;
         writeln!(f, "{}", self.rbe_table)?;
         Ok(())
     }

--- a/shex_compact/src/shapemap_parser.rs
+++ b/shex_compact/src/shapemap_parser.rs
@@ -123,7 +123,7 @@ impl ShapeMapStatementIterator<'_> {
             }),
             Err(Err::Incomplete(_)) => Ok(ShapeMapStatementIterator { src, done: false }),
             Err(e) => Err(ParseError::Custom {
-                msg: format!("cannot start parsing. Error: {}", e),
+                msg: format!("cannot start parsing. Error: {e}"),
             }),
         }
     }

--- a/shex_compact/src/shex_parser.rs
+++ b/shex_compact/src/shex_parser.rs
@@ -98,7 +98,7 @@ impl StatementIterator<'_> {
             }),
             Err(Err::Incomplete(_)) => Ok(StatementIterator { src, done: false }),
             Err(e) => Err(ParseError::Custom {
-                msg: format!("cannot start parsing. Error: {}", e),
+                msg: format!("cannot start parsing. Error: {e}"),
             }),
         }
     }
@@ -143,7 +143,7 @@ impl<'a> Iterator for StatementIterator<'a> {
             }
             Err(e) => {
                 r = Some(Err(ParseError::Custom {
-                    msg: format!("error parsing whitespace. Error: {}", e),
+                    msg: format!("error parsing whitespace. Error: {e}"),
                 }));
                 self.done = true;
             }

--- a/shex_testsuite/src/main.rs
+++ b/shex_testsuite/src/main.rs
@@ -149,10 +149,9 @@ fn print_basic(result: &ManifestRunResult) {
         result.panicked.len(),
     );
     let overview = format!(
-        "Passed: {}, Failed: {}, Skipped: {}, Not implemented: {}",
-        npassed, nfailed, nskipped, npanicked
+        "Passed: {npassed}, Failed: {nfailed}, Skipped: {nskipped}, Not implemented: {npanicked}",
     );
-    println!("{}", overview);
+    println!("{overview}");
 }
 
 fn print_failed(result: &ManifestRunResult) {

--- a/shex_testsuite/src/manifest_validation.rs
+++ b/shex_testsuite/src/manifest_validation.rs
@@ -148,7 +148,7 @@ impl<'de> Deserialize<'de> for Focus {
 fn change_extension(name: String, old_extension: String, new_extension: String) -> String {
     if name.ends_with(&old_extension) {
         let (first, _) = name.split_at(name.len() - old_extension.len());
-        format!("{}{}", first, new_extension)
+        format!("{first}{new_extension}")
     } else {
         name
     }

--- a/shex_validation/src/atom.rs
+++ b/shex_validation/src/atom.rs
@@ -40,8 +40,8 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Atom::Pos(value) => write!(f, "+({})", value),
-            Atom::Neg(value) => write!(f, "!({})", value),
+            Atom::Pos(value) => write!(f, "+({value})"),
+            Atom::Neg(value) => write!(f, "!({value})"),
         }
     }
 }

--- a/shex_validation/src/validator_runner.rs
+++ b/shex_validation/src/validator_runner.rs
@@ -788,7 +788,7 @@ fn show_result(result: &Either<Vec<ValidatorError>, Vec<Reason>>) -> String {
 
 fn show_label(maybe_label: &Option<ShapeLabel>) -> String {
     match maybe_label {
-        Some(label) => format!("{}", label),
+        Some(label) => format!("{label}"),
         None => "No label".to_string(),
     }
 }

--- a/sparql_service/src/srdf_data/rdf_data.rs
+++ b/sparql_service/src/srdf_data/rdf_data.rs
@@ -165,12 +165,12 @@ impl RdfData {
     }
 
     pub fn show_blanknode(&self, bn: &OxBlankNode) -> String {
-        let str: String = format!("{}", bn);
+        let str: String = format!("{bn}");
         format!("{}", str.green())
     }
 
     pub fn show_literal(&self, lit: &OxLiteral) -> String {
-        let str: String = format!("{}", lit);
+        let str: String = format!("{lit}");
         format!("{}", str.red())
     }
 

--- a/srdf/src/literal.rs
+++ b/srdf/src/literal.rs
@@ -169,10 +169,10 @@ impl SLiteral {
             } => match datatype {
                 IriRef::Iri(iri) => write!(f, "\"{lexical_form}\"^^{}", prefixmap.qualify(iri)),
                 IriRef::Prefixed { prefix, local } => {
-                    write!(f, "\"{lexical_form}\"^^{}:{}", prefix, local)
+                    write!(f, "\"{lexical_form}\"^^{prefix}:{local}")
                 }
             },
-            SLiteral::NumericLiteral(n) => write!(f, "{}", n),
+            SLiteral::NumericLiteral(n) => write!(f, "{n}"),
             SLiteral::BooleanLiteral(true) => write!(f, "true"),
             SLiteral::BooleanLiteral(false) => write!(f, "false"),
             SLiteral::DatetimeLiteral(date_time) => write!(f, "{}", date_time.value()),

--- a/srdf/src/numeric_literal.rs
+++ b/srdf/src/numeric_literal.rs
@@ -215,9 +215,9 @@ impl<'de> Deserialize<'de> for NumericLiteral {
 impl Display for NumericLiteral {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            NumericLiteral::Double(d) => write!(f, "{}", d),
-            NumericLiteral::Integer(n) => write!(f, "{}", n),
-            NumericLiteral::Decimal(d) => write!(f, "{}", d),
+            NumericLiteral::Double(d) => write!(f, "{d}"),
+            NumericLiteral::Integer(n) => write!(f, "{n}"),
+            NumericLiteral::Decimal(d) => write!(f, "{d}"),
         }
     }
 }

--- a/srdf/src/query_rdf.rs
+++ b/srdf/src/query_rdf.rs
@@ -108,7 +108,7 @@ impl<S: Rdf> QuerySolution<S> {
                 None => "()".to_string(),
                 Some(v) => format!("{v}"),
             };
-            result.push_str(format!("{} -> {}\n", var, value).as_str())
+            result.push_str(format!("{var} -> {value}\n").as_str())
         }
         result
     }

--- a/srdf/src/rdf.rs
+++ b/srdf/src/rdf.rs
@@ -136,6 +136,10 @@ pub trait Rdf: Sized {
         })
     }
 
+    fn object_as_term(object: &Object) -> Self::Term {
+        Self::Term::from(object.clone())
+    }
+
     fn subject_as_object(subj: &Self::Subject) -> Result<Object, RDFError> {
         let term = Self::subject_as_term(subj);
         <Self::Term as TryInto<Object>>::try_into(term.clone()).map_err(|_| {

--- a/srdf/src/rdf_format.rs
+++ b/srdf/src/rdf_format.rs
@@ -27,7 +27,7 @@ impl FromStr for RDFFormat {
             "n3" => Ok(RDFFormat::N3),
             "nq" => Ok(RDFFormat::NQuads),
             _ => Err(RDFParseError::SRDFError {
-                err: format!("Format {} not supported", s).to_string(),
+                err: format!("Format {s} not supported").to_string(),
             }),
         }
     }

--- a/srdf/src/srdf_graph/srdfgraph.rs
+++ b/srdf/src/srdf_graph/srdfgraph.rs
@@ -155,12 +155,12 @@ impl SRDFGraph {
     }
 
     pub fn show_blanknode(&self, bn: &OxBlankNode) -> String {
-        let str: String = format!("{}", bn);
+        let str: String = format!("{bn}");
         format!("{}", str.green())
     }
 
     pub fn show_literal(&self, lit: &OxLiteral) -> String {
-        let str: String = format!("{}", lit);
+        let str: String = format!("{lit}");
         format!("{}", str.red())
     }
 

--- a/srdf/src/srdf_parser/rdf_node_parser.rs
+++ b/srdf/src/srdf_parser/rdf_node_parser.rs
@@ -1951,7 +1951,7 @@ where
     cond(
         &term,
         move |t| t == &expected,
-        format!("Term {term} not equals {}", expected_str),
+        format!("Term {term} not equals {expected_str}"),
     )
 }
 

--- a/srdf/src/srdf_sparql/srdfsparql.rs
+++ b/srdf/src/srdf_sparql/srdfsparql.rs
@@ -62,12 +62,12 @@ impl SRDFSparql {
     }
 
     fn show_blanknode(&self, bn: &OxBlankNode) -> String {
-        let str: String = format!("{}", bn);
+        let str: String = format!("{bn}");
         format!("{}", str.green())
     }
 
     pub fn show_literal(&self, lit: &OxLiteral) -> String {
-        let str: String = format!("{}", lit);
+        let str: String = format!("{lit}");
         format!("{}", str.red())
     }
 }
@@ -152,7 +152,7 @@ impl AsyncSRDF for SRDFSparql {
     type Err = SRDFSparqlError;
 
     async fn get_predicates_subject(&self, subject: &OxSubject) -> Result<HashSet<OxNamedNode>> {
-        let query = format!(r#"select ?pred where {{ {} ?pred ?obj . }}"#, subject);
+        let query = format!(r#"select ?pred where {{ {subject} ?pred ?obj . }}"#);
         let solutions = make_sparql_query(query.as_str(), &self.client, &self.endpoint_iri)?;
         let mut results = HashSet::new();
         for solution in solutions {

--- a/srdf/src/xsd_datetime.rs
+++ b/srdf/src/xsd_datetime.rs
@@ -72,7 +72,7 @@ impl<'de> Deserialize<'de> for XsdDateTime {
 
 impl Display for XsdDateTime {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.value.to_string())
+        write!(f, "{}", self.value)
     }
 }
 


### PR DESCRIPTION
Refactor the shacl validator code to avoid a generic parameter `S: Rdf` in SchemaIR