### PR TITLE
Added configurable depth for neighbours distance

### DIFF
--- a/python/src/pyrudof_lib.rs
+++ b/python/src/pyrudof_lib.rs
@@ -3,22 +3,22 @@
 //!
 use crate::PyRudofConfig;
 use pyo3::{
-    exceptions::PyValueError, pyclass, pymethods, Bound, Py, PyAny, PyErr, PyRef, PyRefMut, PyResult,
-    Python,
+    Bound, Py, PyAny, PyErr, PyRef, PyRefMut, PyResult, Python, exceptions::PyValueError, pyclass,
+    pymethods,
 };
 use pythonize::pythonize;
 use rudof_lib::{
-    node_info::{format_node_info_list, get_node_info}, parse_node_selector, shacl_validation::validation_report::{report::SortModeReport, result::ValidationResult}, srdf::Object, CoShaMo, ComparatorError,
-    CompareSchemaFormat, CompareSchemaMode, DCTAPFormat, InputSpec, InputSpecError, InputSpecReader, Mie,
-    MimeType, QueryResultFormat, QueryShapeMap, QuerySolution, QuerySolutions, RDFFormat, RdfData,
-    ReaderMode, ResultShapeMap, Rudof, RudofError, ServiceDescription,
-    ServiceDescriptionFormat, ShExFormat, ShExFormatter, ShExSchema, ShaCo, ShaclFormat, ShaclSchemaIR,
-    ShaclValidationMode, ShapeLabel, ShapeMapFormat, ShapeMapFormatter, ShapesGraphSource,
-    SortMode, UmlGenerationMode,
-    ValidationReport,
-    ValidationStatus,
-    VarName,
-    DCTAP,
+    CoShaMo, ComparatorError, CompareSchemaFormat, CompareSchemaMode, DCTAP, DCTAPFormat,
+    InputSpec, InputSpecError, InputSpecReader, Mie, MimeType, QueryResultFormat, QueryShapeMap,
+    QuerySolution, QuerySolutions, RDFFormat, RdfData, ReaderMode, ResultShapeMap, Rudof,
+    RudofError, ServiceDescription, ServiceDescriptionFormat, ShExFormat, ShExFormatter,
+    ShExSchema, ShaCo, ShaclFormat, ShaclSchemaIR, ShaclValidationMode, ShapeLabel, ShapeMapFormat,
+    ShapeMapFormatter, ShapesGraphSource, SortMode, UmlGenerationMode, ValidationReport,
+    ValidationStatus, VarName,
+    node_info::{format_node_info_list, get_node_info},
+    parse_node_selector,
+    shacl_validation::validation_report::{report::SortModeReport, result::ValidationResult},
+    srdf::Object,
 };
 use std::{
     ffi::OsStr,

--- a/rudof_lib/src/node_info.rs
+++ b/rudof_lib/src/node_info.rs
@@ -324,7 +324,7 @@ fn get_incoming_arcs_depth<S: NeighsRDF>(
                 let nodes: Vec<_> = v
                     .iter()
                     .map(|s| IncomingNeighsNode::Term {
-                        term: S::subject_as_term(s)
+                        term: S::subject_as_term(s),
                     })
                     .collect();
                 (k.clone(), nodes)
@@ -347,7 +347,7 @@ fn get_incoming_arcs_depth<S: NeighsRDF>(
                 let rest = get_incoming_arcs_depth(rdf, &subj, depth - 1)?;
                 nodes.push(IncomingNeighsNode::More {
                     term: S::subject_as_term(&subj),
-                    rest
+                    rest,
                 });
             }
             result.insert(k, nodes);


### PR DESCRIPTION
Now is possible to specify the distance of the displayed neighbours in rudof_cli by setting the `-d` flag. This applies to both incoming and outgoing relations.

Closes #359 