### PR TITLE
feat: add `network` feature gate for WASM compatibility

### DIFF
--- a/rudof_rdf/Cargo.toml
+++ b/rudof_rdf/Cargo.toml
@@ -9,6 +9,10 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[features]
+default = ["network"]
+network = ["dep:reqwest", "dep:tokio", "dep:tempfile"]
+
 [dependencies]
 async-trait.workspace = true
 colored.workspace = true
@@ -27,16 +31,16 @@ oxttl.workspace = true
 prefixmap.workspace = true
 proptest.workspace = true
 regex.workspace = true
-reqwest.workspace = true
+reqwest = { workspace = true, optional = true }
 rust_decimal.workspace = true
 rust_decimal_macros.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sparesults.workspace = true
 spargebra.workspace = true
-tempfile.workspace = true
+tempfile = { workspace = true, optional = true }
 tabled.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
+tokio = { workspace = true, optional = true }
 toml.workspace = true
 url.workspace = true

--- a/rudof_rdf/src/rdf_core/visualizer/uml_converter/mod.rs
+++ b/rudof_rdf/src/rdf_core/visualizer/uml_converter/mod.rs
@@ -2,4 +2,6 @@ pub mod errors;
 #[allow(clippy::module_inception)]
 mod uml_converter;
 
-pub use uml_converter::{ImageFormat, UmlConverter, UmlGenerationMode};
+#[cfg(feature = "network")]
+pub use uml_converter::ImageFormat;
+pub use uml_converter::{UmlConverter, UmlGenerationMode};

--- a/rudof_rdf/src/rdf_core/visualizer/uml_converter/uml_converter.rs
+++ b/rudof_rdf/src/rdf_core/visualizer/uml_converter/uml_converter.rs
@@ -1,10 +1,14 @@
 use crate::rdf_core::visualizer::uml_converter::errors::UmlConverterError;
-use std::{
-    fs::File,
-    io::{self, Write},
-    path::Path,
-    process::Command,
-};
+#[cfg(feature = "network")]
+use std::fs::File;
+#[cfg(feature = "network")]
+use std::io;
+use std::io::Write;
+#[cfg(feature = "network")]
+use std::path::Path;
+#[cfg(feature = "network")]
+use std::process::Command;
+#[cfg(feature = "network")]
 use tempfile::TempDir;
 
 /// Trait for converting data structures to PlantUML format.
@@ -35,6 +39,7 @@ pub trait UmlConverter {
     ///
     /// # Returns
     /// * `Result<(), UmlConverterError>` - Ok if successful, Err with details on failure
+    #[cfg(feature = "network")]
     fn as_image<W: Write, P: AsRef<Path>>(
         &self,
         writer: &mut W,
@@ -122,6 +127,7 @@ pub trait UmlConverter {
     ///
     /// # Returns
     /// * `Result<(), UmlConverterError>` - Ok if successful, Err with details on failure
+    #[cfg(feature = "network")]
     fn save_uml_to_tempfile(
         &self,
         tempfile_path: &std::path::Path,
@@ -151,6 +157,7 @@ pub trait UmlConverter {
 ///
 /// # Returns
 /// * `Result<(), io::Error>` - Ok if Java is available, Err otherwise
+#[cfg(feature = "network")]
 fn check_java_installed() -> Result<(), io::Error> {
     let output = Command::new("java").arg("-version").output()?;
     if output.status.success() {
@@ -170,6 +177,7 @@ fn check_java_installed() -> Result<(), io::Error> {
 ///
 /// # Returns
 /// * `Result<(), io::Error>` - Ok if the jar is valid, Err otherwise
+#[cfg(feature = "network")]
 fn check_plantuml_jar<P: AsRef<Path>>(plantuml_path: P) -> Result<(), io::Error> {
     if plantuml_path.as_ref().exists() {
         // Test the jar by running PlantUML with -version flag
@@ -197,6 +205,7 @@ fn check_plantuml_jar<P: AsRef<Path>>(plantuml_path: P) -> Result<(), io::Error>
 }
 
 /// Supported image output formats for PlantUML conversion.
+#[cfg(feature = "network")]
 #[allow(clippy::upper_case_acronyms)]
 pub enum ImageFormat {
     /// Scalable Vector Graphics format

--- a/rudof_rdf/src/rdf_impl/mod.rs
+++ b/rudof_rdf/src/rdf_impl/mod.rs
@@ -1,12 +1,16 @@
 mod in_memory_graph;
 mod in_memory_graph_error;
 mod oxrdf_impl;
+#[cfg(feature = "network")]
 mod sparql_endpoint;
+#[cfg(feature = "network")]
 mod sparql_endpoint_error;
 
 pub use in_memory_graph::{InMemoryGraph, ReaderMode};
 pub use in_memory_graph_error::InMemoryGraphError;
+#[cfg(feature = "network")]
 pub use sparql_endpoint::{SparqlEndpoint, SparqlVars};
+#[cfg(feature = "network")]
 pub use sparql_endpoint_error::SparqlEndpointError;
 
 #[cfg(test)]

--- a/shacl_validation/Cargo.toml
+++ b/shacl_validation/Cargo.toml
@@ -11,6 +11,10 @@ keywords.workspace = true
 categories.workspace = true
 edition.workspace = true
 
+[features]
+default = ["network"]
+network = ["sparql_service/network", "rudof_rdf/network"]
+
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
@@ -20,11 +24,11 @@ indoc.workspace = true
 iri_s.workspace = true
 prefixmap.workspace = true
 serde.workspace = true
-shacl_ast.workspace = true 
-shacl_ir.workspace = true 
-shacl_rdf.workspace = true 
-sparql_service.workspace = true 
-rudof_rdf.workspace = true
+shacl_ast.workspace = true
+shacl_ir.workspace = true
+shacl_rdf.workspace = true
+sparql_service = { version = "0.1.147", path = "../sparql_service", default-features = false }
+rudof_rdf = { version = "0.1.147", path = "../rudof_rdf", default-features = false }
 tabled.workspace = true
 thiserror.workspace = true
 toml.workspace = true

--- a/shacl_validation/src/shacl_processor.rs
+++ b/shacl_validation/src/shacl_processor.rs
@@ -4,12 +4,15 @@ use crate::shacl_engine::sparql::SparqlEngine;
 use crate::shape_validation::Validate;
 use crate::store::Store;
 use crate::store::graph::Graph;
+#[cfg(feature = "network")]
 use crate::store::sparql::Endpoint;
 use crate::validate_error::ValidateError;
 use crate::validation_report::report::ValidationReport;
 use clap::ValueEnum;
+#[cfg(feature = "network")]
 use prefixmap::PrefixMap;
 use rudof_rdf::rdf_core::{NeighsRDF, RDFFormat};
+#[cfg(feature = "network")]
 use rudof_rdf::rdf_impl::SparqlEndpoint;
 use shacl_ir::compiled::schema_ir::SchemaIR;
 use sparql_service::RdfData;
@@ -204,11 +207,13 @@ impl ShaclProcessor<RdfData> for GraphValidation {
 }
 
 /// The Endpoint Graph Validation algorithm.
+#[cfg(feature = "network")]
 pub struct EndpointValidation {
     store: Endpoint,
     mode: ShaclValidationMode,
 }
 
+#[cfg(feature = "network")]
 impl EndpointValidation {
     pub fn new(iri: &str, prefixmap: &PrefixMap, mode: ShaclValidationMode) -> Result<Self, Box<ValidateError>> {
         Ok(EndpointValidation {
@@ -223,6 +228,7 @@ impl EndpointValidation {
     }
 }
 
+#[cfg(feature = "network")]
 impl ShaclProcessor<SparqlEndpoint> for EndpointValidation {
     fn validate(&mut self, shapes_graph: &SchemaIR) -> Result<ValidationReport, Box<ValidateError>> {
         // we initialize the validation report to empty
@@ -233,7 +239,7 @@ impl ShaclProcessor<SparqlEndpoint> for EndpointValidation {
             ShaclValidationMode::Sparql => Box::new(SparqlEngine::new()),
         };
 
-        // for each shape in the schema that has at least rust-analyzer-diagnostics-view:/diagnostic%20message%20[17]?17#file:///home/labra/src/rust/rudof/shacl_validation/src/shacl_processor.rsone target
+        // for each shape in the schema that has at least one target
         for (_, shape) in shapes_graph.iter_with_targets() {
             tracing::debug!("ShaclProcessor.validate with shape {}", shape.id());
             let results = shape.validate(store, &mut (*runner), None, Some(shape), shapes_graph)?;
@@ -245,14 +251,4 @@ impl ShaclProcessor<SparqlEndpoint> for EndpointValidation {
             .with_results(validation_results)
             .with_prefixmap(shapes_graph.prefix_map()))
     }
-    /*fn store(&self) -> &SRDFSparql {
-        self.store.store()
-    }
-
-    fn runner(&self) -> &dyn Engine<SRDFSparql> {
-        match self.mode {
-            ShaclValidationMode::Native => &NativeEngine,
-            ShaclValidationMode::Sparql => &SparqlEngine,
-        }
-    }*/
 }

--- a/shacl_validation/src/store/mod.rs
+++ b/shacl_validation/src/store/mod.rs
@@ -7,6 +7,7 @@ use shacl_rdf::ShaclParser;
 use std::io::BufRead;
 
 pub mod graph;
+#[cfg(feature = "network")]
 pub mod sparql;
 
 pub trait Store<S> {

--- a/shacl_validation/src/validate_error.rs
+++ b/shacl_validation/src/validate_error.rs
@@ -55,6 +55,7 @@ pub enum ValidateError {
     #[error("Error loading the Shapes")]
     Shapes(#[from] RDFError),
 
+    #[cfg(feature = "network")]
     #[error("Error creating the SPARQL endpoint")]
     SPARQLCreation,
 

--- a/sparql_service/Cargo.toml
+++ b/sparql_service/Cargo.toml
@@ -9,6 +9,10 @@ documentation = "https://docs.rs/sparql_service"
 homepage.workspace = true
 repository.workspace = true
 
+[features]
+default = ["network"]
+network = ["rudof_rdf/network"]
+
 [dependencies]
 colored.workspace = true
 const_format = "0.2"
@@ -20,7 +24,7 @@ oxrdf = { workspace = true, features = ["oxsdatatypes", "rdf-12"] }
 oxrdfio = { workspace = true, features = ["rdf-12"] }
 oxsdatatypes.workspace = true
 prefixmap.workspace = true
-rudof_rdf.workspace = true
+rudof_rdf = { version = "0.1.147", path = "../rudof_rdf", default-features = false }
 rust_decimal = "1.38"
 serde.workspace = true
 serde_json.workspace = true

--- a/sparql_service/src/srdf_data/rdf_data_error.rs
+++ b/sparql_service/src/srdf_data/rdf_data_error.rs
@@ -8,14 +8,17 @@ use thiserror::Error;
 
 use rudof_rdf::{
     rdf_core::RDFFormat,
-    rdf_impl::{InMemoryGraphError, SparqlEndpointError},
+    rdf_impl::InMemoryGraphError,
 };
+#[cfg(feature = "network")]
+use rudof_rdf::rdf_impl::SparqlEndpointError;
 
 #[derive(Debug, Error)]
 pub enum RdfDataError {
     #[error("Error extending query solutions for query '{query}': {error}")]
     ExtendingQuerySolutionsError { query: String, error: String },
 
+    #[cfg(feature = "network")]
     #[error("Error extending query solutions for query '{query} for endpoint {endpoint}': {error}")]
     ExtendingQuerySolutionsErrorEndpoint {
         query: String,
@@ -23,12 +26,14 @@ pub enum RdfDataError {
         endpoint: String,
     },
 
+    #[cfg(feature = "network")]
     #[error(transparent)]
     SRDFSparqlError {
         #[from]
         err: SparqlEndpointError,
     },
 
+    #[cfg(feature = "network")]
     #[error("Failed to create SPARQL endpoint {name} with {url}: {err}")]
     SRDFSparqlFromEndpointDescriptionError {
         name: String,


### PR DESCRIPTION
Gate `reqwest`, `tokio`, and `tempfile` behind an opt-in `network` feature (enabled by default) in `rudof_rdf`, `sparql_service`, and `shacl_validation`. This allows these crates to compile to `wasm32-unknown-unknown` when used with `default-features = false`.

In `rudof_rdf`:
- `SparqlEndpoint`, `SparqlEndpointError` gated behind `network`
- `UmlConverter::as_image`, `ImageFormat` gated behind `network`

In `sparql_service`:
- `RdfData` endpoint fields/methods gated behind `network`
- `RdfDataError` endpoint variants gated behind `network`

In `shacl_validation`:
- `EndpointValidation` and `store::sparql` gated behind `network`
- `GraphValidation` and native mode remain always available

Existing users are unaffected: `default = ["network"]` preserves current behavior. Only consumers that explicitly opt out via `default-features = false` get the reduced WASM-compatible surface.