### PR TITLE
fix(shex_ast): apply flags when compiling pattern regex

### DIFF
--- a/shex_ast/src/ir/ast2ir.rs
+++ b/shex_ast/src/ir/ast2ir.rs
@@ -1411,7 +1411,11 @@ fn check_pattern(node: &Node, regex: &str, flags: Option<&str>, base: &Option<Ir
             flags: flags.map(|f| f.to_string()),
         })),
     }?;
-    if let Ok(re) = regex::Regex::new(regex) {
+    let effective_regex = match flags {
+        Some(f) if !f.is_empty() => format!("(?{f}){regex}"),
+        _ => regex.to_string(),
+    };
+    if let Ok(re) = regex::Regex::new(&effective_regex) {
         if re.is_match(&lexical_form) {
             Ok(())
         } else {

--- a/shex_testsuite/tests/baseline_failing.txt
+++ b/shex_testsuite/tests/baseline_failing.txt
@@ -3,8 +3,6 @@
 1dotNoCode3_pass
 1literalFractiondigits_pass-decimal-equalLeadTrail
 1literalFractiondigits_pass-decimal-equalTrail
-1literalPatterni_pass-lit-BC
-1literalPatterni_pass-lit-blowercaseC
 1val1IRIREFClosedExtra1_pass-iri2
 1val1IRIREFExtra1Closed_pass-iri2
 1val1IRIREFExtra1One_pass-iri2


### PR DESCRIPTION
## Problem

`TripleConstraint` and `NodeConstraint` both accept a `flags` field (e.g. `"i"` for case-insensitive). The field was parsed and carried through the AST correctly, but `check_pattern` in `ast2ir.rs` called `regex::Regex::new(regex)` without ever applying the flags, silently dropping them at compile time.

## Fix
One-line change in `check_pattern`: when `flags` is non-empty, prefix the pattern with `(?flags)` before passing it to `Regex::new`.

This maps directly onto the regex crate's inline-flag syntax ((?i), (?s), (?m), etc.).

### Tests
Previously failing:
- 1literalPatterni_pass-lit-BC - /bc/i on "BC"
- 1literalPatterni_pass-lit-blowercaseC - /bc/i on "bC"

Both now pass. **Total**: 1140 passed, 26 failed.