### PR TITLE
Implements choosing the possibility to run tests by trait and to show more information about the traits

### DIFF
--- a/shex_testsuite/README.md
+++ b/shex_testsuite/README.md
@@ -30,17 +30,26 @@ Options:
           Print version
 ```
 
-## Examples
+### Validation tests
 
 By default it runs the validation tests and shows some statistics
 
-```
+```sh
 cargo run -p shex_testsuite
-Passed: 244, Failed: 340, Skipped: 24, Not implemented: 558
+Passed: 1062, Failed: 82, Skipped: 22, Not implemented: 0
 ```
 
-Run testsuite to check that the well-formed schemas are read
+### Check that the well-formed schemas are read
 
-```
+```sh
 cargo run -p shex_testsuite -- -p failed -m shex_testsuite/shexTest/schemas/manifest.jsonld -f schemas
 ```
+
+### Run a concrete test by name
+
+```sh
+cargo run -p shex_testsuite -- -m shex_testsuite/shexTest/validation/manifest.jsonld -e nPlus1
+```
+
+
+### 

--- a/shex_testsuite/src/main.rs
+++ b/shex_testsuite/src/main.rs
@@ -1,7 +1,6 @@
 use anyhow::{Context, Result, bail};
 use clap::Parser;
 use shex_testsuite::manifest_mode::ManifestMode;
-use shex_testsuite::manifest_run_result::ManifestRunResult;
 use shex_testsuite::manifest_schemas::ManifestSchemas;
 use shex_testsuite::print_result_mode::PrintResultMode;
 use shex_testsuite::{
@@ -15,10 +14,9 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
+use tracing::trace;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{filter::EnvFilter, fmt};
-
-use tracing::debug;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -117,7 +115,7 @@ fn main() -> Result<()> {
 
     let manifest = {
         let path_buf = manifest_path.canonicalize()?;
-        debug!("path_buf: {}", &path_buf.display());
+        trace!("path_buf: {}", &path_buf.display());
         let manifest_str = fs::read_to_string(manifest_path)
             .with_context(|| format!("Failed to read manifest: {}", manifest_path.display()))?;
 
@@ -145,81 +143,10 @@ fn main() -> Result<()> {
         cli.trait_name,
     );
 
-    print_result(result, cli.print_result_mode);
+    cli.print_result_mode.print_result(result);
     Ok(())
 }
 
 fn parse_config(file_name: String) -> Result<Config, ConfigError> {
     Config::from_file(file_name.as_str())
-}
-
-fn print_basic(result: &ManifestRunResult) {
-    let (npassed, nskipped, nfailed, npanicked) = (
-        result.passed.len(),
-        result.skipped.len(),
-        result.failed.len(),
-        result.panicked.len(),
-    );
-    let overview = format!("Passed: {npassed}, Failed: {nfailed}, Skipped: {nskipped}, Not implemented: {npanicked}",);
-    println!("{overview}");
-}
-
-fn print_failed(result: &ManifestRunResult) {
-    println!("--- Failed ---");
-    for (name, err) in &result.failed {
-        println!("{name} {err}");
-    }
-}
-
-fn print_failed_simple(result: &ManifestRunResult) {
-    println!("--- Failed ---");
-    let mut sorted_names = result.failed.iter().map(|(name, _)| name).collect::<Vec<&String>>();
-    sorted_names.sort();
-    for name in &sorted_names {
-        println!("{name}");
-    }
-}
-
-fn print_panicked(result: &ManifestRunResult) {
-    println!("--- Not implemented ---");
-    for (name, _err) in &result.panicked {
-        println!("{name}");
-    }
-}
-
-fn print_passed(result: &ManifestRunResult) {
-    println!("--- Passed ---");
-    for name in &result.passed {
-        println!("{name}");
-    }
-}
-
-fn print_result(result: ManifestRunResult, print_result_mode: PrintResultMode) {
-    match print_result_mode {
-        PrintResultMode::Basic => {
-            print_basic(&result);
-        },
-        PrintResultMode::All => {
-            print_passed(&result);
-            print_failed(&result);
-            print_panicked(&result);
-            print_basic(&result);
-        },
-        PrintResultMode::Failed => {
-            print_failed(&result);
-            print_basic(&result);
-        },
-        PrintResultMode::FailedSimple => {
-            print_failed_simple(&result);
-            print_basic(&result);
-        },
-        PrintResultMode::Passed => {
-            print_passed(&result);
-            print_basic(&result);
-        },
-        PrintResultMode::NotImplemented => {
-            print_panicked(&result);
-            print_basic(&result);
-        },
-    }
 }

--- a/shex_testsuite/src/manifest.rs
+++ b/shex_testsuite/src/manifest.rs
@@ -11,12 +11,48 @@ pub trait Manifest {
 
     fn entry_names(&self) -> Vec<String>;
 
+    fn has_traits(&self, name: &str) -> Result<Vec<String>, Box<ManifestError>>;
+
     fn run_entry(&self, name: &str, base: &Path) -> Result<(), Box<ManifestError>>;
 
-    fn should_run_entry_name(&self, single_entries: &Option<Vec<String>>, entry_name: &String) -> bool {
-        match single_entries {
+    fn should_run_entry_name(
+        &self,
+        single_entries: &Option<Vec<String>>,
+        entry_name: &String,
+        allowed_traits: &Option<Vec<String>>,
+    ) -> Result<bool, Box<ManifestError>> {
+        let check_entry_name = match single_entries {
             None => true,
             Some(es) => es.contains(entry_name),
+        };
+        let check_traits = match allowed_traits {
+            None => Ok::<bool, Box<ManifestError>>(true),
+            Some(ts) => {
+                let traits = self.has_traits(entry_name)?;
+                for t in traits {
+                    if ts.contains(&t) {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            },
+        }?;
+        Ok(check_entry_name && check_traits)
+    }
+
+    fn conditional_run(
+        &self,
+        entry_name: &String,
+        base: &Path,
+        single_entries: &Option<Vec<String>>,
+        allowed_traits: &Option<Vec<String>>,
+    ) -> Result<bool, Box<ManifestError>> {
+        let condition = Self::should_run_entry_name(self, single_entries, entry_name, allowed_traits)?;
+        if condition {
+            self.run_entry(entry_name, base)?;
+            Ok(true)
+        } else {
+            Ok(false)
         }
     }
 
@@ -26,26 +62,40 @@ pub trait Manifest {
         mode: ManifestRunMode,
         excluded_entries: Vec<String>,
         single_entries: Option<Vec<String>>,
-        _single_traits: Option<Vec<String>>,
+        allowed_traits: Option<Vec<String>>,
     ) -> ManifestRunResult {
+        /*trace!(
+            "Running manifest with mode: {mode:?}, excluded_entries: {:?}, single_entries: {:?}, allowed_traits: {:?}",
+            excluded_entries, single_entries, allowed_traits
+        );*/
         let mut result: ManifestRunResult = ManifestRunResult::new();
         for entry_name in &self.entry_names() {
+            let entry_traits = self.has_traits(entry_name).unwrap_or_default();
             if excluded_entries.contains(entry_name) {
-                result.add_skipped(entry_name.to_string());
-            } else if Self::should_run_entry_name(self, &single_entries, entry_name) {
-                let safe_result = catch_unwind(AssertUnwindSafe(move || self.run_entry(entry_name, base)));
+                result.add_skipped(entry_name.to_string(), entry_traits);
+            } else {
+                // We clone these here to avoid borrowing issues in the closure passed to catch_unwind
+                let entries = single_entries.clone();
+                let traits = allowed_traits.clone();
+                // We use catch_unwind to catch any panics that occur during the execution of the entry, and treat them as test failures
+                let safe_result = catch_unwind(AssertUnwindSafe(move || {
+                    self.conditional_run(entry_name, base, &entries, &traits)
+                }));
                 match safe_result {
-                    Ok(Ok(())) => {
-                        result.add_passed(entry_name.to_string());
+                    Ok(Ok(true)) => {
+                        result.add_passed(entry_name.to_string(), entry_traits);
+                    },
+                    Ok(Ok(false)) => {
+                        result.add_skipped(entry_name.to_string(), entry_traits);
                     },
                     Ok(Err(e)) => {
-                        result.add_failed(entry_name.to_string(), *e);
+                        result.add_failed(entry_name.to_string(), *e, entry_traits);
                         if mode == ManifestRunMode::FailFirstError {
                             return result;
                         }
                     },
                     Err(err) => {
-                        result.add_panicked(entry_name.to_string(), err);
+                        result.add_panicked(entry_name.to_string(), err, entry_traits);
                         if mode == ManifestRunMode::FailFirstError {
                             return result;
                         }

--- a/shex_testsuite/src/manifest_negative_structure.rs
+++ b/shex_testsuite/src/manifest_negative_structure.rs
@@ -93,6 +93,10 @@ impl Manifest for ManifestNegativeStructure {
             Some(entry) => entry.run(base),
         }
     }
+
+    fn has_traits(&self, _name: &str) -> Result<Vec<std::string::String>, Box<ManifestError>> {
+        todo!()
+    }
 }
 
 #[cfg(test)]

--- a/shex_testsuite/src/manifest_negative_syntax.rs
+++ b/shex_testsuite/src/manifest_negative_syntax.rs
@@ -67,6 +67,10 @@ impl Manifest for ManifestNegativeSyntax {
             Some(entry) => entry.run(base),
         }
     }
+
+    fn has_traits(&self, _name: &str) -> Result<Vec<std::string::String>, Box<ManifestError>> {
+        todo!()
+    }
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/shex_testsuite/src/manifest_run_result.rs
+++ b/shex_testsuite/src/manifest_run_result.rs
@@ -1,6 +1,5 @@
-use std::any::Any;
-
 use crate::manifest_error::ManifestError;
+use std::{any::Any, collections::HashMap};
 
 #[derive(Debug)]
 pub struct ManifestRunResult {
@@ -8,6 +7,10 @@ pub struct ManifestRunResult {
     pub skipped: Vec<String>,
     pub failed: Vec<(String, ManifestError)>,
     pub panicked: Vec<(String, Box<dyn Any + Send + 'static>)>,
+    pub traits_passed: HashMap<String, Vec<String>>,
+    pub traits_skipped: HashMap<String, Vec<String>>,
+    pub traits_failed: HashMap<String, Vec<String>>,
+    pub traits_panicked: HashMap<String, Vec<String>>,
 }
 
 impl Default for ManifestRunResult {
@@ -23,26 +26,42 @@ impl ManifestRunResult {
             skipped: Vec::new(),
             failed: Vec::new(),
             panicked: Vec::new(),
+            traits_passed: HashMap::new(),
+            traits_failed: HashMap::new(),
+            traits_skipped: HashMap::new(),
+            traits_panicked: HashMap::new(),
         }
     }
 
-    pub fn add_passed(&mut self, name: String) -> &Self {
-        self.passed.push(name);
+    pub fn add_passed(&mut self, name: String, traits: Vec<String>) -> &Self {
+        self.passed.push(name.clone());
+        for trait_ in traits {
+            self.traits_passed.entry(trait_).or_default().push(name.clone());
+        }
         self
     }
 
-    pub fn add_skipped(&mut self, name: String) -> &Self {
-        self.skipped.push(name);
+    pub fn add_skipped(&mut self, name: String, traits: Vec<String>) -> &Self {
+        self.skipped.push(name.clone());
+        for trait_ in traits {
+            self.traits_skipped.entry(trait_).or_default().push(name.clone());
+        }
         self
     }
 
-    pub fn add_failed(&mut self, name: String, err: ManifestError) -> &Self {
-        self.failed.push((name, err));
+    pub fn add_failed(&mut self, name: String, err: ManifestError, traits: Vec<String>) -> &Self {
+        self.failed.push((name.clone(), err));
+        for trait_ in traits {
+            self.traits_failed.entry(trait_).or_default().push(name.clone());
+        }
         self
     }
 
-    pub fn add_panicked(&mut self, name: String, err: Box<dyn Any + Send + 'static>) -> &Self {
-        self.panicked.push((name, err));
+    pub fn add_panicked(&mut self, name: String, err: Box<dyn Any + Send + 'static>, traits: Vec<String>) -> &Self {
+        self.panicked.push((name.clone(), err));
+        for trait_ in traits {
+            self.traits_panicked.entry(trait_).or_default().push(name.clone());
+        }
         self
     }
 }

--- a/shex_testsuite/src/manifest_schemas.rs
+++ b/shex_testsuite/src/manifest_schemas.rs
@@ -248,6 +248,10 @@ impl Manifest for ManifestSchemas {
             Some(entry) => entry.run(base),
         }
     }
+
+    fn has_traits(&self, _name: &str) -> Result<Vec<std::string::String>, Box<ManifestError>> {
+        todo!()
+    }
 }
 
 #[cfg(test)]

--- a/shex_testsuite/src/manifest_validation.rs
+++ b/shex_testsuite/src/manifest_validation.rs
@@ -184,6 +184,13 @@ fn parse_schema(path: &Path, _base: Option<&str>, entry_name: &String) -> Result
 }
 
 impl ValidationEntry {
+    pub fn traits(&self) -> Vec<String> {
+        match &self.trait_ {
+            None => Vec::new(),
+            Some(traits) => traits.clone(),
+        }
+    }
+
     pub fn run(&self, folder: &Path) -> Result<(), Box<ManifestError>> {
         let path_absolute = folder.canonicalize().map_err(|err| ManifestError::AbsolutePathError {
             base: folder.to_string_lossy().to_string().into(),
@@ -369,7 +376,6 @@ fn parse_type(str: &str) -> Result<ValidationType, Box<ManifestError>> {
 
 #[cfg(not(target_family = "wasm"))]
 fn path_to_iri(path: &Path) -> Result<IriS, Box<ManifestError>> {
-    trace!("Converting path to IRI: {}", path.display());
     let canonical = path.canonicalize().map_err(|err| {
         Box::new(ManifestError::AbsolutePathError {
             base: path.to_string_lossy().to_string().into(),
@@ -380,7 +386,6 @@ fn path_to_iri(path: &Path) -> Result<IriS, Box<ManifestError>> {
         path: path.to_path_buf(),
     })?;
     let iri = IriS::new_unchecked(url.as_str());
-    trace!("IRI converted: {iri}");
     Ok(iri)
 }
 
@@ -415,6 +420,13 @@ impl Manifest for ManifestValidation {
         match self.map.get(name) {
             None => Err(Box::new(ManifestError::NotFoundEntry { name: name.to_string() })),
             Some(entry) => entry.run(base),
+        }
+    }
+
+    fn has_traits(&self, name: &str) -> Result<Vec<String>, Box<ManifestError>> {
+        match self.map.get(name) {
+            None => Err(Box::new(ManifestError::NotFoundEntry { name: name.to_string() })),
+            Some(entry) => Ok(entry.traits().clone()),
         }
     }
 }

--- a/shex_testsuite/src/print_result_mode.rs
+++ b/shex_testsuite/src/print_result_mode.rs
@@ -1,3 +1,6 @@
+use std::collections::HashSet;
+
+use crate::manifest_run_result::ManifestRunResult;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
 
@@ -9,4 +12,145 @@ pub enum PrintResultMode {
     Passed,
     NotImplemented,
     All,
+    TraitsFailed,
+    TraitsFailedNames,
+    TraitsFailedSkippedNames,
+    TraitsPassedAndFailed,
+}
+
+fn print_basic(result: &ManifestRunResult) {
+    let (npassed, nskipped, nfailed, npanicked) = (
+        result.passed.len(),
+        result.skipped.len(),
+        result.failed.len(),
+        result.panicked.len(),
+    );
+    let overview = format!("Passed: {npassed}, Failed: {nfailed}, Skipped: {nskipped}, Not implemented: {npanicked}",);
+    println!("{overview}");
+}
+
+fn print_traits_failed(result: &ManifestRunResult) {
+    println!("--- Failed with traits ---");
+    for (trait_, failed) in &result.traits_failed {
+        println!("{trait_}: {}", failed.len());
+    }
+}
+
+fn print_traits_failed_names(result: &ManifestRunResult) {
+    println!("--- Failed with traits ---");
+    for (trait_, failed) in &result.traits_failed {
+        println!(
+            "{trait_}: {}",
+            failed.iter().map(|name| name.as_str()).collect::<Vec<_>>().join(", ")
+        );
+    }
+}
+
+fn print_traits_failed_skipped_names(result: &ManifestRunResult) {
+    println!("--- Failed with traits ---");
+    for (trait_, failed) in &result.traits_failed {
+        println!(
+            "{trait_}: {}",
+            failed.iter().map(|name| name.as_str()).collect::<Vec<_>>().join(", ")
+        );
+    }
+    println!("--- Skipped with traits ---");
+    for (trait_, skipped) in &result.traits_skipped {
+        println!(
+            "{trait_}: {}",
+            skipped.iter().map(|name| name.as_str()).collect::<Vec<_>>().join(", ")
+        );
+    }
+}
+
+fn print_traits_passed_and_failed(result: &ManifestRunResult) {
+    let traits_passed = result.traits_passed.keys().cloned().collect::<HashSet<_>>();
+    let traits_failed = result.traits_failed.keys().cloned().collect::<HashSet<_>>();
+    let traits_passed_and_failed = traits_passed.intersection(&traits_failed);
+    println!("--- Passed and Failed traits ---");
+    for trait_ in traits_passed_and_failed {
+        println!("{trait_}");
+    }
+}
+
+fn print_failed(result: &ManifestRunResult) {
+    println!("--- Failed ---");
+    for (name, err) in &result.failed {
+        println!("{name} {err}");
+    }
+}
+
+fn print_failed_simple(result: &ManifestRunResult) {
+    println!("--- Failed ---");
+    let mut sorted_names = result.failed.iter().map(|(name, _)| name).collect::<Vec<&String>>();
+    sorted_names.sort();
+    for name in &sorted_names {
+        println!("{name}");
+    }
+}
+
+fn print_panicked(result: &ManifestRunResult) {
+    println!("--- Not implemented ---");
+    for (name, _err) in &result.panicked {
+        println!("{name}");
+    }
+}
+
+fn print_passed(result: &ManifestRunResult) {
+    println!("--- Passed ---");
+    for name in &result.passed {
+        println!("{name}");
+    }
+}
+
+fn print_result(result: ManifestRunResult, print_result_mode: PrintResultMode) {
+    match print_result_mode {
+        PrintResultMode::Basic => {
+            print_basic(&result);
+        },
+        PrintResultMode::All => {
+            print_passed(&result);
+            print_failed(&result);
+            print_panicked(&result);
+            print_basic(&result);
+        },
+        PrintResultMode::Failed => {
+            print_failed(&result);
+            print_basic(&result);
+        },
+        PrintResultMode::FailedSimple => {
+            print_failed_simple(&result);
+            print_basic(&result);
+        },
+        PrintResultMode::Passed => {
+            print_passed(&result);
+            print_basic(&result);
+        },
+        PrintResultMode::NotImplemented => {
+            print_panicked(&result);
+            print_basic(&result);
+        },
+        PrintResultMode::TraitsFailed => {
+            print_traits_failed(&result);
+            print_basic(&result);
+        },
+        PrintResultMode::TraitsFailedNames => {
+            print_traits_failed_names(&result);
+            print_basic(&result);
+        },
+        PrintResultMode::TraitsFailedSkippedNames => {
+            print_traits_failed_skipped_names(&result);
+            print_basic(&result);
+        },
+        PrintResultMode::TraitsPassedAndFailed => {
+            print_traits_passed_and_failed(&result);
+            print_basic(&result);
+        },
+    }
+}
+
+impl PrintResultMode {
+    pub fn print_result(&self, result: ManifestRunResult) {
+        print_result(result, *self);
+    }
 }


### PR DESCRIPTION
Solves issue #545 

We added several features to the shex_testsuite runner which allow to select traits when running the tests, for example:

If you want to run the tests with trait Extends:

```sh
cargo run -p shex_testsuite -- -m shex_testsuite/shexTest/validation/manifest.jsonld -t Extends 
```

It can also show statistics of the traits and which tests have failed by trait:

```sh
cargo run -p shex_testsuite -- -m shex_testsuite/shexTest/validation/manifest.jsonld -p traits-failed-skipped-names
```