### PR TITLE
More work on Issue585 to add property based tests and benchmarks comparing algorithms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,4 +116,4 @@ jobs:
       - name: Run cargo test
         env:
           CARGO_TARGET_WASM32_UNKNOWN_UNKNOWN_RUNNER: wasm-bindgen-test-runner
-        run: cargo test --workspace --target wasm32-unknown-unknown
+        run: cargo test --workspace --target wasm32-unknown-unknown --lib --tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,6 +250,7 @@ axum-server = "0.7"
 base64 = "0.22.1"
 calamine = { version = "0.31" }
 chrono = { version = "0.4", features = ["serde"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 clap = { version = "4.5", features = ["derive"] }
 clap_complete_command.version = "0.6.1"
 clientele = { version = "0.3.8", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,7 +297,7 @@ pgschema = { version = "0.2.18", path = "./pgschema" }
 petgraph = { version = "0.8" }
 prefixmap = { version = "0.2.18", path = "./prefixmap" }
 pretty = { version = "0.12" }
-proptest = "1.9.0"
+proptest = "1.11.0"
 pyrudof = { version = "0.2.18", path = "./python" }
 rand = "0.8"
 rayon = "1.7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -297,7 +297,7 @@ pgschema = { version = "0.2.18", path = "./pgschema" }
 petgraph = { version = "0.8" }
 prefixmap = { version = "0.2.18", path = "./prefixmap" }
 pretty = { version = "0.12" }
-proptest = "1.11.0"
+proptest = { version = "1.11.0", default-features = false, features = ["std", "bit-set"] }
 pyrudof = { version = "0.2.18", path = "./python" }
 rand = "0.8"
 rayon = "1.7"

--- a/rbe/Cargo.toml
+++ b/rbe/Cargo.toml
@@ -21,10 +21,12 @@ toml.workspace = true
 tracing = { workspace = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
 indoc.workspace = true
 proptest.workspace = true
 tracing-test.workspace = true
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { workspace = true }
 
 [[bench]]
 name = "match_bag"

--- a/rbe/Cargo.toml
+++ b/rbe/Cargo.toml
@@ -21,6 +21,11 @@ toml.workspace = true
 tracing = { workspace = true }
 
 [dev-dependencies]
+criterion = { workspace = true }
 indoc.workspace = true
 proptest.workspace = true
 tracing-test.workspace = true
+
+[[bench]]
+name = "match_bag"
+harness = false

--- a/rbe/Cargo.toml
+++ b/rbe/Cargo.toml
@@ -22,4 +22,5 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 indoc.workspace = true
+proptest.workspace = true
 tracing-test.workspace = true

--- a/rbe/benches/match_bag.rs
+++ b/rbe/benches/match_bag.rs
@@ -1,0 +1,149 @@
+//! Benchmarks comparing the Derivatives and Interval algorithms for `match_bag`.
+//!
+//! Four groups each isolate one dimension of the input space:
+//!
+//! 1. `shape_breadth`  – fixed bag density (2 per symbol), shape grows in number of symbols.
+//!    Both algorithms are O(symbols); interval has lower constant overhead.
+//!
+//! 2. `bag_density`    – fixed 4-symbol shape, bag count per symbol grows.
+//!    Derivatives are O(total_occurrences); interval is O(distinct_symbols), so it stays flat.
+//!
+//! 3. `open_extras`    – fixed 4-symbol shape, open matching, growing number of extra symbols.
+//!    Derivatives must process every extra occurrence; interval skips them all.
+//!
+//! 4. `star_density`   – `(p{1,1})*` shape, bag count grows.
+//!    Same O(total) vs O(1) split as `bag_density`, but through a Star node.
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rbe::{Bag, Max, RbeStruct};
+
+// ---------------------------------------------------------------------------
+// Shape / bag builders
+// ---------------------------------------------------------------------------
+
+/// `And(p_0{1,100}, p_1{1,100}, ..., p_{n-1}{1,100})`
+fn flat_and(num_syms: usize) -> RbeStruct<u32> {
+    let items: Vec<RbeStruct<u32>> = (0..num_syms as u32)
+        .map(|sym| RbeStruct::symbol(sym, 1, Max::IntMax(100)))
+        .collect();
+    RbeStruct::and(items)
+}
+
+/// Bag with `count_per_sym` occurrences of each of the first `num_syms` symbols.
+fn bag_dense(num_syms: usize, count_per_sym: usize) -> Bag<u32> {
+    let mut bag = Bag::new();
+    for sym in 0..num_syms as u32 {
+        bag.insert_many(sym, count_per_sym);
+    }
+    bag
+}
+
+/// Bag matching the first `num_syms` symbols (1 each) plus `num_extras` unknown symbols.
+fn bag_with_extras(num_syms: usize, num_extras: usize) -> Bag<u32> {
+    let mut bag = Bag::new();
+    for sym in 0..num_syms as u32 {
+        bag.insert(sym);
+    }
+    for extra in num_syms as u32..(num_syms + num_extras) as u32 {
+        bag.insert(extra);
+    }
+    bag
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark groups
+// ---------------------------------------------------------------------------
+
+/// Shape breadth: how both algorithms scale with the number of distinct symbol types.
+fn bench_shape_breadth(c: &mut Criterion) {
+    let mut group = c.benchmark_group("shape_breadth");
+    for num_syms in [4_usize, 8, 16, 32] {
+        let rbe = flat_and(num_syms);
+        let bag = bag_dense(num_syms, 2);
+        group.throughput(Throughput::Elements(num_syms as u64));
+        group.bench_with_input(BenchmarkId::new("deriv", num_syms), &(&rbe, &bag), |b, (rbe, bag)| {
+            b.iter(|| rbe.match_bag_deriv(bag, false))
+        });
+        group.bench_with_input(
+            BenchmarkId::new("interval", num_syms),
+            &(&rbe, &bag),
+            |b, (rbe, bag)| b.iter(|| rbe.match_bag_interval(bag, false)),
+        );
+    }
+    group.finish();
+}
+
+/// Bag density: fixed 4-symbol shape, count per symbol grows.
+/// Derivatives must re-derive for every occurrence; interval only needs one lookup per type.
+fn bench_bag_density(c: &mut Criterion) {
+    let mut group = c.benchmark_group("bag_density");
+    let rbe = flat_and(4);
+    for count_per_sym in [1_usize, 10, 50, 100] {
+        let bag = bag_dense(4, count_per_sym);
+        group.throughput(Throughput::Elements((4 * count_per_sym) as u64));
+        group.bench_with_input(
+            BenchmarkId::new("deriv", count_per_sym),
+            &(&rbe, &bag),
+            |b, (rbe, bag)| b.iter(|| rbe.match_bag_deriv(bag, false)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("interval", count_per_sym),
+            &(&rbe, &bag),
+            |b, (rbe, bag)| b.iter(|| rbe.match_bag_interval(bag, false)),
+        );
+    }
+    group.finish();
+}
+
+/// Open matching: fixed 4-symbol shape, bag has growing number of extra symbols.
+/// Derivatives process each extra symbol in the derivative chain; interval ignores them.
+fn bench_open_extras(c: &mut Criterion) {
+    let mut group = c.benchmark_group("open_extras");
+    let rbe = flat_and(4);
+    for num_extras in [0_usize, 8, 32, 128] {
+        let bag = bag_with_extras(4, num_extras);
+        group.throughput(Throughput::Elements((4 + num_extras) as u64));
+        group.bench_with_input(BenchmarkId::new("deriv", num_extras), &(&rbe, &bag), |b, (rbe, bag)| {
+            b.iter(|| rbe.match_bag_deriv(bag, true))
+        });
+        group.bench_with_input(
+            BenchmarkId::new("interval", num_extras),
+            &(&rbe, &bag),
+            |b, (rbe, bag)| b.iter(|| rbe.match_bag_interval(bag, true)),
+        );
+    }
+    group.finish();
+}
+
+/// Star density: `(p{1,1})*` shape, bag count grows.
+/// Interval uses a short-circuit via `no_symbols_in_bag` and then a single interval check;
+/// derivatives must iterate through every occurrence.
+fn bench_star_density(c: &mut Criterion) {
+    let mut group = c.benchmark_group("star_density");
+    let rbe = RbeStruct::star(RbeStruct::symbol(0_u32, 1, Max::IntMax(1)));
+    for count_per_sym in [1_usize, 10, 50, 100] {
+        let mut bag = Bag::new();
+        bag.insert_many(0_u32, count_per_sym);
+        group.throughput(Throughput::Elements(count_per_sym as u64));
+        group.bench_with_input(
+            BenchmarkId::new("deriv", count_per_sym),
+            &(&rbe, &bag),
+            |b, (rbe, bag)| b.iter(|| rbe.match_bag_deriv(bag, false)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("interval", count_per_sym),
+            &(&rbe, &bag),
+            |b, (rbe, bag)| b.iter(|| rbe.match_bag_interval(bag, false)),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_shape_breadth,
+    bench_bag_density,
+    bench_open_extras,
+    bench_star_density,
+);
+criterion_main!(benches);

--- a/rbe/src/interval.rs
+++ b/rbe/src/interval.rs
@@ -43,9 +43,10 @@ impl Interval {
         }
     }
 
-    /// Returns true if the interval is empty. An interval [n, m] is empty if n is greater than m.
+    /// Returns true if the interval is empty. An interval [n, m] is empty if n is greater than m,
+    /// or if n is Unbounded (no finite value can satisfy t >= Unbounded).
     pub fn is_empty(&self) -> bool {
-        self.n.greater_than(&self.m)
+        matches!(self.n, Max::Unbounded) || self.n.greater_than(&self.m)
     }
 
     /// Returns true if the interval contains the value v: n <= v <= m.

--- a/rbe/src/rbe.rs
+++ b/rbe/src/rbe.rs
@@ -326,6 +326,11 @@ where
                 Self::mk_and(&d, &rest)
             },
             Rbe::Star { ref value } => {
+                if open && !controlled.contains(x) {
+                    // Extra symbol (not controlled): the Star stays in its current state.
+                    // No iteration is forced; zero-or-more semantics still holds.
+                    return Rbe::Star { value: value.clone() };
+                }
                 let d = value.deriv(x, n, open, controlled);
                 Self::mk_and(&d, &Rbe::Star { value: value.clone() })
             },

--- a/rbe/src/rbe.rs
+++ b/rbe/src/rbe.rs
@@ -118,9 +118,16 @@ where
                 and
             },
             Rbe::Or { values } => {
-                let or = values
-                    .iter()
-                    .fold(Interval::zero_zero(), |acc, v| acc.addition(&v.interval(bag)));
+                // Minkowski sum: every branch must have a valid scale factor.
+                // If any branch interval is empty the whole Or is unsatisfiable.
+                let or = values.iter().fold(Interval::zero_zero(), |acc, v| {
+                    if acc.is_empty() {
+                        acc
+                    } else {
+                        let iv = v.interval(bag);
+                        if iv.is_empty() { Interval::fail() } else { acc.addition(&iv) }
+                    }
+                });
                 // trace!("Or {self} with bag {bag} is {or}");
                 or
             },
@@ -138,7 +145,8 @@ where
             },
             Rbe::Plus { value } => {
                 if self.no_symbols_in_bag(bag) {
-                    Interval::zero_zero()
+                    // A single nullable repetition satisfies Plus with an empty bag.
+                    if value.nullable() { Interval::zero_any() } else { Interval::zero_zero() }
                 } else {
                     let interval = value.interval(bag);
                     if interval.is_empty() {

--- a/rbe/src/rbe.rs
+++ b/rbe/src/rbe.rs
@@ -125,7 +125,11 @@ where
                         acc
                     } else {
                         let iv = v.interval(bag);
-                        if iv.is_empty() { Interval::fail() } else { acc.addition(&iv) }
+                        if iv.is_empty() {
+                            Interval::fail()
+                        } else {
+                            acc.addition(&iv)
+                        }
                     }
                 });
                 // trace!("Or {self} with bag {bag} is {or}");
@@ -146,7 +150,11 @@ where
             Rbe::Plus { value } => {
                 if self.no_symbols_in_bag(bag) {
                     // A single nullable repetition satisfies Plus with an empty bag.
-                    if value.nullable() { Interval::zero_any() } else { Interval::zero_zero() }
+                    if value.nullable() {
+                        Interval::zero_any()
+                    } else {
+                        Interval::zero_zero()
+                    }
                 } else {
                     let interval = value.interval(bag);
                     if interval.is_empty() {

--- a/rbe/src/rbe_struct.rs
+++ b/rbe/src/rbe_struct.rs
@@ -273,6 +273,83 @@ where
 }
 
 #[cfg(test)]
+mod prop_tests {
+    use super::*;
+    use proptest::collection::vec as prop_vec;
+    use proptest::prelude::*;
+
+    fn arb_char() -> impl Strategy<Value = char> {
+        prop_oneof![Just('a'), Just('b'), Just('c')]
+    }
+
+    /// Characters used in bags include 'd' so that bags may contain symbols absent from the RBE,
+    /// exercising the extra-symbol handling in both algorithms.
+    fn arb_bag_char() -> impl Strategy<Value = char> {
+        prop_oneof![Just('a'), Just('b'), Just('c'), Just('d')]
+    }
+
+    /// Generates an `RbeStruct<char>` without `Repeat` nodes (which have a `todo!()` in the
+    /// interval algorithm).  The depth and node-count limits keep generation tractable.
+    fn arb_rbe_struct() -> impl Strategy<Value = RbeStruct<char>> {
+        let leaf = prop_oneof![
+            2 => Just(RbeStruct::<char>::empty()),
+            8 => (arb_char(), 0usize..=2usize, 0usize..=2usize)
+                    .prop_map(|(sym, min, extra)| RbeStruct::symbol(sym, min, Max::IntMax(min + extra))),
+        ];
+        leaf.prop_recursive(3, 32, 3, |inner| {
+            prop_oneof![
+                prop_vec(inner.clone(), 2..=3).prop_map(RbeStruct::and),
+                prop_vec(inner.clone(), 2..=3).prop_map(RbeStruct::or),
+                inner.clone().prop_map(RbeStruct::star),
+                inner.prop_map(RbeStruct::plus),
+            ]
+        })
+    }
+
+    fn arb_bag() -> impl Strategy<Value = Bag<char>> {
+        prop_vec(arb_bag_char(), 0..=4).prop_map(|cs| cs.into_iter().collect::<Bag<char>>())
+    }
+
+    proptest! {
+        /// For every generated RBE and bag the derivatives algorithm and the interval algorithm
+        /// must agree on whether the bag matches (both Ok) or not (both Err), when matching is
+        /// closed (`open = false`).
+        #[test]
+        fn deriv_and_interval_agree_closed(
+            rbe in arb_rbe_struct(),
+            bag in arb_bag(),
+        ) {
+            let deriv    = rbe.match_bag_deriv(&bag, false);
+            let interval = rbe.match_bag_interval(&bag, false);
+            prop_assert_eq!(
+                deriv.is_ok(),
+                interval.is_ok(),
+                "rbe={:?}  bag={:?}\n  deriv={:?}\n  interval={:?}",
+                rbe, bag, deriv, interval
+            );
+        }
+
+        /// Same check with open matching (`open = true`).  In this branch `match_bag_interval`
+        /// always delegates to `match_bag_deriv`, so the property holds trivially, but the test
+        /// guards against regressions in the dispatch logic.
+        #[test]
+        fn deriv_and_interval_agree_open(
+            rbe in arb_rbe_struct(),
+            bag in arb_bag(),
+        ) {
+            let deriv    = rbe.match_bag_deriv(&bag, true);
+            let interval = rbe.match_bag_interval(&bag, true);
+            prop_assert_eq!(
+                deriv.is_ok(),
+                interval.is_ok(),
+                "rbe={:?}  bag={:?}\n  deriv={:?}\n  interval={:?}",
+                rbe, bag, deriv, interval
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod tests {
     use super::*;
 

--- a/rbe/src/rbe_struct.rs
+++ b/rbe/src/rbe_struct.rs
@@ -38,14 +38,16 @@ where
     }
 
     pub fn match_bag_interval(&self, bag: &Bag<A>, open: bool) -> Result<(), DerivError<A>> {
-        if self.has_repeats || open {
+        if self.has_repeats {
             self.rbe.match_bag_deriv(bag, open)
         } else {
-            let extra_symbols = self.extra_symbols(bag);
-            if !extra_symbols.is_empty() {
-                return Err(DerivError::ExtraSymbolsClosed {
-                    extra_symbols: extra_symbols.into_iter().map(|s| s.to_string()).collect(),
-                });
+            if !open {
+                let extra_symbols = self.extra_symbols(bag);
+                if !extra_symbols.is_empty() {
+                    return Err(DerivError::ExtraSymbolsClosed {
+                        extra_symbols: extra_symbols.into_iter().map(|s| s.to_string()).collect(),
+                    });
+                }
             }
             let interval = self.rbe.interval(bag);
             if interval.contains(1) {
@@ -330,8 +332,8 @@ mod prop_tests {
         }
 
         /// Same check with open matching (`open = true`).  In this branch `match_bag_interval`
-        /// always delegates to `match_bag_deriv`, so the property holds trivially, but the test
-        /// guards against regressions in the dispatch logic.
+        /// uses the interval algorithm directly (skipping the extra-symbol check), so this
+        /// property is a real correctness test and not merely a tautology.
         #[test]
         fn deriv_and_interval_agree_open(
             rbe in arb_rbe_struct(),


### PR DESCRIPTION
This PR adds property based tests for RBEs to compare that the results of match_bag are always the same either using the derivatives algorithm or the interval algorithm.

It also creates a `benches` folder for benchamrk tests. The results of the benchmarks tests are:

# Benchmark Results

---

## shape_breadth
**Fixed density (2/symbol), shape grows**

| symbols | deriv | interval | speedup |
| :--- | :--- | :--- | :--- |
| 4 | 3.5 µs | 121 ns | 29× |
| 8 | 17.2 µs | 201 ns | 85× |
| 16 | 124 µs | 376 ns | 330× |
| 32 | 785 µs | 742 ns | 1057× |

> The derivative algorithm blows up super-linearly because each new **And** branch multiplies the intermediate expression size (the RBE tree grows as derivatives are applied). The interval algorithm grows linearly and stays in the nanosecond range.

---

## bag_density
**Fixed 4-symbol shape, count per symbol grows**

| count/sym | deriv | interval |
| :--- | :--- | :--- |
| 1 | 1.73 µs | 109 ns |
| 10 | 14.3 µs | 117 ns |
| 50 | 75.1 µs | 127 ns |
| 100 | 162 µs | 127 ns |

> The interval algorithm is completely flat — it only needs `bag.contains(sym)` per distinct type, regardless of count. The derivative algorithm is linear in total occurrences, since it steps through each one.

---

## open_extras
**4-symbol shape open, extra symbols grow**

| extras | deriv | interval |
| :--- | :--- | :--- |
| 0 | 1.97 µs | 86 ns |
| 8 | 22.5 µs | 78 ns |
| 32 | 96.3 µs | 78 ns |
| 128 | 366 µs | 88 ns |

> After the fix from the previous session, the interval algorithm completely ignores extra symbols (no loop, just skip the extra-symbols check). The derivative must run each extra symbol through the full **Star/Symbol** derivative chain, so it scales linearly with extras.

---

## star_density
**(p{1,1})* shape, count per symbol grows**

| count | deriv | interval |
| :--- | :--- | :--- |
| 1 | 169 ns | 92 ns |
| 10 | 43 µs | 100 ns |
| 50 | 8.6 ms | 92 ns |
| 100 | 39.4 ms | 92 ns |

> The most dramatic case. The derivative chain for `Star(p{1,1})` produces an exponentially growing intermediate expression as the count increases (the partial derivative tree branches at each step). Interval stays constant at ~92 ns because it only checks whether `contains(p) > 0` and returns [1, ∞).
