### PR TITLE
fix(python): replace ellipsis in text_signature with enum defaults (#362)

### DIFF
--- a/python/src/pyrudof_lib.rs
+++ b/python/src/pyrudof_lib.rs
@@ -175,7 +175,7 @@ impl PyRudof {
     ///   label: Optional label of the shape to convert or None to use the start shape or the first shape
     #[pyo3(
         signature = (schema, mode = "shex", format = "turtle", base = None, reader_mode = &PyReaderMode::Lax, label = None),
-//        text_signature = "(schema, mode, format, base=None, reader_mode=ReaderMode.Lax, label=None)"
+        text_signature = "(schema, mode, format, base=None, reader_mode=ReaderMode.Lax, label=None)"
     )]
     pub fn get_coshamo_str(
         &mut self,
@@ -215,8 +215,8 @@ impl PyRudof {
     ///   base1, base2: Optional base IRIs to resolve relative IRIs in the schemas
     ///   reader_mode: Reader mode to use when reading the schemas, e.g. lax, strict
     #[pyo3(
-        signature = (schema1, schema2, mode1 = "shex", mode2 = "shex", format1 = "turtle", format2 = "turtle", base1 = None, base2 = None, label1 = None, label2 = None, reader_mode = &PyReaderMode::Lax), 
-        // text_signature = "(schema1, schema2, mode1='shex', mode2='shex', format1='turtle', format2='turtle', base1=None, base2=None, label1=None, label2=None, reader_mode=ReaderMode.Lax)"
+        signature = (schema1, schema2, mode1 = "shex", mode2 = "shex", format1 = "turtle", format2 = "turtle", base1 = None, base2 = None, label1 = None, label2 = None, reader_mode = &PyReaderMode::Lax),
+         text_signature = "(schema1, schema2, mode1='shex', mode2='shex', format1='turtle', format2='turtle', base1=None, base2=None, label1=None, label2=None, reader_mode=ReaderMode.Lax)"
     )]
     #[allow(clippy::too_many_arguments)]
     pub fn compare_schemas_str(
@@ -292,7 +292,7 @@ impl PyRudof {
     /// Run a SPARQL CONSTRUCT query obtained from a string on the RDF data
     #[pyo3(
         signature = (input, format = &PyQueryResultFormat::Turtle),
-        // text_signature = "(input, format=QueryResultFormat.Turtle)"
+         text_signature = "(input, format=QueryResultFormat.Turtle)"
     )]
     pub fn run_query_construct_str(
         &mut self,
@@ -308,8 +308,8 @@ impl PyRudof {
     }
 
     /// Run the current query on the current RDF data if it is a CONSTRUCT query
-    #[pyo3(signature = (format = &PyQueryResultFormat::Turtle))]
-    // text_signature = "(format=QueryResultFormat.Turtle)")]
+    #[pyo3(signature = (format = &PyQueryResultFormat::Turtle),
+        text_signature = "(format=QueryResultFormat.Turtle)")]
     pub fn run_current_query_construct(
         &mut self,
         format: &PyQueryResultFormat,
@@ -406,7 +406,7 @@ impl PyRudof {
     /// Raises:
     ///     RudofError if there is an error reading the DCTAP data
     #[pyo3(signature = (input, format = &PyDCTapFormat::CSV),
-        // text_signature = "(input, format=PyDCTapFormat.CSV)"
+         text_signature = "(input, format=PyDCTapFormat.CSV)"
     )]
     pub fn read_dctap_str(&mut self, input: &str, format: &PyDCTapFormat) -> PyResult<()> {
         self.inner.reset_dctap();
@@ -427,8 +427,8 @@ impl PyRudof {
     ///
     /// Raises:
     ///     RudofError if there is an error reading the DCTAP data
-    #[pyo3(signature = (path_name, format = &PyDCTapFormat::CSV))]
-    // text_signature = "(path_name, format=DCTapFormat.CSV)")]
+    #[pyo3(signature = (path_name, format = &PyDCTapFormat::CSV),
+        text_signature = "(path_name, format=DCTapFormat.CSV)")]
     pub fn read_dctap_path(&mut self, path_name: &str, format: &PyDCTapFormat) -> PyResult<()> {
         let reader = get_path_reader(path_name, "DCTAP data")?;
         self.inner.reset_dctap();
@@ -452,7 +452,7 @@ impl PyRudof {
     ///
     #[pyo3(
         signature = (input, format = &PyShExFormat::ShExC, base = None, reader_mode = &PyReaderMode::Lax),
-        // text_signature = "(input, format=ShExFormat.ShExC, base=None, reader_mode=ReaderMode.Lax)"
+         text_signature = "(input, format=ShExFormat.ShExC, base=None, reader_mode=ReaderMode.Lax)"
     )]
     pub fn read_shex_str(
         &mut self,
@@ -489,7 +489,7 @@ impl PyRudof {
     /// Raises:
     ///     RudofError if there is an error reading the SHACL shapes graph
     #[pyo3(signature = (input, format = &PyShaclFormat::Turtle, base = None, reader_mode = &PyReaderMode::Lax),
-        // text_signature = "(input, format=ShaclFormat.Turtle, base=None, reader_mode=ReaderMode.Lax)"
+         text_signature = "(input, format=ShaclFormat.Turtle, base=None, reader_mode=ReaderMode.Lax)"
     )]
     pub fn read_shacl_str(
         &mut self,
@@ -522,7 +522,7 @@ impl PyRudof {
     ///
     #[pyo3(
         signature = (input, format = &PyShExFormat::ShExC, base = None, reader_mode = &PyReaderMode::Lax),
-        // text_signature = "(input, format=ShExFormat.ShExC, base=None, reader_mode=ReaderMode.Lax)"
+         text_signature = "(input, format=ShExFormat.ShExC, base=None, reader_mode=ReaderMode.Lax)"
     )]
     pub fn read_shex(
         &mut self,
@@ -554,7 +554,7 @@ impl PyRudof {
     /// Raises:
     ///     RudofError if there is an error reading the SHACL shapes graph
     #[pyo3(signature = (input, format = &PyShaclFormat::Turtle, base = None, reader_mode = &PyReaderMode::Lax),
-        // text_signature = "(input, format=ShaclFormat.Turtle, base=None, reader_mode=ReaderMode.Lax)"
+         text_signature = "(input, format=ShaclFormat.Turtle, base=None, reader_mode=ReaderMode.Lax)"
     )]
     pub fn read_shacl(
         &mut self,
@@ -659,7 +659,7 @@ impl PyRudof {
     ///     RudofError if there is an error reading the RDF data
     ///
     #[pyo3(signature = (input, format = &PyRDFFormat::Turtle, base = None, reader_mode = &PyReaderMode::Lax, merge = false),
-        // text_signature = "(input, format=RDFFormat.Turtle, base=None, reader_mode=ReaderMode.Lax, merge = False)"
+         text_signature = "(input, format=RDFFormat.Turtle, base=None, reader_mode=ReaderMode.Lax, merge = False)"
     )]
     pub fn read_data(
         &mut self,
@@ -692,7 +692,7 @@ impl PyRudof {
     /// Raises:
     ///     `RudofError` if there is an error reading the Service Description
     #[pyo3(signature = (input, format = &PyRDFFormat::Turtle, base = None, reader_mode = &PyReaderMode::Lax),
-        // text_signature = "(input, format=RDFFormat.Turtle, base=None, reader_mode=ReaderMode.Lax)"
+        text_signature = "(input, format=RDFFormat.Turtle, base=None, reader_mode=ReaderMode.Lax)"
     )]
     pub fn read_service_description(
         &mut self,
@@ -723,7 +723,7 @@ impl PyRudof {
     /// Raises:
     ///    `RudofError` if there is an error reading the Service Description
     #[pyo3(signature = (input, format = &PyRDFFormat::Turtle, base = None, reader_mode = &PyReaderMode::Lax),
-        // text_signature = "(input, format=RDFFormat.Turtle, base=None, reader_mode=ReaderMode.Lax)"
+         text_signature = "(input, format=RDFFormat.Turtle, base=None, reader_mode=ReaderMode.Lax)"
     )]
     pub fn read_service_description_str(
         &mut self,
@@ -751,7 +751,7 @@ impl PyRudof {
     /// Raises:
     ///     `RudofError` if there is an error writing the Service Description
     #[pyo3(signature = (output, format = &PyServiceDescriptionFormat::Internal),
-        // text_signature = "(output, format=ServiceDescriptionFormat.Internal)"
+         text_signature = "(output, format=ServiceDescriptionFormat.Internal)"
     )]
     pub fn serialize_service_description(
         &self,
@@ -782,7 +782,7 @@ impl PyRudof {
     /// Raises:
     ///     RudofError if there is an error reading the RDF data
     #[pyo3(signature = (input, format = &PyRDFFormat::Turtle, base = None, reader_mode = &PyReaderMode::Lax, merge = false),
-        // text_signature = "(input, format=RDFFormat.Turtle, base=None, reader_mode=ReaderMode.Lax, merge = False)"
+         text_signature = "(input, format=RDFFormat.Turtle, base=None, reader_mode=ReaderMode.Lax, merge = False)"
     )]
     pub fn read_data_str(
         &mut self,
@@ -805,7 +805,7 @@ impl PyRudof {
     /// Args:
     ///     format: Format of the ShEx schema, e.g. shexc, turtle
     #[pyo3(signature = (format = &PyRDFFormat::Turtle),
-        // text_signature = "(format=RDFFormat.Turtle)"
+         text_signature = "(format=RDFFormat.Turtle)"
     )]
     pub fn serialize_data(&self, format: &PyRDFFormat) -> PyResult<String> {
         let mut v = Vec::new();
@@ -898,7 +898,7 @@ impl PyRudof {
     /// Converts the current ShEx to a Class-like diagram using PlantUML syntax
     ///
     /// Args:
-    ///    uml_mode: Mode of UML generation, all nodes or only the neighbours  
+    ///    uml_mode: Mode of UML generation, all nodes or only the neighbours
     ///
     /// Returns:
     ///    String containing the PlantUML representation of the current ShEx schema


### PR DESCRIPTION
- Uncommented text_signature attributes in pyrudof_lib.rs
- Replaces ellipsis (...) with proper enum default values
- Improves IDE autocomplete and documentation generation
- Should resolve #362