### PR TITLE
Iri Registry

### DIFF
--- a/rudof_iri/Cargo.toml
+++ b/rudof_iri/Cargo.toml
@@ -11,6 +11,7 @@ repository.workspace = true
 
 [dependencies]
 getrandom.workspace = true
+indexmap.workspace = true
 oxiri.workspace = true
 oxrdf.workspace = true
 serde.workspace = true

--- a/rudof_iri/src/lib.rs
+++ b/rudof_iri/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod error;
 mod iri;
 mod mime_type;
+pub mod registry;
 
 pub use crate::iri::{Iri, IriS};
 pub use crate::mime_type::MimeType;

--- a/rudof_iri/src/registry/mod.rs
+++ b/rudof_iri/src/registry/mod.rs
@@ -1,14 +1,16 @@
-mod simple;
 mod parallel;
+mod simple;
 
-pub use simple::SimpleIriSRegistry;
 pub use parallel::ParallelIriSRegistry;
+pub use simple::SimpleIriSRegistry;
 
 pub type IriRegistryIdx = usize;
 
 pub trait IriRegistry {
     type IRI;
-    type RET<'a> where Self: 'a;
+    type RET<'a>
+    where
+        Self: 'a;
 
     /// Register an IRI and return its index.
     fn register(&mut self, iri: Self::IRI) -> IriRegistryIdx;

--- a/rudof_iri/src/registry/mod.rs
+++ b/rudof_iri/src/registry/mod.rs
@@ -1,0 +1,17 @@
+mod simple;
+mod parallel;
+
+pub use simple::SimpleIriSRegistry;
+pub use parallel::ParallelIriSRegistry;
+
+pub type IriRegistryIdx = usize;
+
+pub trait IriRegistry {
+    type IRI;
+    type RET<'a> where Self: 'a;
+
+    /// Register an IRI and return its index.
+    fn register(&mut self, iri: Self::IRI) -> IriRegistryIdx;
+    /// Look up an IRI by index.
+    fn get(&self, id: &IriRegistryIdx) -> Option<Self::RET<'_>>;
+}

--- a/rudof_iri/src/registry/parallel.rs
+++ b/rudof_iri/src/registry/parallel.rs
@@ -1,8 +1,8 @@
-use std::sync::{Arc, RwLock};
-use std::fmt::{Display, Formatter};
-use indexmap::IndexSet;
 use crate::IriS;
 use crate::registry::{IriRegistry, IriRegistryIdx};
+use indexmap::IndexSet;
+use std::fmt::{Display, Formatter};
+use std::sync::{Arc, RwLock};
 
 /// A thread-safe IRI registry.
 #[derive(Debug)]
@@ -12,7 +12,9 @@ pub struct ParallelIriSRegistry {
 
 impl ParallelIriSRegistry {
     pub fn new() -> Self {
-        Self { registry: RwLock::new(IndexSet::new()) }
+        Self {
+            registry: RwLock::new(IndexSet::new()),
+        }
     }
 }
 
@@ -21,17 +23,12 @@ impl IriRegistry for ParallelIriSRegistry {
     type RET<'a> = Arc<IriS>;
 
     fn register(&mut self, iri: Self::IRI) -> IriRegistryIdx {
-        let (idx, _) = self
-            .registry
-            .write()
-            .unwrap()
-            .insert_full(iri);
+        let (idx, _) = self.registry.write().unwrap().insert_full(iri);
         idx
     }
 
     fn get(&self, id: &IriRegistryIdx) -> Option<Self::RET<'_>> {
-        self
-            .registry
+        self.registry
             .read()
             .unwrap()
             .get_index(*id)
@@ -48,12 +45,7 @@ impl Default for ParallelIriSRegistry {
 impl Display for ParallelIriSRegistry {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "ParallelIriRegistry {{")?;
-        for (idx, value) in self
-            .registry
-            .read()
-            .map_err(|_| std::fmt::Error)?
-            .iter()
-            .enumerate() {
+        for (idx, value) in self.registry.read().map_err(|_| std::fmt::Error)?.iter().enumerate() {
             write!(f, " {}: {},", idx, value)?;
         }
         write!(f, " }}")

--- a/rudof_iri/src/registry/parallel.rs
+++ b/rudof_iri/src/registry/parallel.rs
@@ -1,0 +1,61 @@
+use std::sync::{Arc, RwLock};
+use std::fmt::{Display, Formatter};
+use indexmap::IndexSet;
+use crate::IriS;
+use crate::registry::{IriRegistry, IriRegistryIdx};
+
+/// A thread-safe IRI registry.
+#[derive(Debug)]
+pub struct ParallelIriSRegistry {
+    registry: RwLock<IndexSet<IriS>>,
+}
+
+impl ParallelIriSRegistry {
+    pub fn new() -> Self {
+        Self { registry: RwLock::new(IndexSet::new()) }
+    }
+}
+
+impl IriRegistry for ParallelIriSRegistry {
+    type IRI = IriS;
+    type RET<'a> = Arc<IriS>;
+
+    fn register(&mut self, iri: Self::IRI) -> IriRegistryIdx {
+        let (idx, _) = self
+            .registry
+            .write()
+            .unwrap()
+            .insert_full(iri);
+        idx
+    }
+
+    fn get(&self, id: &IriRegistryIdx) -> Option<Self::RET<'_>> {
+        self
+            .registry
+            .read()
+            .unwrap()
+            .get_index(*id)
+            .map(|iri| Arc::new(iri.clone()))
+    }
+}
+
+impl Default for ParallelIriSRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Display for ParallelIriSRegistry {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ParallelIriRegistry {{")?;
+        for (idx, value) in self
+            .registry
+            .read()
+            .map_err(|_| std::fmt::Error)?
+            .iter()
+            .enumerate() {
+            write!(f, " {}: {},", idx, value)?;
+        }
+        write!(f, " }}")
+    }
+}

--- a/rudof_iri/src/registry/simple.rs
+++ b/rudof_iri/src/registry/simple.rs
@@ -1,0 +1,65 @@
+use std::collections::hash_map::IntoIter;
+use crate::registry::{IriRegistry, IriRegistryIdx};
+use crate::IriS;
+use std::fmt::{Display, Formatter};
+use indexmap::IndexSet;
+
+/// A single-threaded IRI registry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SimpleIriSRegistry {
+    registry: IndexSet<IriS>,
+}
+
+impl SimpleIriSRegistry {
+    pub fn new() -> Self {
+        Self { registry: IndexSet::new() }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (IriRegistryIdx, &IriS)> {
+        self
+            .registry
+            .iter()
+            .enumerate()
+            .map(|(idx, iri)| (idx, iri))
+    }
+}
+
+impl IriRegistry for SimpleIriSRegistry {
+    type IRI = IriS;
+    type RET<'a> = &'a IriS;
+
+    fn register(&mut self, iri: Self::IRI) -> IriRegistryIdx {
+        let (idx, _) = self.registry.insert_full(iri);
+        idx
+    }
+
+    fn get(&self, id: &IriRegistryIdx) -> Option<Self::RET<'_>> {
+        self.registry.get_index(*id)
+    }
+}
+
+impl Display for SimpleIriSRegistry {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SimpleIriRegistry {{")?;
+        for (idx, iri) in self.registry.iter().enumerate() {
+            write!(f, " {}: {},", idx, iri)?;
+        }
+        write!(f, " }}")
+    }
+}
+
+impl IntoIterator for SimpleIriSRegistry {
+    type Item = (IriRegistryIdx, IriS);
+    type IntoIter = IntoIter<IriRegistryIdx, IriS>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        // self.registry.into_iter()
+        todo!()
+    }
+}
+
+impl Default for SimpleIriSRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/rudof_iri/src/registry/simple.rs
+++ b/rudof_iri/src/registry/simple.rs
@@ -1,8 +1,9 @@
 use crate::IriS;
 use crate::registry::{IriRegistry, IriRegistryIdx};
 use indexmap::IndexSet;
-use std::collections::hash_map::IntoIter;
+use indexmap::set::IntoIter;
 use std::fmt::{Display, Formatter};
+use std::iter::Enumerate;
 
 /// A single-threaded IRI registry.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,11 +49,10 @@ impl Display for SimpleIriSRegistry {
 
 impl IntoIterator for SimpleIriSRegistry {
     type Item = (IriRegistryIdx, IriS);
-    type IntoIter = IntoIter<IriRegistryIdx, IriS>;
+    type IntoIter = Enumerate<IntoIter<IriS>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        // self.registry.into_iter()
-        todo!()
+        self.registry.into_iter().enumerate()
     }
 }
 

--- a/rudof_iri/src/registry/simple.rs
+++ b/rudof_iri/src/registry/simple.rs
@@ -1,8 +1,8 @@
-use std::collections::hash_map::IntoIter;
-use crate::registry::{IriRegistry, IriRegistryIdx};
 use crate::IriS;
-use std::fmt::{Display, Formatter};
+use crate::registry::{IriRegistry, IriRegistryIdx};
 use indexmap::IndexSet;
+use std::collections::hash_map::IntoIter;
+use std::fmt::{Display, Formatter};
 
 /// A single-threaded IRI registry.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -12,15 +12,13 @@ pub struct SimpleIriSRegistry {
 
 impl SimpleIriSRegistry {
     pub fn new() -> Self {
-        Self { registry: IndexSet::new() }
+        Self {
+            registry: IndexSet::new(),
+        }
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (IriRegistryIdx, &IriS)> {
-        self
-            .registry
-            .iter()
-            .enumerate()
-            .map(|(idx, iri)| (idx, iri))
+        self.registry.iter().enumerate()
     }
 }
 


### PR DESCRIPTION
Added an `IriRegistry` trait to allow us to index `IriS` in some rudof subcrates.

Also single-thread and thread-safe implementations are provided.