### PR TITLE
Fix ShEx validation with multiple type constraints

### DIFF
--- a/rbe/src/rbe_table.rs
+++ b/rbe/src/rbe_table.rs
@@ -111,19 +111,17 @@ where
                         Ok(_) => {
                             pairs_found += 1;
                             pairs.push((key.clone(), value.clone(), *component, cond.clone()));
-                        }
+                        },
                         Err(err) => {
-                            trace!(
-                                "Pre-filter: condition {cond} rejected value {value} for component {component}"
-                            );
+                            trace!("Pre-filter: condition {cond} rejected value {value} for component {component}");
                             last_err = Some(err);
-                        }
+                        },
                     }
                 }
-                if pairs.is_empty() {
-                    if let Some(err) = last_err {
-                        return Err(err);
-                    }
+                if pairs.is_empty()
+                    && let Some(err) = last_err
+                {
+                    return Err(err);
                 }
             } else {
                 for component in components {


### PR DESCRIPTION
### Problem

When validating RDF nodes that belong to multiple classes simultaneously, ShEx validation failed unexpectedly. 

For example, a node declared as both Person and Employee would fail validation even when the schema explicitly required both types through separate constraints. The error message indicated that one of the type values was not accepted by a constraint designed for a different type.

### Root Cause

The validation engine used a naive **cartesian product** algorithm in the `RbeTable matches` method. This algorithm generated all possible combinations of value-to-component assignments, including invalid pairings where a value would be checked against an incompatible component. 

The problem occurred because when multiple values shared the same property key and multiple components existed for that key, the algorithm would create every possible pairing. 

For instance, with two type values and two type components, it generated four combinations, two of which were invalid. The iterator would then evaluate these combinations sequentially, and when it encountered the first invalid pairing, it would immediately return an error to the caller without attempting the remaining valid combinations.

### Solution

The fix introduces a **pre-filtering** step that eliminates invalid pairings before the cartesian product is generated. When multiple components are registered for the same key, the algorithm now tests each component's condition against each value upfront. Only the compatible pairings are kept for further processing.

This means that invalid combinations are filtered out early, and the cartesian product only generates valid assignments. In the example scenario with two type values and two type components, the pre-filtering reduces the combinations from four down to just one valid pairing, which is then successfully validated.

Closes #531.