### PR TITLE
Repairs bug detected in issue575 

### DIFF
--- a/examples/shex/issue575.map
+++ b/examples/shex/issue575.map
@@ -1,0 +1,2 @@
+# :a@:Person,
+:b@:User

--- a/examples/shex/issue575.shex
+++ b/examples/shex/issue575.shex
@@ -1,0 +1,12 @@
+prefix : <http://example.org/>
+prefix schema: <http://schema.org/>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:Person {
+  schema:name xsd:string;
+  schema:knows @:Person*
+}
+
+:User EXTENDS @:Person {
+    schema:email xsd:string
+}

--- a/examples/shex/issue575.ttl
+++ b/examples/shex/issue575.ttl
@@ -1,0 +1,8 @@
+prefix : <http://example.org/>
+prefix schema: <http://schema.org/>
+
+:a schema:name  "Alice" .
+
+:b schema:name  "Bob"    ;
+   schema:knows :a ;
+   schema:email "bob@example.com" .

--- a/shex_ast/src/ir/shape.rs
+++ b/shex_ast/src/ir/shape.rs
@@ -3,7 +3,7 @@ use super::{
     dependency_graph::{DependencyGraph, PosNeg},
     sem_act::SemAct,
 };
-use crate::{Expr, Pred, ShapeLabelIdx};
+use crate::{Expr, Pred, ShapeLabelIdx, ir::schema_ir::SchemaIR};
 use itertools::Itertools;
 use std::{collections::HashMap, fmt::Display};
 
@@ -54,8 +54,17 @@ impl Shape {
         &self.extra
     }
 
-    pub fn references(&self) -> HashMap<Pred, Vec<ShapeLabelIdx>> {
-        self.get_value_expr_references()
+    /// Get the references in this shape expression.
+    pub fn references(&self, schema: &SchemaIR) -> HashMap<Pred, Vec<ShapeLabelIdx>> {
+        let mut result = self.get_value_expr_references();
+        for e in &self.extends {
+            let info = schema.find_shape_idx(e).unwrap();
+            let refs = info.expr().references(schema);
+            for (p, v) in refs {
+                result.entry(p).or_default().extend(v);
+            }
+        }
+        result
     }
 
     /// Regular Bag expression that corresponds to the triple expression of the shape
@@ -124,14 +133,14 @@ impl Display for Shape {
         write!(f, "Shape {extends}{closed}{extra} ")?;
         write!(f, "Preds: {preds}")?;
         write!(f, ", TripleExpr: {}", self.expr)?;
-        write!(
+        /*write!(
             f,
             ", References: [{}]",
             self.references()
                 .iter()
                 .map(|(p, ls)| format!("{}->{}", p, ls.iter().join(" ")))
                 .join(", ")
-        )?;
+        )?;*/
         Ok(())
     }
 }

--- a/shex_ast/src/ir/shape_expr.rs
+++ b/shex_ast/src/ir/shape_expr.rs
@@ -75,6 +75,7 @@ impl ShapeExpr {
         }
     }
 
+    /// Get the references in this shape expression.
     pub fn references(&self, schema: &SchemaIR) -> HashMap<Pred, Vec<ShapeLabelIdx>> {
         match self {
             ShapeExpr::ShapeOr { exprs, .. } => exprs.iter().fold(HashMap::new(), |mut acc, expr| {
@@ -102,7 +103,7 @@ impl ShapeExpr {
                 .map(|info| info.expr().references(schema))
                 .unwrap_or_default(),
             ShapeExpr::NodeConstraint(_nc) => HashMap::new(),
-            ShapeExpr::Shape(s) => s.references().clone(),
+            ShapeExpr::Shape(s) => s.references(schema).clone(),
             ShapeExpr::External {} => HashMap::new(),
             ShapeExpr::Ref { idx } => {
                 let mut map = HashMap::new();

--- a/shex_testsuite/tests/baseline_failing.txt
+++ b/shex_testsuite/tests/baseline_failing.txt
@@ -74,14 +74,10 @@ startCode1startReffail_abort
 startCode3fail_abort
 vitals-RESTRICTS-pass_lie-BP
 vitals-RESTRICTS-pass_lie-Posture
-vitals-RESTRICTS-pass_lie-PostureBP
 vitals-RESTRICTS-pass_lie-PostureVital
 vitals-RESTRICTS-pass_lie-Reclined
 vitals-RESTRICTS-pass_lie-ReclinedBP
 vitals-RESTRICTS-pass_lie-ReclinedVital
-vitals-RESTRICTS-pass_lie-Vital
 vitals-RESTRICTS-pass_sit-BP
 vitals-RESTRICTS-pass_sit-Posture
-vitals-RESTRICTS-pass_sit-PostureBP
 vitals-RESTRICTS-pass_sit-PostureVital
-vitals-RESTRICTS-pass_sit-Vital

--- a/shex_validation/src/engine.rs
+++ b/shex_validation/src/engine.rs
@@ -199,6 +199,11 @@ impl Engine {
         }
     }
 
+    /// Returns the set of pairs `(node, shape_idx)` that are dependencies of `node@idx`,
+    /// i.e. all pairs `(node1, idx1)` such that:
+    /// - `node1@idx1` is a direct reference in the shape expression of `idx`, or
+    /// - there is a triple constraint `(pred, ref)` in the shape expression of `idx` and
+    ///   the neighbours of `node` are `(pred, node1)`
     pub(crate) fn dep<R>(
         &self,
         node: &Node,
@@ -218,8 +223,8 @@ impl Engine {
                 dep.insert((node.clone(), *idx));
             }
 
-            // Search all pairs (node1, idx1) in the shape expr referenced by idx such that there is a triple constraint (pred, ref)
-            // and the neighbours of node are (pred, node1)
+            // Search all pairs `(node1, idx1)` in the shape expr referenced by `idx` such that there is a triple constraint `(pred, ref)`
+            // and the neighbours of `node` are `(pred, node1)`
             let references = se.references(schema);
             // trace!("References in shape expr: {:?}", references);
             let preds = references.keys().cloned().collect::<Vec<_>>();


### PR DESCRIPTION
Solves issue #575. The problem is that we were not calculating all the references in a extended shape.

With this change, now we pass the following tests also:
- vitals-RESTRICTS-pass_lie-PostureBP
- vitals-RESTRICTS-pass_lie-Vital
- vitals-RESTRICTS-pass_sit-PostureBP
- vitals-RESTRICTS-pass_sit-Vital