### PR TITLE
fix: remove unnecessary unwrap from closed_info

### DIFF
--- a/shacl_ir/src/compiled/closed_info.rs
+++ b/shacl_ir/src/compiled/closed_info.rs
@@ -48,7 +48,7 @@ impl ClosedInfo {
         let (is_closed, ignored_properties) = shape.closed_component();
         if is_closed {
             let ignored_properties: HashSet<IriS> = ignored_properties.into_iter().collect();
-            let defined_properties = defined_properties_for(&shape.property_shapes(), schema)?;
+            let defined_properties = defined_properties_for(shape.property_shapes(), schema)?;
             let all_properties = defined_properties
                 .union(&ignored_properties)
                 .cloned()
@@ -70,7 +70,7 @@ impl ClosedInfo {
         let (is_closed, ignored_properties) = shape.closed_component();
         if is_closed {
             let ignored_properties: HashSet<IriS> = ignored_properties.into_iter().collect();
-            let defined_properties = defined_properties_for(&shape.property_shapes(), schema)?;
+            let defined_properties = defined_properties_for(shape.property_shapes(), schema)?;
             let all_properties = defined_properties
                 .union(&ignored_properties)
                 .cloned()


### PR DESCRIPTION
Node shapes with `sh:closed true` panic on complex paths.
This should not be the case.

```turtle
@prefix ex: <http://example.org/>.
@prefix sh: <http://www.w3.org/ns/shacl#>.

<failingShape> a sh:NodeShape;
  sh:closed true;
  sh:property [ sh:path [ sh:inversePath ex:test ] ].
```