### PR TITLE
fix(shex): BCP-47 subtag prefix matching for languageStem

### DIFF
--- a/rudof_rdf/src/rdf_core/term/literal/lang.rs
+++ b/rudof_rdf/src/rdf_core/term/literal/lang.rs
@@ -1,32 +1,19 @@
-use std::hash::Hash;
-
-use oxilangtag::LanguageTag;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
-/// A validated language tag wrapper that ensures normalization and validity.
+/// A language tag wrapper for IETF BCP 47 language tags.
 ///
-/// This type wraps an `oxilangtag::LanguageTag` and provides a type-safe way to work
-/// with IETF BCP 47 language tags (e.g., "en", "en-US", "es-ES"). The language tag is
-/// validated and normalized upon construction, ensuring it conforms to the standard.
+/// Standard BCP-47 tags are normalized on construction:
+/// - Primary language subtag lowercased (e.g., "EN" → "en")
+/// - Script subtags title-cased (e.g., "latn" → "Latn")
+/// - Region subtags uppercased (e.g., "us" → "US")
 ///
-/// # Normalization
-///
-/// Language tags are automatically normalized according to BCP 47 rules:
-/// - The primary language subtag is lowercased (e.g., "EN" → "en")
-/// - Script subtags are title-cased (e.g., "latn" → "Latn")
-/// - Region subtags are uppercased (e.g., "us" → "US")
-///
-/// # Serialization
-///
-/// The `#[serde(transparent)]` attribute ensures that this type serializes as a plain
-/// string rather than a struct with a single field, making it compatible with JSON
-/// schemas that expect language tags as strings.
-/// ```
+/// Non-standard but syntactically valid tags (e.g., "fr-be-fbcl" from ShEx
+/// conformance tests) are accepted and lowercased rather than rejected.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[serde(transparent)]
 pub struct Lang {
-    lang: LanguageTag<String>,
+    lang: String,
 }
 
 impl Lang {
@@ -34,36 +21,54 @@ impl Lang {
     ///
     /// # Errors
     ///
-    /// Returns `LangParseError` if the language tag is invalid.
+    /// Returns `LangParseError` if the tag is not even syntactically valid
+    /// (empty subtag or non-alphanumeric characters).
     pub fn new(lang: impl Into<String>) -> Result<Lang, LangParseError> {
-        let lang = oxilangtag::LanguageTag::parse_and_normalize(&lang.into())?;
-        Ok(Lang { lang })
+        let s: String = lang.into();
+        // Try strict BCP-47 normalization first
+        if let Ok(normalized) = oxilangtag::LanguageTag::parse_and_normalize(&s) {
+            return Ok(Lang { lang: normalized.into_inner() });
+        }
+        // Fall back to accepting any syntactically valid lang tag
+        // (e.g. non-IANA-registered subtag sequences used in ShEx test data)
+        if is_syntactically_valid_lang(&s) {
+            return Ok(Lang { lang: s.to_ascii_lowercase() });
+        }
+        Err(LangParseError::InvalidLangTag(s))
     }
 
     /// Returns the language tag as a string slice.
     #[inline]
     pub fn as_str(&self) -> &str {
-        self.lang.as_str()
+        &self.lang
     }
 }
 
+/// Returns `true` if the string matches the Turtle language tag grammar:
+/// `[a-zA-Z]+ ('-' [a-zA-Z0-9]+)*`
+fn is_syntactically_valid_lang(s: &str) -> bool {
+    let mut parts = s.split('-');
+    let first = parts.next().unwrap_or("");
+    if first.is_empty() || !first.bytes().all(|b| b.is_ascii_alphabetic()) {
+        return false;
+    }
+    for part in parts {
+        if part.is_empty() || !part.bytes().all(|b| b.is_ascii_alphanumeric()) {
+            return false;
+        }
+    }
+    true
+}
+
 impl std::fmt::Display for Lang {
-    /// Formats the language tag for display.
-    ///
-    /// This outputs the normalized form of the language tag, making it suitable
-    /// for user-facing output, logging, and serialization to text formats.
-    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.lang)
     }
 }
 
 /// Error type for language tag parsing failures.
-///
-/// This error is returned when attempting to construct a `Lang` from an invalid
-/// language tag string. It wraps the underlying parsing error from `oxilangtag`.
 #[derive(Error, Debug)]
 pub enum LangParseError {
     #[error("Invalid language tag: {0}")]
-    InvalidLangTag(#[from] oxilangtag::LanguageTagParseError),
+    InvalidLangTag(String),
 }

--- a/rudof_rdf/src/rdf_core/term/literal/lang.rs
+++ b/rudof_rdf/src/rdf_core/term/literal/lang.rs
@@ -27,12 +27,16 @@ impl Lang {
         let s: String = lang.into();
         // Try strict BCP-47 normalization first
         if let Ok(normalized) = oxilangtag::LanguageTag::parse_and_normalize(&s) {
-            return Ok(Lang { lang: normalized.into_inner() });
+            return Ok(Lang {
+                lang: normalized.into_inner(),
+            });
         }
         // Fall back to accepting any syntactically valid lang tag
         // (e.g. non-IANA-registered subtag sequences used in ShEx test data)
         if is_syntactically_valid_lang(&s) {
-            return Ok(Lang { lang: s.to_ascii_lowercase() });
+            return Ok(Lang {
+                lang: s.to_ascii_lowercase(),
+            });
         }
         Err(LangParseError::InvalidLangTag(s))
     }

--- a/rudof_rdf/src/rdf_impl/in_memory_graph.rs
+++ b/rudof_rdf/src/rdf_impl/in_memory_graph.rs
@@ -186,8 +186,8 @@ impl InMemoryGraph {
         reader_mode: &ReaderMode,
     ) -> Result<(), InMemoryGraphError> {
         let turtle_parser = match base {
-            None => TurtleParser::new(),
-            Some(iri) => TurtleParser::new().with_base_iri(iri)?,
+            None => TurtleParser::new().lenient(),
+            Some(iri) => TurtleParser::new().lenient().with_base_iri(iri)?,
         };
 
         let mut turtle_reader = turtle_parser.for_reader(reader);

--- a/rudof_rdf/src/rdf_impl/in_memory_graph.rs
+++ b/rudof_rdf/src/rdf_impl/in_memory_graph.rs
@@ -202,7 +202,17 @@ impl InMemoryGraph {
                     Some(t) => t,
                     None => continue,
                 };
-            graph.insert(triple.as_ref());
+            let triple_ref = triple.as_ref();
+            if let Err(e) = validate_triple_iris(triple_ref) {
+                match handle_parse_error(Err::<(), _>(e), reader_mode, |e| InMemoryGraphError::TurtleParseError {
+                    source_name: source_name.to_string(),
+                    error: format!("Invalid IRI in triple: {e}"),
+                })? {
+                    Some(_) => unreachable!(),
+                    None => continue,
+                }
+            }
+            graph.insert(triple_ref);
         }
 
         let prefixes: HashMap<&str, &str> = turtle_reader.prefixes().collect();
@@ -1111,6 +1121,17 @@ fn triple_to_quad(t: TripleRef, graph_name: GraphName) -> Quad {
 /// * `Ok(Some(value))` - Parsing succeeded
 /// * `Ok(None)` - Parsing failed in lax mode (skip this item)
 /// * `Err(error)` - Parsing failed in strict mode
+fn validate_triple_iris(triple: TripleRef) -> Result<(), String> {
+    if let oxrdf::NamedOrBlankNodeRef::NamedNode(n) = triple.subject {
+        OxNamedNode::new(n.as_str()).map_err(|e| e.to_string())?;
+    }
+    OxNamedNode::new(triple.predicate.as_str()).map_err(|e| e.to_string())?;
+    if let TermRef::NamedNode(n) = triple.object {
+        OxNamedNode::new(n.as_str()).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
 fn handle_parse_error<T, E: std::fmt::Display>(
     result: Result<T, E>,
     reader_mode: &ReaderMode,

--- a/shex_ast/src/ir/value_set_value.rs
+++ b/shex_ast/src/ir/value_set_value.rs
@@ -80,6 +80,18 @@ pub enum StringOrIriStem {
     IriStem { stem: String },
 }
 
+fn lang_stem_matches(stem: &str, tag: &str) -> bool {
+    let stem_parts: Vec<&str> = stem.split('-').collect();
+    let tag_parts: Vec<&str> = tag.split('-').collect();
+    if stem_parts.len() > tag_parts.len() {
+        return false;
+    }
+    stem_parts
+        .iter()
+        .zip(tag_parts.iter())
+        .all(|(s, t)| s.eq_ignore_ascii_case(t))
+}
+
 impl ValueSetValue {
     pub fn match_value(&self, object: &Object) -> bool {
         match self {
@@ -169,7 +181,7 @@ impl ValueSetValue {
             ValueSetValue::LanguageStem { stem } => object
                 .lang()
                 .map(|lang| match stem {
-                    LangOrWildcard::Lang(s) => lang.as_str().starts_with(s.as_str()),
+                    LangOrWildcard::Lang(s) => lang_stem_matches(s.as_str(), lang.as_str()),
                     LangOrWildcard::Wildcard { .. } => true, // Matches everything for now
                 })
                 .unwrap_or(false),
@@ -177,7 +189,7 @@ impl ValueSetValue {
                 let matches_stem = match stem {
                     LangOrWildcard::Lang(lang) => match object {
                         Object::Literal(ConcreteLiteral::StringLiteral { lang: Some(l), .. }) => {
-                            l.as_str().starts_with(lang.as_str())
+                            lang_stem_matches(lang.as_str(), l.as_str())
                         },
                         _ => false,
                     },
@@ -198,7 +210,7 @@ impl ValueSetValue {
                             },
                             LanguageExclusion::LanguageStem(stem) => {
                                 if let Object::Literal(ConcreteLiteral::StringLiteral { lang: Some(l), .. }) = object
-                                    && l.as_str().starts_with(stem.as_str())
+                                    && lang_stem_matches(stem.as_str(), l.as_str())
                                 {
                                     return false;
                                 }

--- a/shex_testsuite/tests/baseline_failing.txt
+++ b/shex_testsuite/tests/baseline_failing.txt
@@ -7,14 +7,6 @@
 1val1IRIREFExtra1Closed_pass-iri2
 1val1IRIREFExtra1One_pass-iri2
 1val1IRIREFExtra1_pass-iri2
-1val1LANGTAG_LabLTen-fr-jura
-1val1emptylanguageStemMinuslanguage3_passLAtfr-be-fbcl
-1val1emptylanguageStemMinuslanguageStem3_LAtfr-be-fbcl
-1val1languageStemMinuslanguage3_passLAtfr-be-fbcl
-1val1languageStemMinuslanguageStem3_LAtfr-be-fbcl
-1val1languageStemMinuslanguageStem3_LAtfrc
-1val1languageStem_failLAtfrc
-1val1languageStem_passLAtfr-be-fbcl
 1val2IRIREFExtra1_pass-iri-bnode
 3Eachdot3Extra_pass-iri2
 3EachdotExtra3NLex_pass-iri2


### PR DESCRIPTION
## Problem

`languageStem` matching used a plain `starts_with` check, so `"fr"` incorrectly matched `"fra"` and failed to match `"fr-BE"` or `"fr-be-fbcl"`. Additionally, the Turtle parser rejected syntactically valid but non-IANA-registered language tags (e.g. `fr-be-fbcl`, `en-fr-jura`) before ShEx validation could run.

## Changes

* `shex_ast/src/ir/value_set_value.rs`: Added `lang_stem_matches(stem, tag) -> bool` that splits on `-` and compares subtags left-to-right case-insensitively; a stem matches iff its subtags are a prefix of the tag's. Applied to `LanguageStem`, and both the stem and exclusion checks in `LanguageStemRange`.

* `rudof_rdf/src/rdf_impl/in_memory_graph.rs`: Switched to `TurtleParser::new().lenient()` to accept language tags that are valid Turtle but not strict BCP-47 (e.g. `fr-be-fbcl`). The Turtle grammar allows any `[a-zA-Z]+(-[a-zA-Z0-9]+)*`; BCP-47 validation is out of scope at this layer.

* `rudof_rdf/src/rdf_core/term/literal/lang.rs`: `Lang` now stores a plain `String`. `Lang::new` attempts `oxilangtag` strict normalization first; on failure, accepts any Turtle-grammar-valid tag (lowercased). This lets non-registered subtag sequences from the ShEx conformance suite pass through without error.

## Test results
**Before**: 8 of the target tests failing
**After**: all target tests pass

- `1val1languageStem*`
- `1val1LANGTAG_*` 
- `1val1emptylanguageStem*` 

  **Overall**: 26 → 18 failing