### PR TITLE
feat: New user prefixes when using the `data` command

### DIFF
--- a/prefixmap/src/iri/test.rs
+++ b/prefixmap/src/iri/test.rs
@@ -105,7 +105,7 @@ mod iri_ref_tests {
         #[test]
         fn get_iri_prefixmap_owned_for_resolvable_prefixed(prefix in PREFIX_REGEX, uri in URI_REGEX, local in LOCAL_REGEX) {
             let mut pm = PrefixMap::new();
-            pm.add_prefix(prefix.clone(), IriS::new(&uri)?)?;
+            pm.add_prefix(prefix.clone(), IriS::new(&uri)?);
 
             let iri_ref = IriRef::Prefixed {
                 prefix, local: local.clone(),

--- a/prefixmap/src/map.rs
+++ b/prefixmap/src/map.rs
@@ -52,7 +52,7 @@ impl PrefixMap {
     /// Inserts an alias association to an IRI
     ///
     // Returns an [`PrefixMapError`] if the alias already exists.
-    pub fn add_prefix<A, I>(&mut self, alias: A, iri: I) -> Result<(), PrefixMapError>
+    pub fn add_prefix<A, I>(&mut self, alias: A, iri: I)
     where
         A: AsRef<str>,
         I: Into<IriS>,
@@ -65,7 +65,6 @@ impl PrefixMap {
         //     });
         // }
         self.map.insert(key.to_string(), iri.into());
-        Ok(())
     }
 
     /// Finds an IRI associated with a given alias
@@ -75,12 +74,11 @@ impl PrefixMap {
 
     /// Merges another [`PrefixMap`] into this one.
     ///
-    /// Returns an error if any of the aliases in the other [`PrefixMap`] already exist in this one.
-    pub fn merge(&mut self, other: PrefixMap) -> Result<(), PrefixMapError> {
+    // Returns an error if any of the aliases in the other [`PrefixMap`] already exist in this one.
+    pub fn merge(&mut self, other: PrefixMap) {
         for (alias, iri) in other.into_iter() {
-            self.add_prefix(alias, iri)?
+            self.add_prefix(alias, iri)
         }
-        Ok(())
     }
 
     /// Returns an iterator over the aliases in the [`PrefixMap`]
@@ -512,7 +510,7 @@ impl TryFrom<HashMap<&str, &str>> for PrefixMap {
         let mut pm = PrefixMap::new();
         for (a, s) in value {
             let iri = IriS::from_str(s)?;
-            pm.add_prefix(a, iri)?;
+            pm.add_prefix(a, iri);
         }
         Ok(pm)
     }

--- a/prefixmap/src/test.rs
+++ b/prefixmap/src/test.rs
@@ -18,7 +18,7 @@ mod prefixmap_tests {
         fn prefix_map_add(prefix in PREFIX_REGEX, uri in URI_REGEX, local in LOCAL_REGEX) {
             let mut pm = PrefixMap::new();
             let binding = IriS::from_str(&uri)?;
-            pm.add_prefix(prefix.clone(), binding)?;
+            pm.add_prefix(prefix.clone(), binding);
             let expected = IriS::from_str(&format!("{uri}{local}"))?;
             assert_eq!(pm.resolve(&format!("{prefix}:{local}"))?, expected);
 
@@ -35,7 +35,7 @@ mod prefixmap_tests {
 
             for i in 0..5 {
                 let iri = IriS::from_str(&uris[i])?;
-                pm.add_prefix(&prefix_vec[i], iri)?;
+                pm.add_prefix(&prefix_vec[i], iri);
                 writeln!(expected, "prefix {}: <{}>", &prefix_vec[i], &uris[i]).unwrap();
             }
 
@@ -46,7 +46,7 @@ mod prefixmap_tests {
         fn prefixmap_resolve(prefix in PREFIX_REGEX, uri in URI_REGEX, local in LOCAL_REGEX) {
             let mut pm = PrefixMap::new();
             let ex_iri = IriS::from_str(&uri)?;
-            pm.add_prefix(prefix.clone(), ex_iri)?;
+            pm.add_prefix(prefix.clone(), ex_iri);
             assert_eq!(
                 pm.resolve(&format!("{prefix}:{local}"))?,
                 IriS::from_str(&format!("{uri}{local}"))?
@@ -63,7 +63,7 @@ mod prefixmap_tests {
             let prefix_vec: Vec<String> = prefix.iter().cloned().collect();
 
             for i in 0..5 {
-                pm.add_prefix(&prefix_vec[i], IriS::from_str(&uri[i])?)?;
+                pm.add_prefix(&prefix_vec[i], IriS::from_str(&uri[i])?);
             }
             for i in 0..5 {
                 assert_eq!(

--- a/python/src/pyrudof_lib.rs
+++ b/python/src/pyrudof_lib.rs
@@ -210,7 +210,7 @@ impl PyRudof {
         let mut parsed_input = None;
         if let Some(input) = input {
             parsed_input = Some(vec![
-                InputSpec::parse_from_str(input, true)
+                InputSpec::from_str(input)
                     .map_err(|e| InputSpecError::InvalidInput {
                         error: { e.to_string() },
                     })
@@ -295,7 +295,7 @@ impl PyRudof {
         let format = cnv_shex_format(format);
         let reader_mode = cnv_reader_mode(reader_mode);
 
-        let input = InputSpec::parse_from_str(input, true)
+        let input = InputSpec::from_str(input)
             .map_err(|e| InputSpecError::InvalidInput {
                 error: { e.to_string() },
             })
@@ -435,7 +435,7 @@ impl PyRudof {
         let mut parsed_input = None;
         if let Some(input) = input {
             parsed_input = Some(
-                InputSpec::parse_from_str(input, true)
+                InputSpec::from_str(input)
                     .map_err(|e| InputSpecError::InvalidInput {
                         error: { e.to_string() },
                     })
@@ -513,7 +513,7 @@ impl PyRudof {
     ) -> PyResult<()> {
         let format = cnv_shapemap_format(format);
 
-        let input = InputSpec::parse_from_str(input, true)
+        let input = InputSpec::from_str(input)
             .map_err(|e| InputSpecError::InvalidInput {
                 error: { e.to_string() },
             })
@@ -663,7 +663,7 @@ impl PyRudof {
     pub fn read_dctap(&mut self, input: &str, format: Option<&PyDCTapFormat>) -> PyResult<()> {
         let format = cnv_dctap_format(format);
 
-        let input = InputSpec::parse_from_str(input, true)
+        let input = InputSpec::from_str(input)
             .map_err(|e| InputSpecError::InvalidInput {
                 error: { e.to_string() },
             })
@@ -722,7 +722,7 @@ impl PyRudof {
     pub fn read_query(&mut self, input: &str, query_type: Option<&PyQueryType>) -> PyResult<()> {
         let query_type = cnv_query_type(query_type);
 
-        let input = InputSpec::parse_from_str(input, true)
+        let input = InputSpec::from_str(input)
             .map_err(|e| InputSpecError::InvalidInput {
                 error: { e.to_string() },
             })
@@ -810,7 +810,7 @@ impl PyRudof {
         let reader_mode = cnv_reader_mode(reader_mode);
         let format = cnv_rdf_format(format);
 
-        let input = InputSpec::parse_from_str(input, true)
+        let input = InputSpec::from_str(input)
             .map_err(|e| InputSpecError::InvalidInput {
                 error: { e.to_string() },
             })
@@ -897,13 +897,13 @@ impl PyRudof {
         label2: Option<&str>,
         reader_mode: Option<&PyReaderMode>,
     ) -> PyResult<String> {
-        let schema1 = InputSpec::parse_from_str(schema1, true)
+        let schema1 = InputSpec::from_str(schema1)
             .map_err(|e| InputSpecError::InvalidInput {
                 error: { e.to_string() },
             })
             .map_err(|e| cnv_err(e.into()))?;
 
-        let schema2 = InputSpec::parse_from_str(schema2, true)
+        let schema2 = InputSpec::from_str(schema2)
             .map_err(|e| InputSpecError::InvalidInput {
                 error: { e.to_string() },
             })
@@ -967,7 +967,7 @@ impl PyRudof {
         templates_folder: Option<&str>,
         output_folder: Option<&str>,
     ) -> PyResult<String> {
-        let schema = InputSpec::parse_from_str(schema, true)
+        let schema = InputSpec::from_str(schema)
             .map_err(|e| InputSpecError::InvalidInput {
                 error: { e.to_string() },
             })

--- a/rudof_cli/src/cli/parser/data.rs
+++ b/rudof_cli/src/cli/parser/data.rs
@@ -10,6 +10,15 @@ pub struct DataArgs {
     pub data: Vec<InputSpec>,
 
     #[arg(
+        short = 'p',
+        long = "prefix",
+        value_name = "PREFIX-SOURCE",
+        help = "Prefix source (can be a string, a path or an URL)",
+        value_parser = clap::value_parser!(InputSpec)
+    )]
+    pub prefixes: Vec<InputSpec>,
+
+    #[arg(
         short = 't',
         long = "data-format",
         value_name = "FORMAT",

--- a/rudof_cli/src/cli/parser/data.rs
+++ b/rudof_cli/src/cli/parser/data.rs
@@ -3,7 +3,7 @@ use crate::cli::wrappers::{DataFormatCli, DataReaderModeCli, ResultDataFormatCli
 use clap::Args;
 use rudof_lib::formats::InputSpec;
 
-/// Arguments for the `shacl-validate` command
+/// Arguments for the `data` command
 #[derive(Debug, Clone, Args)]
 pub struct DataArgs {
     #[clap(value_parser = clap::value_parser!(InputSpec))]

--- a/rudof_cli/src/commands/data.rs
+++ b/rudof_cli/src/commands/data.rs
@@ -43,6 +43,9 @@ impl Command for DataCommand {
         if let Some(endpoint) = self.args.endpoint.as_deref() {
             loading = loading.with_endpoint(endpoint);
         }
+        if !self.args.prefixes.is_empty() {
+            loading = loading.with_prefixes(&self.args.prefixes);
+        }
         loading.execute()?;
 
         ctx.rudof

--- a/rudof_lib/Cargo.toml
+++ b/rudof_lib/Cargo.toml
@@ -29,6 +29,7 @@ prefixmap.workspace = true
 pgschema.workspace = true
 rdf_config.workspace = true
 reqwest.workspace = true
+regex.workspace = true
 rudof_generate.workspace = true
 rudof_rdf.workspace = true
 serde.workspace = true

--- a/rudof_lib/src/api/data/builders/load_data.rs
+++ b/rudof_lib/src/api/data/builders/load_data.rs
@@ -112,7 +112,7 @@ impl<'a> LoadDataBuilder<'a> {
             self.endpoint,
             self.reader_mode,
             self.merge,
-            self.prefixes
+            self.prefixes,
         )
     }
 }

--- a/rudof_lib/src/api/data/builders/load_data.rs
+++ b/rudof_lib/src/api/data/builders/load_data.rs
@@ -16,6 +16,7 @@ pub struct LoadDataBuilder<'a> {
     endpoint: Option<&'a str>,
     reader_mode: Option<&'a DataReaderMode>,
     merge: Option<bool>,
+    prefixes: Option<&'a [InputSpec]>,
 }
 
 impl<'a> LoadDataBuilder<'a> {
@@ -32,6 +33,7 @@ impl<'a> LoadDataBuilder<'a> {
             endpoint: None,
             reader_mode: None,
             merge: None,
+            prefixes: None,
         }
     }
 
@@ -95,6 +97,11 @@ impl<'a> LoadDataBuilder<'a> {
         self
     }
 
+    pub fn with_prefixes(mut self, prefixes: &'a [InputSpec]) -> Self {
+        self.prefixes = Some(prefixes);
+        self
+    }
+
     /// Executes the data loading operation with the configured parameters.
     pub fn execute(self) -> Result<()> {
         <Rudof as DataOperations>::load_data(
@@ -105,6 +112,7 @@ impl<'a> LoadDataBuilder<'a> {
             self.endpoint,
             self.reader_mode,
             self.merge,
+            self.prefixes
         )
     }
 }

--- a/rudof_lib/src/api/data/data_operations_trait.rs
+++ b/rudof_lib/src/api/data/data_operations_trait.rs
@@ -31,6 +31,7 @@ pub trait DataOperations {
         endpoint: Option<&str>,
         reader_mode: Option<&DataReaderMode>,
         merge: Option<bool>,
+        prefixes: Option<&[InputSpec]>
     ) -> Result<()>;
 
     /// Serializes the current RDF data to a writer.
@@ -133,8 +134,9 @@ impl DataOperations for Rudof {
         endpoint: Option<&str>,
         reader_mode: Option<&DataReaderMode>,
         merge: Option<bool>,
+        prefixes: Option<&[InputSpec]>
     ) -> Result<()> {
-        load_data(self, data, data_format, base, endpoint, reader_mode, merge)
+        load_data(self, data, data_format, base, endpoint, reader_mode, merge, prefixes)
     }
 
     fn serialize_data<W: io::Write>(

--- a/rudof_lib/src/api/data/data_operations_trait.rs
+++ b/rudof_lib/src/api/data/data_operations_trait.rs
@@ -31,7 +31,7 @@ pub trait DataOperations {
         endpoint: Option<&str>,
         reader_mode: Option<&DataReaderMode>,
         merge: Option<bool>,
-        prefixes: Option<&[InputSpec]>
+        prefixes: Option<&[InputSpec]>,
     ) -> Result<()>;
 
     /// Serializes the current RDF data to a writer.
@@ -134,7 +134,7 @@ impl DataOperations for Rudof {
         endpoint: Option<&str>,
         reader_mode: Option<&DataReaderMode>,
         merge: Option<bool>,
-        prefixes: Option<&[InputSpec]>
+        prefixes: Option<&[InputSpec]>,
     ) -> Result<()> {
         load_data(self, data, data_format, base, endpoint, reader_mode, merge, prefixes)
     }

--- a/rudof_lib/src/api/data/implementations/load_data.rs
+++ b/rudof_lib/src/api/data/implementations/load_data.rs
@@ -1,3 +1,4 @@
+use crate::errors::{InputSpecError, RudofError};
 use crate::{
     Result, Rudof,
     errors::DataError,
@@ -7,14 +8,13 @@ use crate::{
 };
 use pgschema::parser::pg_builder::PgBuilder;
 use prefixmap::PrefixMap;
+use regex::Regex;
 use rudof_iri::{IriS, MimeType};
+use rudof_rdf::rdf_core::BuildRDF;
 use rudof_rdf::rdf_impl::SparqlEndpoint;
 use sparql_service::RdfData;
-use std::{io, str::FromStr};
 use std::io::Read;
-use regex::Regex;
-use rudof_rdf::rdf_core::BuildRDF;
-use crate::errors::{InputSpecError, RudofError};
+use std::{io, str::FromStr};
 
 pub fn load_data(
     rudof: &mut Rudof,
@@ -24,7 +24,7 @@ pub fn load_data(
     endpoint: Option<&str>,
     reader_mode: Option<&DataReaderMode>,
     merge: Option<bool>,
-    prefixes: Option<&[InputSpec]>
+    prefixes: Option<&[InputSpec]>,
 ) -> Result<()> {
     let (data_format, reader_mode, base, merge) = init_defaults(rudof, data_format, reader_mode, base, merge)?;
 
@@ -84,7 +84,7 @@ fn load_data_from_specs_rdf(
     base: IriS,
     reader_mode: DataReaderMode,
     merge: bool,
-    prefixes: Option<&[InputSpec]>
+    prefixes: Option<&[InputSpec]>,
 ) -> Result<()> {
     for input_spec in data {
         let mut data_reader = input_spec
@@ -113,35 +113,27 @@ fn load_data_from_specs_rdf(
             pm.merge(load_user_prefixes(prefix)?)
         }
 
-        rudof
-            .data
-            .as_mut()
-            .unwrap()
-            .unwrap_rdf_mut()
-            .merge_prefixes(pm);
+        rudof.data.as_mut().unwrap().unwrap_rdf_mut().merge_prefixes(pm);
     }
     Ok(())
 }
 
-fn load_user_prefixes(
-    input_spec: &InputSpec
-) -> Result<PrefixMap> {
+fn load_user_prefixes(input_spec: &InputSpec) -> Result<PrefixMap> {
     if matches!(input_spec, InputSpec::Stdin) {
         return Err(RudofError::InputSpec(InputSpecError::InvalidInput {
             error: "Stdin is not supported".to_string(),
-        }))
+        }));
     }
     let mut pm = PrefixMap::new();
 
     let mut reader = input_spec.open_read(Some("text/plain"), "Prefix error")?;
     let mut buffer = Vec::new();
-    reader.read_to_end(&mut buffer).map_err(|e| RudofError::InputSpec(InputSpecError::InvalidInput {
-        error: e.to_string(),
-    }))?;
+    reader
+        .read_to_end(&mut buffer)
+        .map_err(|e| RudofError::InputSpec(InputSpecError::InvalidInput { error: e.to_string() }))?;
 
-    let content = String::from_utf8(buffer).map_err(|e| RudofError::InputSpec(InputSpecError::InvalidInput {
-        error: e.to_string(),
-    }))?;
+    let content = String::from_utf8(buffer)
+        .map_err(|e| RudofError::InputSpec(InputSpecError::InvalidInput { error: e.to_string() }))?;
 
     // Maybe replace with https://www.w3.org/TR/turtle/#grammar-production-PN_PREFIX
     let prefix_regex = Regex::new(r"^(.*) *: *<(.*)>$").unwrap();
@@ -150,9 +142,11 @@ fn load_user_prefixes(
         if let Some(captures) = prefix_regex.captures(content) {
             let prefix = captures.get(1).unwrap().as_str().trim();
             let iri = captures.get(2).unwrap().as_str().trim();
-            pm.add_prefix(prefix, IriS::from_str(iri).map_err(|e| RudofError::InputSpec(InputSpecError::InvalidInput {
-                error: e.to_string(),
-            }))?);
+            pm.add_prefix(
+                prefix,
+                IriS::from_str(iri)
+                    .map_err(|e| RudofError::InputSpec(InputSpecError::InvalidInput { error: e.to_string() }))?,
+            );
             Ok(())
         } else {
             Err(RudofError::InputSpec(InputSpecError::InvalidInput {
@@ -171,12 +165,12 @@ fn load_user_prefixes(
                 }
                 add_prefix(line)?
             }
-        }
+        },
         InputSpec::Stdin => unreachable!(),
         InputSpec::Str(_) => {
             let content = content.trim();
             add_prefix(content)?
-        }
+        },
     }
 
     Ok(pm)

--- a/rudof_lib/src/api/data/implementations/load_data.rs
+++ b/rudof_lib/src/api/data/implementations/load_data.rs
@@ -11,6 +11,10 @@ use rudof_iri::{IriS, MimeType};
 use rudof_rdf::rdf_impl::SparqlEndpoint;
 use sparql_service::RdfData;
 use std::{io, str::FromStr};
+use std::io::Read;
+use regex::Regex;
+use rudof_rdf::rdf_core::BuildRDF;
+use crate::errors::{InputSpecError, RudofError};
 
 pub fn load_data(
     rudof: &mut Rudof,
@@ -20,6 +24,7 @@ pub fn load_data(
     endpoint: Option<&str>,
     reader_mode: Option<&DataReaderMode>,
     merge: Option<bool>,
+    prefixes: Option<&[InputSpec]>
 ) -> Result<()> {
     let (data_format, reader_mode, base, merge) = init_defaults(rudof, data_format, reader_mode, base, merge)?;
 
@@ -30,7 +35,7 @@ pub fn load_data(
         .into()),
         (Some(data), None) => match data_format {
             DataFormat::Pg => load_data_from_specs_pg(rudof, data, merge),
-            _ => load_data_from_specs_rdf(rudof, data, data_format, base, reader_mode, merge),
+            _ => load_data_from_specs_rdf(rudof, data, data_format, base, reader_mode, merge, prefixes),
         },
         (None, Some(endpoint)) => load_data_from_endpoint(rudof, endpoint),
         (None, None) => Err(Box::new(DataError::DataSourceSpec {
@@ -79,6 +84,7 @@ fn load_data_from_specs_rdf(
     base: IriS,
     reader_mode: DataReaderMode,
     merge: bool,
+    prefixes: Option<&[InputSpec]>
 ) -> Result<()> {
     for input_spec in data {
         let mut data_reader = input_spec
@@ -100,10 +106,83 @@ fn load_data_from_specs_rdf(
         )?;
     }
 
+    if let Some(prefixes) = prefixes {
+        let mut pm = PrefixMap::new();
+
+        for prefix in prefixes {
+            pm.merge(load_user_prefixes(prefix)?)
+        }
+
+        rudof
+            .data
+            .as_mut()
+            .unwrap()
+            .unwrap_rdf_mut()
+            .merge_prefixes(pm);
+    }
     Ok(())
 }
 
-fn read_rdf_data<R: io::Read>(
+fn load_user_prefixes(
+    input_spec: &InputSpec
+) -> Result<PrefixMap> {
+    if matches!(input_spec, InputSpec::Stdin) {
+        return Err(RudofError::InputSpec(InputSpecError::InvalidInput {
+            error: "Stdin is not supported".to_string(),
+        }))
+    }
+    let mut pm = PrefixMap::new();
+
+    let mut reader = input_spec.open_read(Some("text/plain"), "Prefix error")?;
+    let mut buffer = Vec::new();
+    reader.read_to_end(&mut buffer).map_err(|e| RudofError::InputSpec(InputSpecError::InvalidInput {
+        error: e.to_string(),
+    }))?;
+
+    let content = String::from_utf8(buffer).map_err(|e| RudofError::InputSpec(InputSpecError::InvalidInput {
+        error: e.to_string(),
+    }))?;
+
+    // Maybe replace with https://www.w3.org/TR/turtle/#grammar-production-PN_PREFIX
+    let prefix_regex = Regex::new(r"^(.*) *: *<(.*)>$").unwrap();
+
+    let mut add_prefix = |content: &str| {
+        if let Some(captures) = prefix_regex.captures(content) {
+            let prefix = captures.get(1).unwrap().as_str().trim();
+            let iri = captures.get(2).unwrap().as_str().trim();
+            pm.add_prefix(prefix, IriS::from_str(iri).map_err(|e| RudofError::InputSpec(InputSpecError::InvalidInput {
+                error: e.to_string(),
+            }))?);
+            Ok(())
+        } else {
+            Err(RudofError::InputSpec(InputSpecError::InvalidInput {
+                error: format!("Invalid prefix declaration: '{}'", content),
+            }))
+        }
+    };
+
+    match input_spec {
+        InputSpec::Path(_) | InputSpec::Url(_) => {
+            let lines = content.split("\n");
+            for line in lines {
+                let line = line.trim();
+                if line.is_empty() {
+                    continue;
+                }
+                add_prefix(line)?
+            }
+        }
+        InputSpec::Stdin => unreachable!(),
+        InputSpec::Str(_) => {
+            let content = content.trim();
+            add_prefix(content)?
+        }
+    }
+
+    Ok(pm)
+}
+
+fn read_rdf_data<R: Read>(
     rudof: &mut Rudof,
     data_reader: &mut R,
     source_name: &str,

--- a/rudof_lib/src/api/data/implementations/tests/load_data_tests.rs
+++ b/rudof_lib/src/api/data/implementations/tests/load_data_tests.rs
@@ -28,7 +28,7 @@ fn test_load_data_rdf_success() {
         None,
         Some(&DataReaderMode::Strict),
         Some(false),
-        None
+        None,
     )
     .unwrap();
 
@@ -57,7 +57,7 @@ fn test_serialize_data_rdf_jsonld() {
         None,
         Some(&DataReaderMode::Strict),
         Some(false),
-        None
+        None,
     )
     .unwrap();
 
@@ -83,7 +83,7 @@ fn test_serialize_data_rdf_json_alias() {
         None,
         Some(&DataReaderMode::Strict),
         Some(false),
-        None
+        None,
     )
     .unwrap();
 
@@ -111,7 +111,7 @@ fn test_load_data_rdf_merge() {
         None,
         None,
         Some(false),
-        None
+        None,
     )
     .unwrap();
 
@@ -123,7 +123,7 @@ fn test_load_data_rdf_merge() {
         None,
         None,
         Some(true),
-        None
+        None,
     )
     .unwrap();
 
@@ -154,7 +154,7 @@ fn test_load_data_rdf_replace() {
         None,
         None,
         Some(false),
-        None
+        None,
     )
     .unwrap();
 

--- a/rudof_lib/src/api/data/implementations/tests/load_data_tests.rs
+++ b/rudof_lib/src/api/data/implementations/tests/load_data_tests.rs
@@ -28,6 +28,7 @@ fn test_load_data_rdf_success() {
         None,
         Some(&DataReaderMode::Strict),
         Some(false),
+        None
     )
     .unwrap();
 
@@ -56,6 +57,7 @@ fn test_serialize_data_rdf_jsonld() {
         None,
         Some(&DataReaderMode::Strict),
         Some(false),
+        None
     )
     .unwrap();
 
@@ -81,6 +83,7 @@ fn test_serialize_data_rdf_json_alias() {
         None,
         Some(&DataReaderMode::Strict),
         Some(false),
+        None
     )
     .unwrap();
 
@@ -108,6 +111,7 @@ fn test_load_data_rdf_merge() {
         None,
         None,
         Some(false),
+        None
     )
     .unwrap();
 
@@ -119,6 +123,7 @@ fn test_load_data_rdf_merge() {
         None,
         None,
         Some(true),
+        None
     )
     .unwrap();
 
@@ -149,6 +154,7 @@ fn test_load_data_rdf_replace() {
         None,
         None,
         Some(false),
+        None
     )
     .unwrap();
 
@@ -160,6 +166,7 @@ fn test_load_data_rdf_replace() {
         None,
         None,
         Some(false),
+        None,
     )
     .unwrap();
 
@@ -188,6 +195,7 @@ fn test_load_data_invalid_rdf() {
         None,
         None,
         None,
+        None,
     );
 
     assert!(result.is_err());
@@ -212,6 +220,7 @@ fn test_load_data_pg_success() {
         None,
         None,
         Some(false),
+        None,
     )
     .unwrap();
 
@@ -245,6 +254,7 @@ fn test_load_data_pg_merge() {
         None,
         None,
         Some(true),
+        None,
     )
     .unwrap();
 
@@ -256,6 +266,7 @@ fn test_load_data_pg_merge() {
         None,
         None,
         Some(true),
+        None,
     )
     .unwrap();
 
@@ -286,6 +297,7 @@ fn test_load_data_pg_replace() {
         None,
         None,
         Some(false),
+        None,
     )
     .unwrap();
 
@@ -297,6 +309,7 @@ fn test_load_data_pg_replace() {
         None,
         None,
         Some(false),
+        None,
     )
     .unwrap();
 
@@ -325,6 +338,7 @@ fn test_load_data_pg_invalid_syntax() {
         None,
         None,
         None,
+        None,
     );
 
     assert!(result.is_err());
@@ -340,6 +354,7 @@ fn test_load_data_endpoint_success() {
         None,
         None,
         Some("http://example.org/sparql"),
+        None,
         None,
         None,
     )
@@ -359,6 +374,7 @@ fn test_load_data_endpoint_uses_configured_prefixmap_for_known_endpoint() {
         None,
         None,
         Some("https://dbpedia.org/sparql"),
+        None,
         None,
         None,
     )
@@ -391,6 +407,7 @@ fn test_load_data_conflicting_sources() {
         Some("http://example.org/sparql"),
         None,
         None,
+        None,
     );
 
     assert!(result.is_err());
@@ -400,7 +417,7 @@ fn test_load_data_conflicting_sources() {
 fn test_load_data_no_source() {
     let mut rudof = Rudof::new(RudofConfig::default());
 
-    let result = load_data(&mut rudof, None, None, None, None, None, None);
+    let result = load_data(&mut rudof, None, None, None, None, None, None, None);
 
     assert!(result.is_err());
 }

--- a/rudof_lib/src/api/pgschema/implementations/tests/validate_pgschema_tests.rs
+++ b/rudof_lib/src/api/pgschema/implementations/tests/validate_pgschema_tests.rs
@@ -42,6 +42,7 @@ fn test_validate_and_serialize_pgschema() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 

--- a/rudof_lib/src/api/pgschema/implementations/tests/validate_pgschema_tests.rs
+++ b/rudof_lib/src/api/pgschema/implementations/tests/validate_pgschema_tests.rs
@@ -42,7 +42,7 @@ fn test_validate_and_serialize_pgschema() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 

--- a/rudof_lib/src/api/shacl/implementations/tests/load_shacl_schema_tests.rs
+++ b/rudof_lib/src/api/shacl/implementations/tests/load_shacl_schema_tests.rs
@@ -161,7 +161,7 @@ fn test_extract_shacl_shapes_from_data_no_shapes() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -438,7 +438,7 @@ fn test_extract_shapes_multiple_data_sources() {
         None,
         None,
         Some(true),
-        None
+        None,
     )
     .unwrap();
 
@@ -485,7 +485,7 @@ fn test_extract_shapes_with_merge() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -514,7 +514,7 @@ fn test_extract_shapes_with_merge() {
         None,
         None,
         Some(true),
-        None
+        None,
     )
     .unwrap();
 

--- a/rudof_lib/src/api/shacl/implementations/tests/load_shacl_schema_tests.rs
+++ b/rudof_lib/src/api/shacl/implementations/tests/load_shacl_schema_tests.rs
@@ -58,6 +58,7 @@ fn test_extract_shacl_shapes_from_loaded_data() {
         None,
         None,
         None,
+        None,
     )
     .unwrap();
 
@@ -118,6 +119,7 @@ fn test_extract_shacl_shapes_mixed_data() {
         None,
         None,
         None,
+        None,
     )
     .unwrap();
 
@@ -159,6 +161,7 @@ fn test_extract_shacl_shapes_from_data_no_shapes() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -248,6 +251,7 @@ fn test_extract_and_serialize_complex_shapes() {
         None,
         None,
         None,
+        None,
     )
     .unwrap();
 
@@ -290,6 +294,7 @@ fn test_extract_shapes_then_load_separate_schema() {
         &mut rudof,
         Some(&[data_with_shapes]),
         Some(&DataFormat::Turtle),
+        None,
         None,
         None,
         None,
@@ -371,6 +376,7 @@ fn test_extract_shacl_shapes_with_lists() {
         None,
         None,
         None,
+        None,
     )
     .unwrap();
 
@@ -432,6 +438,7 @@ fn test_extract_shapes_multiple_data_sources() {
         None,
         None,
         Some(true),
+        None
     )
     .unwrap();
 
@@ -478,6 +485,7 @@ fn test_extract_shapes_with_merge() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -506,6 +514,7 @@ fn test_extract_shapes_with_merge() {
         None,
         None,
         Some(true),
+        None
     )
     .unwrap();
 

--- a/rudof_lib/src/api/shacl/implementations/tests/validate_shacl_tests.rs
+++ b/rudof_lib/src/api/shacl/implementations/tests/validate_shacl_tests.rs
@@ -77,7 +77,7 @@ fn test_validate_shacl_conforming_data() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -146,7 +146,7 @@ fn test_validate_shacl_non_conforming_data() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -216,7 +216,7 @@ fn test_validate_shacl_without_schema() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -267,7 +267,7 @@ fn test_validate_shacl_datatype_violations() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -330,7 +330,7 @@ fn test_validate_shacl_min_max_violations() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -393,7 +393,7 @@ fn test_validate_shacl_pattern_violations() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -463,7 +463,7 @@ fn test_validate_shacl_node_shape_violations() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -519,7 +519,7 @@ fn test_serialize_validation_results_compact() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -576,7 +576,7 @@ fn test_serialize_validation_results_details() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -634,7 +634,7 @@ fn test_serialize_validation_results_turtle() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -704,7 +704,7 @@ fn test_validate_shacl_with_validation_mode() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -777,7 +777,7 @@ fn test_validate_multiple_violations() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 

--- a/rudof_lib/src/api/shacl/implementations/tests/validate_shacl_tests.rs
+++ b/rudof_lib/src/api/shacl/implementations/tests/validate_shacl_tests.rs
@@ -77,6 +77,7 @@ fn test_validate_shacl_conforming_data() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -145,6 +146,7 @@ fn test_validate_shacl_non_conforming_data() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -214,6 +216,7 @@ fn test_validate_shacl_without_schema() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -264,6 +267,7 @@ fn test_validate_shacl_datatype_violations() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -326,6 +330,7 @@ fn test_validate_shacl_min_max_violations() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -388,6 +393,7 @@ fn test_validate_shacl_pattern_violations() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -457,6 +463,7 @@ fn test_validate_shacl_node_shape_violations() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -512,6 +519,7 @@ fn test_serialize_validation_results_compact() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -568,6 +576,7 @@ fn test_serialize_validation_results_details() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -625,6 +634,7 @@ fn test_serialize_validation_results_turtle() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -694,6 +704,7 @@ fn test_validate_shacl_with_validation_mode() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -766,6 +777,7 @@ fn test_validate_multiple_violations() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 

--- a/rudof_lib/src/api/shex/implementations/tests/load_shapemap_tests.rs
+++ b/rudof_lib/src/api/shex/implementations/tests/load_shapemap_tests.rs
@@ -36,7 +36,7 @@ fn test_load_shapemap_compact_success() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -87,7 +87,7 @@ fn test_load_shapemap_replace() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -162,7 +162,7 @@ fn test_load_shapemap_no_schema_error() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -192,7 +192,7 @@ fn test_load_shapemap_invalid_syntax() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -233,7 +233,7 @@ fn test_load_shapemap_with_base_nodes() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -286,7 +286,7 @@ fn test_serialize_shapemap_json() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 

--- a/rudof_lib/src/api/shex/implementations/tests/load_shapemap_tests.rs
+++ b/rudof_lib/src/api/shex/implementations/tests/load_shapemap_tests.rs
@@ -36,6 +36,7 @@ fn test_load_shapemap_compact_success() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -86,6 +87,7 @@ fn test_load_shapemap_replace() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -160,6 +162,7 @@ fn test_load_shapemap_no_schema_error() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -189,6 +192,7 @@ fn test_load_shapemap_invalid_syntax() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -229,6 +233,7 @@ fn test_load_shapemap_with_base_nodes() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -281,6 +286,7 @@ fn test_serialize_shapemap_json() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 

--- a/rudof_lib/src/api/shex/implementations/tests/validate_shex_tests.rs
+++ b/rudof_lib/src/api/shex/implementations/tests/validate_shex_tests.rs
@@ -44,7 +44,7 @@ fn test_validate_shex_success() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -122,7 +122,7 @@ fn test_validate_shex_no_schema_error() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -150,7 +150,7 @@ fn test_validate_shex_no_shapemap_error() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -187,7 +187,7 @@ fn test_validate_shex_validation_failure() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -241,7 +241,7 @@ fn test_serialize_validation_results_compact() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -293,7 +293,7 @@ fn test_serialize_validation_results_json() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -346,7 +346,7 @@ fn test_serialize_validation_results_csv() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -398,7 +398,7 @@ fn test_serialize_validation_results_details() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 
@@ -464,7 +464,7 @@ fn test_validate_shex_multiple_nodes() {
         None,
         None,
         None,
-        None
+        None,
     )
     .unwrap();
 

--- a/rudof_lib/src/api/shex/implementations/tests/validate_shex_tests.rs
+++ b/rudof_lib/src/api/shex/implementations/tests/validate_shex_tests.rs
@@ -44,6 +44,7 @@ fn test_validate_shex_success() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -121,6 +122,7 @@ fn test_validate_shex_no_schema_error() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -148,6 +150,7 @@ fn test_validate_shex_no_shapemap_error() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -184,6 +187,7 @@ fn test_validate_shex_validation_failure() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -237,6 +241,7 @@ fn test_serialize_validation_results_compact() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -288,6 +293,7 @@ fn test_serialize_validation_results_json() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -340,6 +346,7 @@ fn test_serialize_validation_results_csv() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -391,6 +398,7 @@ fn test_serialize_validation_results_details() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 
@@ -456,6 +464,7 @@ fn test_validate_shex_multiple_nodes() {
         None,
         None,
         None,
+        None
     )
     .unwrap();
 

--- a/rudof_lib/src/api/shex/implementations/validate_shex.rs
+++ b/rudof_lib/src/api/shex/implementations/validate_shex.rs
@@ -24,7 +24,7 @@ pub fn validate_shex(rudof: &mut Rudof) -> Result<()> {
     }
 
     let result = shex_validator
-        .validate_shapemap(shapemap, rdf_data, shex_schema, &Some(rdf_data.prefixmap_in_memory()))
+        .validate_shapemap(shapemap, rdf_data, shex_schema, &Some(rdf_data.graph_prefixmap()))
         .map_err(|e| ShExError::FailedShExValidation { error: e.to_string() })?;
 
     // Read back the map state that was mutated by MapActionExtension closures during validation.

--- a/rudof_lib/src/errors/input_spec_error.rs
+++ b/rudof_lib/src/errors/input_spec_error.rs
@@ -10,6 +10,10 @@ pub enum InputSpecError {
     #[error("The specified file does not exist: '{str}'")]
     FileDoesntExist { str: String },
 
+    /// This error is returned when a given path is a dir, not a file.
+    #[error("The specified path is a directory, not a file: {str}")]
+    PathIsDir { str: String },
+
     /// The input data is invalid or cannot be processed.
     #[error("The input data is invalid or cannot be processed: {error}")]
     InvalidInput { error: String },

--- a/rudof_lib/src/formats/input_spec.rs
+++ b/rudof_lib/src/formats/input_spec.rs
@@ -3,6 +3,7 @@ use crate::errors::InputSpecError;
 #[cfg(target_family = "wasm")]
 use crate::wasm_stubs::{Client, ClientBuilder, Response};
 use either::Either;
+use regex::Regex;
 #[cfg(not(target_family = "wasm"))]
 use reqwest::blocking::{Client, ClientBuilder, Response};
 use reqwest::header::{ACCEPT, HeaderValue, USER_AGENT};
@@ -15,7 +16,6 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-use regex::Regex;
 use url::Url;
 
 /// Specification for different input sources in Rudof.
@@ -224,7 +224,7 @@ impl FromStr for InputSpec {
         if s.is_empty() {
             return Err(InputSpecError::InvalidInput {
                 error: "The provided input is empty".to_string(),
-            })
+            });
         }
 
         match s {
@@ -240,14 +240,10 @@ impl FromStr for InputSpec {
             _ if filepath_regex.is_match(s) => {
                 let path = Path::new(s);
                 if !path.exists() {
-                    return Err(InputSpecError::FileDoesntExist {
-                        str: s.to_string(),
-                    })
+                    return Err(InputSpecError::FileDoesntExist { str: s.to_string() });
                 }
                 if path.is_dir() {
-                    return Err(InputSpecError::PathIsDir {
-                        str: s.to_string(),
-                    })
+                    return Err(InputSpecError::PathIsDir { str: s.to_string() });
                 }
 
                 let pb: PathBuf = PathBuf::from_str(s).map_err(|e| InputSpecError::ParsingPathError {

--- a/rudof_lib/src/formats/input_spec.rs
+++ b/rudof_lib/src/formats/input_spec.rs
@@ -15,6 +15,7 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
+use regex::Regex;
 use url::Url;
 
 /// Specification for different input sources in Rudof.
@@ -193,34 +194,6 @@ impl InputSpec {
             InputSpec::Str(_) => Ok("string://".to_string()),
         }
     }
-
-    // Get an `InputSpec` from a string
-    // The `allow_plain_str` parameter controls whether arbitrary strings that don't match
-    // other patterns should be treated as raw strings (Str) instead of resulting in an error.
-    // This is used to provide flexibility in contexts where raw string input is expected like in Python bindings,
-    // while still allowing for strict parsing in other contexts.
-    pub fn parse_from_str(s: &str, allow_plain_str: bool) -> Result<Self, InputSpecError> {
-        match s {
-            _ if s == "-" => Ok(InputSpec::Stdin),
-            _ if s.starts_with("http://") => {
-                let url_spec = UrlSpec::parse(s)?;
-                Ok(InputSpec::Url(url_spec))
-            },
-            _ if s.starts_with("https://") => {
-                let url_spec = UrlSpec::parse(s)?;
-                Ok(InputSpec::Url(url_spec))
-            },
-            _ if Path::new(s).exists() => {
-                let pb: PathBuf = PathBuf::from_str(s).map_err(|e| InputSpecError::ParsingPathError {
-                    str: s.to_string(),
-                    error: format!("{e}"),
-                })?;
-                Ok(InputSpec::Path(pb))
-            },
-            _ if allow_plain_str => Ok(InputSpec::Str(s.to_string())),
-            _ => Err(InputSpecError::FileDoesntExist { str: s.to_string() }),
-        }
-    }
 }
 
 impl Display for InputSpec {
@@ -245,9 +218,46 @@ impl FromStr for InputSpec {
     /// - Existing file paths become Path
     /// - Everything else becomes a raw string (Str)
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // The `allow_plain_str` parameter is set to false here to prevent treating arbitrary strings as file paths,
-        // which could lead to confusing errors if the string doesn't exist as a file.
-        Self::parse_from_str(s, false)
+        // TODO - This probably needs some improvements
+        let filepath_regex = Regex::new(r"^[.~/a-zA-Z0-9]?[/\\a-zA-Z0-9._-]*$").unwrap();
+
+        if s.is_empty() {
+            return Err(InputSpecError::InvalidInput {
+                error: "The provided input is empty".to_string(),
+            })
+        }
+
+        match s {
+            _ if s == "-" => Ok(InputSpec::Stdin),
+            _ if s.starts_with("http://") => {
+                let url_spec = UrlSpec::parse(s)?;
+                Ok(InputSpec::Url(url_spec))
+            },
+            _ if s.starts_with("https://") => {
+                let url_spec = UrlSpec::parse(s)?;
+                Ok(InputSpec::Url(url_spec))
+            },
+            _ if filepath_regex.is_match(s) => {
+                let path = Path::new(s);
+                if !path.exists() {
+                    return Err(InputSpecError::FileDoesntExist {
+                        str: s.to_string(),
+                    })
+                }
+                if path.is_dir() {
+                    return Err(InputSpecError::PathIsDir {
+                        str: s.to_string(),
+                    })
+                }
+
+                let pb: PathBuf = PathBuf::from_str(s).map_err(|e| InputSpecError::ParsingPathError {
+                    str: s.to_string(),
+                    error: format!("{e}"),
+                })?;
+                Ok(InputSpec::Path(pb))
+            },
+            _ => Ok(InputSpec::Str(s.to_string())),
+        }
     }
 }
 

--- a/rudof_mcp/src/service/tools/data_tools_impl.rs
+++ b/rudof_mcp/src/service/tools/data_tools_impl.rs
@@ -129,7 +129,7 @@ pub async fn load_rdf_data_from_sources_impl(
     // Parse data specifications - return Tool Execution Error for invalid input
     let data_specs: Vec<InputSpec> = match data
         .iter()
-        .map(|s| InputSpec::parse_from_str(s, true))
+        .map(|s| InputSpec::from_str(s))
         .collect::<Result<Vec<_>, _>>()
     {
         Ok(specs) => specs,

--- a/rudof_mcp/src/service/tools/shacl_validate_tools_impl.rs
+++ b/rudof_mcp/src/service/tools/shacl_validate_tools_impl.rs
@@ -88,7 +88,7 @@ pub async fn validate_shacl_impl(
         shapes.as_deref(),
         "shapes",
         "Provide valid SHACL shapes content, URL, or file path",
-        |s| InputSpec::parse_from_str(s, true),
+        |s| InputSpec::from_str(s),
     ) {
         Ok(value) => value,
         Err(e) => return Ok(e.into_call_tool_result()),

--- a/rudof_mcp/src/service/tools/shacl_validate_tools_impl.rs
+++ b/rudof_mcp/src/service/tools/shacl_validate_tools_impl.rs
@@ -88,7 +88,7 @@ pub async fn validate_shacl_impl(
         shapes.as_deref(),
         "shapes",
         "Provide valid SHACL shapes content, URL, or file path",
-        |s| InputSpec::from_str(s),
+        InputSpec::from_str,
     ) {
         Ok(value) => value,
         Err(e) => return Ok(e.into_call_tool_result()),

--- a/rudof_mcp/src/service/tools/shex_tools_impl.rs
+++ b/rudof_mcp/src/service/tools/shex_tools_impl.rs
@@ -77,7 +77,7 @@ pub async fn show_shex_impl(
         &schema,
         "schema",
         "Provide valid schema content, URL, or file path",
-        |s| InputSpec::parse_from_str(s, true),
+        |s| InputSpec::from_str(s),
     ) {
         Ok(value) => value,
         Err(e) => return Ok(e.into_call_tool_result()),
@@ -261,7 +261,7 @@ pub async fn check_shex_impl(
         &schema,
         "schema",
         "Provide valid schema content, URL, or file path",
-        |s| InputSpec::parse_from_str(s, true),
+        |s| InputSpec::from_str(s),
     ) {
         Ok(value) => value,
         Err(e) => return Ok(e.into_call_tool_result()),

--- a/rudof_mcp/src/service/tools/shex_tools_impl.rs
+++ b/rudof_mcp/src/service/tools/shex_tools_impl.rs
@@ -77,7 +77,7 @@ pub async fn show_shex_impl(
         &schema,
         "schema",
         "Provide valid schema content, URL, or file path",
-        |s| InputSpec::from_str(s),
+        InputSpec::from_str,
     ) {
         Ok(value) => value,
         Err(e) => return Ok(e.into_call_tool_result()),
@@ -261,7 +261,7 @@ pub async fn check_shex_impl(
         &schema,
         "schema",
         "Provide valid schema content, URL, or file path",
-        |s| InputSpec::from_str(s),
+        InputSpec::from_str,
     ) {
         Ok(value) => value,
         Err(e) => return Ok(e.into_call_tool_result()),

--- a/rudof_mcp/src/service/tools/shex_validate_tools_impl.rs
+++ b/rudof_mcp/src/service/tools/shex_validate_tools_impl.rs
@@ -108,7 +108,7 @@ pub async fn validate_shex_impl(
         &schema,
         "schema",
         "Provide valid schema content, URL, or file path",
-        |s| InputSpec::from_str(s),
+        InputSpec::from_str,
     ) {
         Ok(value) => value,
         Err(e) => return Ok(e.into_call_tool_result()),
@@ -155,7 +155,7 @@ pub async fn validate_shex_impl(
         &effective_shapemap,
         "shapemap",
         "Provide a valid ShapeMap value, URL, or file path",
-        |s| InputSpec::from_str(s),
+        InputSpec::from_str,
     ) {
         Ok(value) => value,
         Err(e) => return Ok(e.into_call_tool_result()),

--- a/rudof_mcp/src/service/tools/shex_validate_tools_impl.rs
+++ b/rudof_mcp/src/service/tools/shex_validate_tools_impl.rs
@@ -108,7 +108,7 @@ pub async fn validate_shex_impl(
         &schema,
         "schema",
         "Provide valid schema content, URL, or file path",
-        |s| InputSpec::parse_from_str(s, true),
+        |s| InputSpec::from_str(s),
     ) {
         Ok(value) => value,
         Err(e) => return Ok(e.into_call_tool_result()),
@@ -155,7 +155,7 @@ pub async fn validate_shex_impl(
         &effective_shapemap,
         "shapemap",
         "Provide a valid ShapeMap value, URL, or file path",
-        |s| InputSpec::parse_from_str(s, true),
+        |s| InputSpec::from_str(s),
     ) {
         Ok(value) => value,
         Err(e) => return Ok(e.into_call_tool_result()),

--- a/rudof_rdf/src/rdf_core/build_rdf.rs
+++ b/rudof_rdf/src/rdf_core/build_rdf.rs
@@ -32,12 +32,12 @@ pub trait BuildRDF: NeighsRDF {
     /// * `iri` - The full namespace IRI this prefix represents
     fn add_prefix(&mut self, alias: &str, iri: &IriS);
 
-    /// Adds multiple prefix declarations from a prefix map.
+    /// Replaces the graph prefixmap.
     ///
     /// # Arguments
     ///
     /// * `prefix_map` - A map of prefix aliases to namespace IRIs
-    fn add_prefix_map(&mut self, prefix_map: PrefixMap);
+    fn set_prefix_map(&mut self, prefix_map: PrefixMap);
 
     /// Merges the graph prefixmap with another given.
     ///

--- a/rudof_rdf/src/rdf_core/build_rdf.rs
+++ b/rudof_rdf/src/rdf_core/build_rdf.rs
@@ -22,7 +22,7 @@ pub trait BuildRDF: NeighsRDF {
     /// # Arguments
     ///
     /// * `base` - Optional base IRI for resolving relative references
-    fn add_base(&mut self, base: &Option<IriS>) -> Result<(), Self::Err>;
+    fn add_base(&mut self, base: &Option<IriS>);
 
     /// Adds a namespace prefix declaration to the graph.
     ///
@@ -30,14 +30,21 @@ pub trait BuildRDF: NeighsRDF {
     ///
     /// * `alias` - The prefix alias (e.g., "foaf", "ex", "rdf")
     /// * `iri` - The full namespace IRI this prefix represents
-    fn add_prefix(&mut self, alias: &str, iri: &IriS) -> Result<(), Self::Err>;
+    fn add_prefix(&mut self, alias: &str, iri: &IriS);
 
     /// Adds multiple prefix declarations from a prefix map.
     ///
     /// # Arguments
     ///
     /// * `prefix_map` - A map of prefix aliases to namespace IRIs
-    fn add_prefix_map(&mut self, prefix_map: PrefixMap) -> Result<(), Self::Err>;
+    fn add_prefix_map(&mut self, prefix_map: PrefixMap);
+
+    /// Merges the graph prefixmap with another given.
+    ///
+    /// # Arguments
+    ///
+    /// * `prefix_map` - A map of prefix aliases to namespace IRIs
+    fn merge_prefixes(&mut self, prefix_map: PrefixMap);
 
     /// Adds an RDF triple to the graph.
     ///

--- a/rudof_rdf/src/rdf_core/query/query_solutions.rs
+++ b/rudof_rdf/src/rdf_core/query/query_solutions.rs
@@ -59,11 +59,10 @@ impl<S: Rdf> QuerySolutions<S> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the prefix maps have conflicting definitions for
-    /// the same prefix (same prefix bound to different namespaces).
-    pub fn extend(&mut self, solutions: Vec<QuerySolution<S>>, prefixmap: PrefixMap) -> Result<(), PrefixMapError> {
+    // Returns an error if the prefix maps have conflicting definitions for
+    // the same prefix (same prefix bound to different namespaces).
+    pub fn extend(&mut self, solutions: Vec<QuerySolution<S>>, prefixmap: PrefixMap) {
         self.solutions.extend(solutions);
-        Ok(())
         self.prefixmap.merge(prefixmap);
     }
 

--- a/rudof_rdf/src/rdf_core/query/query_solutions.rs
+++ b/rudof_rdf/src/rdf_core/query/query_solutions.rs
@@ -1,5 +1,5 @@
 use crate::rdf_core::{RDFError, Rdf, query::QuerySolution, term::Object};
-use prefixmap::{PrefixMap, PrefixMapError};
+use prefixmap::PrefixMap;
 use serde::Serialize;
 use std::fmt::Display;
 use std::io::Write;

--- a/rudof_rdf/src/rdf_core/query/query_solutions.rs
+++ b/rudof_rdf/src/rdf_core/query/query_solutions.rs
@@ -63,8 +63,8 @@ impl<S: Rdf> QuerySolutions<S> {
     /// the same prefix (same prefix bound to different namespaces).
     pub fn extend(&mut self, solutions: Vec<QuerySolution<S>>, prefixmap: PrefixMap) -> Result<(), PrefixMapError> {
         self.solutions.extend(solutions);
-        self.prefixmap.merge(prefixmap)?;
         Ok(())
+        self.prefixmap.merge(prefixmap);
     }
 
     /// Returns an iterator over the query solutions.

--- a/rudof_rdf/src/rdf_impl/in_memory_graph.rs
+++ b/rudof_rdf/src/rdf_impl/in_memory_graph.rs
@@ -205,7 +205,7 @@ impl InMemoryGraph {
             (Some(b), None) => Some(b.clone()),
             (_, Some(b)) => Some(IriS::new_unchecked(b)),
         };
-        self.merge_prefixes(prefixes.try_into()?)?;
+        self.merge_prefixes(prefixes.try_into()?);
 
         Ok(())
     }
@@ -336,20 +336,6 @@ impl InMemoryGraph {
             Arc::make_mut(&mut self.graph).insert(triple.as_ref());
         }
 
-        Ok(())
-    }
-
-    /// Merges a prefix map into the graph's prefix map.
-    ///
-    /// # Parameters
-    ///
-    /// * `prefixmap` - The prefix map to merge
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if merging fails due to conflicting prefixes.
-    pub fn merge_prefixes(&mut self, prefixmap: PrefixMap) -> Result<(), InMemoryGraphError> {
-        self.pm.merge(prefixmap)?;
         Ok(())
     }
 
@@ -894,9 +880,8 @@ impl BuildRDF for InMemoryGraph {
     /// # Parameters
     ///
     /// * `base` - Optional base IRI to set
-    fn add_base(&mut self, base: &Option<IriS>) -> Result<(), Self::Err> {
+    fn add_base(&mut self, base: &Option<IriS>) {
         self.base = base.clone();
-        Ok(())
     }
 
     /// Adds a prefix mapping to the graph's prefix map.
@@ -910,9 +895,8 @@ impl BuildRDF for InMemoryGraph {
     ///
     /// # Errors
     ///
-    /// Returns an error if the prefix cannot be added to the prefix map.
-    fn add_prefix(&mut self, alias: &str, iri: &IriS) -> Result<(), Self::Err> {
-        Ok(())
+    // Returns an error if the prefix cannot be added to the prefix map.
+    fn add_prefix(&mut self, alias: &str, iri: &IriS) {
         self.pm.add_prefix(alias, iri.clone());
     }
 
@@ -921,9 +905,21 @@ impl BuildRDF for InMemoryGraph {
     /// # Parameters
     ///
     /// * `prefix_map` - The new prefix map to use
-    fn add_prefix_map(&mut self, prefix_map: PrefixMap) -> Result<(), Self::Err> {
+    fn add_prefix_map(&mut self, prefix_map: PrefixMap) {
         self.pm = prefix_map;
-        Ok(())
+    }
+
+    /// Merges a prefix map into the graph's prefix map.
+    ///
+    /// # Parameters
+    ///
+    /// * `prefixmap` - The prefix map to merge
+    ///
+    /// # Errors
+    ///
+    // Returns an error if merging fails due to conflicting prefixes.
+    fn merge_prefixes(&mut self, prefix_map: PrefixMap) {
+        self.pm.merge(prefix_map);
     }
 
     /// Generates a new unique blank node.
@@ -1028,7 +1024,7 @@ impl BuildRDF for InMemoryGraph {
         let mut serializer = RdfSerializer::from_format(cnv_rdf_format(format));
 
         for (prefix, iri) in &self.pm.map {
-            serializer = serializer.with_prefix(prefix, iri.as_str()).unwrap();
+            serializer = serializer.with_prefix(prefix, iri.as_str())?;
         }
 
         let mut writer = serializer.for_writer(write);
@@ -1235,12 +1231,7 @@ impl QueryRDF for InMemoryGraph {
 
             let solutions = cnv_query_results(query_results)?;
 
-            sols.extend(solutions, self.prefixmap().clone()).map_err(|e| {
-                InMemoryGraphError::ExtendingQuerySolutionsError {
-                    query: query_str.to_string(),
-                    error: e.to_string(),
-                }
-            })?;
+            sols.extend(solutions, self.prefixmap().clone());
         }
 
         Ok(sols)

--- a/rudof_rdf/src/rdf_impl/in_memory_graph.rs
+++ b/rudof_rdf/src/rdf_impl/in_memory_graph.rs
@@ -905,7 +905,7 @@ impl BuildRDF for InMemoryGraph {
     /// # Parameters
     ///
     /// * `prefix_map` - The new prefix map to use
-    fn add_prefix_map(&mut self, prefix_map: PrefixMap) {
+    fn set_prefix_map(&mut self, prefix_map: PrefixMap) {
         self.pm = prefix_map;
     }
 

--- a/rudof_rdf/src/rdf_impl/in_memory_graph.rs
+++ b/rudof_rdf/src/rdf_impl/in_memory_graph.rs
@@ -912,8 +912,8 @@ impl BuildRDF for InMemoryGraph {
     ///
     /// Returns an error if the prefix cannot be added to the prefix map.
     fn add_prefix(&mut self, alias: &str, iri: &IriS) -> Result<(), Self::Err> {
-        self.pm.add_prefix(alias, iri.clone())?;
         Ok(())
+        self.pm.add_prefix(alias, iri.clone());
     }
 
     /// Replaces the entire prefix map with a new one.

--- a/shacl/src/ir/schema.rs
+++ b/shacl/src/ir/schema.rs
@@ -262,16 +262,12 @@ impl IRSchema {
     pub fn build_graph<RDF: BuildRDF>(&self) -> Result<RDF, ShaclWriterError> {
         let mut graph = RDF::empty();
 
-        graph
-            .add_prefix_map(self.prefixmap.clone())
-            .map_err(|err| ShaclWriterError::AddPrefixMap { msg: err.to_string() })?;
-        let _ = graph.add_prefix("rdf", RdfVocab::base_iri());
-        let _ = graph.add_prefix("xsd", XsdVocab::base_iri());
-        let _ = graph.add_prefix("sh", ShaclVocab::base_iri());
+        graph.add_prefix_map(self.prefixmap.clone());
+        graph.add_prefix("rdf", RdfVocab::base_iri());
+        graph.add_prefix("xsd", XsdVocab::base_iri());
+        graph.add_prefix("sh", ShaclVocab::base_iri());
 
-        graph
-            .add_base(&self.base().cloned())
-            .map_err(|err| ShaclWriterError::AddBase { msg: err.to_string() })?;
+        graph.add_base(&self.base().cloned());
 
         self.labels_idx_map.iter().try_for_each(|(id, idx)| {
             let shape = self.shapes.get(idx).ok_or(ShaclWriterError::Write {

--- a/shacl/src/ir/schema.rs
+++ b/shacl/src/ir/schema.rs
@@ -262,7 +262,7 @@ impl IRSchema {
     pub fn build_graph<RDF: BuildRDF>(&self) -> Result<RDF, ShaclWriterError> {
         let mut graph = RDF::empty();
 
-        graph.add_prefix_map(self.prefixmap.clone());
+        graph.set_prefix_map(self.prefixmap.clone());
         graph.add_prefix("rdf", RdfVocab::base_iri());
         graph.add_prefix("xsd", XsdVocab::base_iri());
         graph.add_prefix("sh", ShaclVocab::base_iri());

--- a/shacl/src/validator/processor/mod.rs
+++ b/shacl/src/validator/processor/mod.rs
@@ -85,7 +85,7 @@ pub trait ShaclProcessor<S: NeighsRDF + Debug + Send + Sync> {
 
         let mut pm = shapes_graph.prefix_map().clone();
         if let Some(store_pm) = store.prefixmap() {
-            _ = pm.merge(store_pm);
+            pm.merge(store_pm);
         }
 
         Ok(ValidationReport::new().with_results(all_results).with_prefixmap(pm))

--- a/shacl/src/validator/report/mod.rs
+++ b/shacl/src/validator/report/mod.rs
@@ -100,8 +100,7 @@ impl ValidationReport {
 
     pub fn to_rdf<RDF: BuildRDF + Sized>(&self, writer: &mut RDF) -> Result<(), ReportError> {
         writer
-            .add_prefix("sh", ShaclVocab::sh_ref())
-            .map_err(error_mapper::<RDF>("Error adding prefix to writer"))?;
+            .add_prefix("sh", ShaclVocab::sh_ref());
 
         let report_node: RDF::Subject = writer
             .add_bnode()

--- a/shacl/src/validator/report/mod.rs
+++ b/shacl/src/validator/report/mod.rs
@@ -99,8 +99,7 @@ impl ValidationReport {
     }
 
     pub fn to_rdf<RDF: BuildRDF + Sized>(&self, writer: &mut RDF) -> Result<(), ReportError> {
-        writer
-            .add_prefix("sh", ShaclVocab::sh_ref());
+        writer.add_prefix("sh", ShaclVocab::sh_ref());
 
         let report_node: RDF::Subject = writer
             .add_bnode()

--- a/shex_ast/src/ast/schema.rs
+++ b/shex_ast/src/ast/schema.rs
@@ -1,6 +1,5 @@
 use crate::ast::{SchemaJsonError, serde_string_or_struct::*};
 use crate::{BNode, IriOrStr, ShapeExprLabel};
-use prefixmap::error::PrefixMapError;
 use prefixmap::{IriRef, PrefixMap};
 use rudof_iri::error::IriSError;
 use rudof_iri::{IriS, iri};

--- a/shex_ast/src/ast/schema.rs
+++ b/shex_ast/src/ast/schema.rs
@@ -119,10 +119,10 @@ impl Schema {
         match self.prefixmap {
             None => {
                 let mut pm = PrefixMap::new();
-                pm.add_prefix(alias, iri.clone())?;
+                pm.add_prefix(alias, iri.clone());
                 self.prefixmap = Some(pm);
             },
-            Some(ref mut pm) => pm.add_prefix(alias, iri.clone())?,
+            Some(ref mut pm) => pm.add_prefix(alias, iri.clone()),
         };
         Ok(())
     }

--- a/shex_ast/src/ast/schema.rs
+++ b/shex_ast/src/ast/schema.rs
@@ -115,7 +115,7 @@ impl Schema {
         self
     }
 
-    pub fn add_prefix(&mut self, alias: &str, iri: &IriS) -> Result<(), PrefixMapError> {
+    pub fn add_prefix(&mut self, alias: &str, iri: &IriS) {
         match self.prefixmap {
             None => {
                 let mut pm = PrefixMap::new();
@@ -124,7 +124,6 @@ impl Schema {
             },
             Some(ref mut pm) => pm.add_prefix(alias, iri.clone()),
         };
-        Ok(())
     }
 
     pub fn with_prefixmap(mut self, prefixmap: Option<PrefixMap>) -> Self {

--- a/shex_ast/src/compact/shapemap_parser.rs
+++ b/shex_ast/src/compact/shapemap_parser.rs
@@ -187,13 +187,11 @@ mod tests {
         let str = r#":a@:S"#;
         let mut nodes_prefixmap = PrefixMap::new();
         nodes_prefixmap
-            .add_prefix("", IriS::new_unchecked("http://example.org/"))
-            .unwrap();
+            .add_prefix("", IriS::new_unchecked("http://example.org/"));
 
         let mut shapes_prefixmap = PrefixMap::new();
         shapes_prefixmap
-            .add_prefix("", IriS::new_unchecked("http://example.org/shapes/"))
-            .unwrap();
+            .add_prefix("", IriS::new_unchecked("http://example.org/shapes/"));
 
         let parsed_shapemap = ShapeMapParser::parse(
             str,

--- a/shex_ast/src/compact/shapemap_parser.rs
+++ b/shex_ast/src/compact/shapemap_parser.rs
@@ -186,12 +186,10 @@ mod tests {
     fn test_prefix() {
         let str = r#":a@:S"#;
         let mut nodes_prefixmap = PrefixMap::new();
-        nodes_prefixmap
-            .add_prefix("", IriS::new_unchecked("http://example.org/"));
+        nodes_prefixmap.add_prefix("", IriS::new_unchecked("http://example.org/"));
 
         let mut shapes_prefixmap = PrefixMap::new();
-        shapes_prefixmap
-            .add_prefix("", IriS::new_unchecked("http://example.org/shapes/"));
+        shapes_prefixmap.add_prefix("", IriS::new_unchecked("http://example.org/shapes/"));
 
         let parsed_shapemap = ShapeMapParser::parse(
             str,

--- a/shex_ast/src/compact/shex_compact_printer.rs
+++ b/shex_ast/src/compact/shex_compact_printer.rs
@@ -927,9 +927,8 @@ mod tests {
     #[test]
     fn empty_schema() {
         let mut pm = PrefixMap::new();
-        pm.add_prefix("", IriS::new_unchecked("http://example.org/")).unwrap();
-        pm.add_prefix("schema", IriS::new_unchecked("https://schema.org/"))
-            .unwrap();
+        pm.add_prefix("", IriS::new_unchecked("http://example.org/"));
+        pm.add_prefix("schema", IriS::new_unchecked("https://schema.org/"));
         let schema = Schema::new(&iri!("http://default/")).with_prefixmap(Some(pm));
         let s = ShExFormatter::default().without_colors().format_schema(&schema);
         assert_eq!(

--- a/shex_ast/src/compact/shex_parser.rs
+++ b/shex_ast/src/compact/shex_parser.rs
@@ -161,8 +161,7 @@ mod tests {
  "#;
         let schema = ShExParser::parse(str, None, &iri!("http://default/")).unwrap();
         let mut expected = Schema::new(&iri!("http://default/"));
-        expected
-            .add_prefix("e", &IriS::new_unchecked("http://example.org/"));
+        expected.add_prefix("e", &IriS::new_unchecked("http://example.org/"));
         expected.add_shape(
             ShapeExprLabel::iri_unchecked("http://example.org/S"),
             ShapeExpr::Shape(Shape::new(None, None, None)),

--- a/shex_ast/src/compact/shex_parser.rs
+++ b/shex_ast/src/compact/shex_parser.rs
@@ -39,7 +39,7 @@ impl ShExParser<'_> {
                     schema = schema.with_base(Some(iri));
                 },
                 ShExStatement::PrefixDecl { alias, iri } => {
-                    schema.add_prefix(alias, &iri)?;
+                    schema.add_prefix(alias, &iri);
                 },
                 ShExStatement::StartDecl { shape_expr } => schema = schema.with_start(Some(shape_expr)),
                 ShExStatement::ImportDecl { iri } => {
@@ -162,8 +162,7 @@ mod tests {
         let schema = ShExParser::parse(str, None, &iri!("http://default/")).unwrap();
         let mut expected = Schema::new(&iri!("http://default/"));
         expected
-            .add_prefix("e", &IriS::new_unchecked("http://example.org/"))
-            .unwrap();
+            .add_prefix("e", &IriS::new_unchecked("http://example.org/"));
         expected.add_shape(
             ShapeExprLabel::iri_unchecked("http://example.org/S"),
             ShapeExpr::Shape(Shape::new(None, None, None)),

--- a/sparql_service/src/query_processor.rs
+++ b/sparql_service/src/query_processor.rs
@@ -16,7 +16,7 @@ impl QueryProcessor {
     }
 
     pub fn prefix_map(&self) -> Option<PrefixMap> {
-        Some(self.rdf_data.prefixmap_in_memory())
+        Some(self.rdf_data.graph_prefixmap())
     }
 
     pub fn query_select<S: NeighsRDF>(_str: &str) -> QuerySolutions<S> {

--- a/sparql_service/src/srdf_data/rdf_data.rs
+++ b/sparql_service/src/srdf_data/rdf_data.rs
@@ -393,23 +393,14 @@ impl QueryRDF for RdfData {
                 .execute()?;
             trace!("Got results from in-memory store");
             let sol = cnv_query_results(new_sol)?;
-            sols.extend(sol, self.graph_prefixmap())
-                .map_err(|e| RdfDataError::ExtendingQuerySolutionsError {
-                    query: query_str.to_string(),
-                    error: format!("{e}"),
-                })?;
+            sols.extend(sol, self.graph_prefixmap());
         } else {
             trace!("No in-memory store to query");
         }
-        for (name, endpoint) in self.endpoints_to_use() {
+        for (_, endpoint) in self.endpoints_to_use() {
             let new_sols = endpoint.query_select(query_str)?;
             let new_sols_converted: Vec<QuerySolution<RdfData>> = new_sols.iter().map(cnv_sol).collect();
-            sols.extend(new_sols_converted, endpoint.prefixmap().clone())
-                .map_err(|e| RdfDataError::ExtendingQuerySolutionsErrorEndpoint {
-                    query: query_str.to_string(),
-                    error: format!("{e}"),
-                    endpoint: name.to_string(),
-                })?;
+            sols.extend(new_sols_converted, endpoint.prefixmap().clone());
         }
         Ok(sols)
     }
@@ -514,28 +505,28 @@ impl BuildRDF for RdfData {
         RdfData::new()
     }
 
-    fn add_base(&mut self, _base: &Option<IriS>) -> Result<(), Self::Err> {
-        self.graph
-            .as_mut()
-            .map(|g| g.add_base(_base))
-            .unwrap_or(Ok(()))
-            .map_err(|e| RdfDataError::SRDFGraphError { err: Box::new(e) })
+    fn add_base(&mut self, base: &Option<IriS>) {
+        if let Some(graph) = &mut self.graph {
+            graph.add_base(base)
+        }
     }
 
-    fn add_prefix(&mut self, alias: &str, iri: &IriS) -> Result<(), Self::Err> {
-        self.graph
-            .as_mut()
-            .map(|g| g.add_prefix(alias, iri))
-            .unwrap_or(Ok(()))
-            .map_err(|e| RdfDataError::SRDFGraphError { err: Box::new(e) })
+    fn add_prefix(&mut self, alias: &str, iri: &IriS) {
+        if let Some(graph) = &mut self.graph {
+            graph.add_prefix(alias, iri)
+        }
     }
 
-    fn add_prefix_map(&mut self, prefix_map: PrefixMap) -> Result<(), Self::Err> {
-        self.graph
-            .as_mut()
-            .map(|g| g.add_prefix_map(prefix_map))
-            .unwrap_or(Ok(()))
-            .map_err(|e| RdfDataError::SRDFGraphError { err: Box::new(e) })
+    fn add_prefix_map(&mut self, prefix_map: PrefixMap) {
+        if let Some(graph) = &mut self.graph {
+            graph.add_prefix_map(prefix_map)
+        }
+    }
+
+    fn merge_prefixes(&mut self, prefix_map: PrefixMap) {
+        if let Some(graph) = &mut self.graph {
+            graph.merge_prefixes(prefix_map)
+        }
     }
 
     fn add_triple<S, P, O>(&mut self, subj: S, pred: P, obj: O) -> Result<(), Self::Err>
@@ -636,8 +627,7 @@ mod tests {
     fn test_build_rdf_data() {
         let mut rdf_data = RdfData::new();
         rdf_data
-            .add_prefix("ex", &IriS::from_str("http://example.org/").unwrap())
-            .unwrap();
+            .add_prefix("ex", &IriS::from_str("http://example.org/").unwrap());
         rdf_data
             .add_triple(
                 iri!("http://example.org/alice"),

--- a/sparql_service/src/srdf_data/rdf_data.rs
+++ b/sparql_service/src/srdf_data/rdf_data.rs
@@ -626,8 +626,7 @@ mod tests {
     #[test]
     fn test_build_rdf_data() {
         let mut rdf_data = RdfData::new();
-        rdf_data
-            .add_prefix("ex", &IriS::from_str("http://example.org/").unwrap());
+        rdf_data.add_prefix("ex", &IriS::from_str("http://example.org/").unwrap());
         rdf_data
             .add_triple(
                 iri!("http://example.org/alice"),

--- a/sparql_service/src/srdf_data/rdf_data.rs
+++ b/sparql_service/src/srdf_data/rdf_data.rs
@@ -306,13 +306,7 @@ impl Rdf for RdfData {
                 } else {
                     let mut pm = PrefixMap::new();
                     for e in self.use_endpoints.values() {
-                        match pm.merge(e.prefixmap().clone()) {
-                            Ok(_) => {},
-                            Err(e) => {
-                                eprintln!("Warning: cannot merge prefixmap from endpoint: {}", e);
-                                return None;
-                            },
-                        }
+                        pm.merge(e.prefixmap().clone())
                     }
                     Some(pm)
                 }

--- a/sparql_service/src/srdf_data/rdf_data.rs
+++ b/sparql_service/src/srdf_data/rdf_data.rs
@@ -517,9 +517,9 @@ impl BuildRDF for RdfData {
         }
     }
 
-    fn add_prefix_map(&mut self, prefix_map: PrefixMap) {
+    fn set_prefix_map(&mut self, prefix_map: PrefixMap) {
         if let Some(graph) = &mut self.graph {
-            graph.add_prefix_map(prefix_map)
+            graph.set_prefix_map(prefix_map)
         }
     }
 

--- a/sparql_service/src/srdf_data/rdf_data.rs
+++ b/sparql_service/src/srdf_data/rdf_data.rs
@@ -297,7 +297,7 @@ impl Rdf for RdfData {
     type Triple = OxTriple;
     type Err = RdfDataError;
 
-    fn prefixmap(&self) -> std::option::Option<PrefixMap> {
+    fn prefixmap(&self) -> Option<PrefixMap> {
         match &self.graph {
             Some(g) => Some(g.prefixmap().clone()),
             None => {

--- a/sparql_service/src/srdf_data/rdf_data.rs
+++ b/sparql_service/src/srdf_data/rdf_data.rs
@@ -127,6 +127,7 @@ impl RdfData {
         self.graph.as_ref()
     }
 
+    /// Gets the PrefixMap from the in-memory graph
     pub fn graph_prefixmap(&self) -> PrefixMap {
         self.graph.as_ref().map(|g| g.prefixmap().clone()).unwrap_or_default()
     }
@@ -210,11 +211,6 @@ impl RdfData {
         self.use_endpoints
             .iter()
             .map(|(name, endpoint)| (name.as_str(), endpoint))
-    }
-
-    /// Gets the PrefixMap from the in-memory graph
-    pub fn prefixmap_in_memory(&self) -> PrefixMap {
-        self.graph.as_ref().map(|g| g.prefixmap().clone()).unwrap_or_default()
     }
 
     pub fn show_blanknode(&self, bn: &OxBlankNode) -> String {


### PR DESCRIPTION
Now its possible to add new prefixes when converting data with the `data` command.

The prefix must be `prefix:<URI>`.

The `-p / --prefix` can be repeated multiple times and must be:
- A string with the previously said format.
- A path to a file with prefixes with the same format, one per line
- A url pointing to a file with a prefix per line (like the local file case).

Also some issues has been addressed:
- Some PrefixMap operations couldn't fail, so the error raising has been removed.
- Added merge prefix map function to `BuildRDF` trait.
- Fixed `InputSpec` file detection.

Closes #624. Related to #584 and #613.