### PR TITLE
feat: implement EXTERNAL resolver flow

### DIFF
--- a/rudof_lib/src/rudof_config.rs
+++ b/rudof_lib/src/rudof_config.rs
@@ -19,7 +19,7 @@ const DEFAULT_CONFIG: &str = include_str!("default_config.toml");
 /// This structure encapsulates all configuration options for Rudof operations,
 /// including RDF data handling, schema validation (ShEx and SHACL), conversions,
 /// and visualization settings.
-#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct RudofConfig {
     pub(crate) rdf_data: Option<RdfDataConfig>,
     pub(crate) shex: Option<ShExConfig>,

--- a/shex_ast/src/ast/schema.rs
+++ b/shex_ast/src/ast/schema.rs
@@ -232,6 +232,10 @@ impl Schema {
         self.shapes.clone()
     }
 
+    pub fn shapes_mut(&mut self) -> Option<&mut Vec<ShapeDecl>> {
+        self.shapes.as_mut()
+    }
+
     pub fn get_type(&self) -> String {
         self.type_.clone()
     }

--- a/shex_ast/src/ast/simple_repr_schema.rs
+++ b/shex_ast/src/ast/simple_repr_schema.rs
@@ -41,7 +41,7 @@ impl SimpleReprSchema {
             ShapeExpr::ShapeNot { shape_expr: _ } => todo!(),
             ShapeExpr::NodeConstraint(_) => todo!(),
             ShapeExpr::Shape(shape) => self.convert_shape(name, shape, schema),
-            ShapeExpr::External => todo!(),
+            ShapeExpr::External => SimpleReprShape::new(name),
             ShapeExpr::Ref(_) => todo!(),
         }
     }

--- a/shex_ast/src/ir/ast2ir.rs
+++ b/shex_ast/src/ir/ast2ir.rs
@@ -698,7 +698,12 @@ impl AST2IR {
                     trace!("Returning NOT cond with idx {idx_not}");
                     Ok((mk_cond_ref(idx_not), display))
                 },
-                ast::ShapeExpr::External => todo("value_expr2match_cond: ShapeExternal"),
+                ast::ShapeExpr::External => {
+                    let idx_ext = compiled_schema.new_index(source_iri);
+                    compiled_schema.replace_shape(&idx_ext, ShapeExpr::External {});
+                    let display = format!("EXTERNAL {idx_ext}");
+                    Ok((mk_cond_ref(idx_ext), display))
+                },
             }
         } else {
             Ok((MatchCond::single(SingleCond::new().with_name(".")), ".".to_string()))
@@ -1707,13 +1712,6 @@ fn check_node_max_length(node: &Node, len: usize) -> CResult<()> {
             node: format!("{node}"),
         }))
     }
-}
-
-fn todo<A>(str: &str) -> CResult<A> {
-    panic!("TODO: {str}");
-    /*Err(Box::new(SchemaIRError::Todo {
-        msg: str.to_string(),
-    }))*/
 }
 
 fn cnv_iri_ref(iri: &IriRef, prefixmap: &PrefixMap) -> Result<IriS, Box<SchemaIRError>> {

--- a/shex_ast/src/ir/external_resolver.rs
+++ b/shex_ast/src/ir/external_resolver.rs
@@ -79,7 +79,7 @@ impl Default for ExternalShapeResolverRegistry {
     /// terminator always sits at the end of the chain.
     fn default() -> Self {
         Self {
-            resolvers: vec![Arc::new(RejectAllExternalResolver::default())],
+            resolvers: vec![Arc::new(RejectAllExternalResolver)],
         }
     }
 }
@@ -174,12 +174,14 @@ impl SchemaExternalResolver {
     /// source of EXTERNAL definitions. Uses the standard ShExC parser.
     pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, ExternalResolverError> {
         let path = path.as_ref();
-        let source_iri: IriS = path.try_into().map_err(|e: rudof_iri::error::IriSError| ExternalResolverError::PathToIri {
-            path: path.to_path_buf(),
-            error: e.to_string(),
-        })?;
-        let externs = crate::ShExParser::parse_buf(path, Some(source_iri))
-            .map_err(|e| ExternalResolverError::Parse {
+        let source_iri: IriS =
+            path.try_into()
+                .map_err(|e: rudof_iri::error::IriSError| ExternalResolverError::PathToIri {
+                    path: path.to_path_buf(),
+                    error: e.to_string(),
+                })?;
+        let externs =
+            crate::ShExParser::parse_buf(path, Some(source_iri)).map_err(|e| ExternalResolverError::Parse {
                 path: path.to_path_buf(),
                 error: e.to_string(),
             })?;
@@ -214,10 +216,10 @@ impl ExternalShapeResolver for SchemaExternalResolver {
         };
         if let Some(decls) = schema.shapes_mut() {
             for decl in decls.iter_mut() {
-                if matches!(decl.shape_expr, ast::ShapeExpr::External) {
-                    if let Some(matching) = lookup_decl(&lookups, &decl.id) {
-                        decl.shape_expr = matching.shape_expr.clone();
-                    }
+                if matches!(decl.shape_expr, ast::ShapeExpr::External)
+                    && let Some(matching) = lookup_decl(&lookups, &decl.id)
+                {
+                    decl.shape_expr = matching.shape_expr.clone();
                 }
             }
         }
@@ -225,10 +227,7 @@ impl ExternalShapeResolver for SchemaExternalResolver {
     }
 }
 
-fn lookup_decl<'a>(
-    decls: &'a [ast::ShapeDecl],
-    label: &ShapeExprLabel,
-) -> Option<&'a ast::ShapeDecl> {
+fn lookup_decl<'a>(decls: &'a [ast::ShapeDecl], label: &ShapeExprLabel) -> Option<&'a ast::ShapeDecl> {
     decls.iter().find(|d| &d.id == label)
 }
 
@@ -238,10 +237,7 @@ pub enum ExternalResolverError {
     PathToIri { path: std::path::PathBuf, error: String },
 
     #[error("Could not parse external shapes file {path:?}: {error}")]
-    Parse {
-        path: std::path::PathBuf,
-        error: String,
-    },
+    Parse { path: std::path::PathBuf, error: String },
 }
 
 #[cfg(test)]
@@ -277,10 +273,7 @@ mod tests {
         let node = Node::iri(IriS::new_unchecked("http://example/n"));
         let schema = SchemaIR::new(SemanticActionsRegistry::default());
         let ctx = dummy_ctx(&node, &schema);
-        assert!(matches!(
-            reg.dispatch(&ctx),
-            DispatchOutcome::NonConformant { .. }
-        ));
+        assert!(matches!(reg.dispatch(&ctx), DispatchOutcome::NonConformant { .. }));
     }
 
     #[test]
@@ -336,6 +329,9 @@ mod tests {
         // rewrite_ast: user resolver substitutes the External; reject-all is a no-op for rewrite.
         let main = schema_with(vec![ShapeDecl::new(sext, ShapeExpr::External, false)]);
         let rewritten = reg.rewrite_ast(main);
-        assert!(!matches!(rewritten.shapes().unwrap()[0].shape_expr, ShapeExpr::External));
+        assert!(!matches!(
+            rewritten.shapes().unwrap()[0].shape_expr,
+            ShapeExpr::External
+        ));
     }
 }

--- a/shex_ast/src/ir/external_resolver.rs
+++ b/shex_ast/src/ir/external_resolver.rs
@@ -1,0 +1,341 @@
+//! Pluggable resolution of EXTERNAL shape expressions.
+//!
+//! The ShEx specification states that an EXTERNAL shape conforms when
+//! "implementation-specific mechanisms not defined in this specification
+//! indicate success". `rudof` exposes this extension point as a chain of
+//! resolvers that can:
+//!
+//! 1. Rewrite the AST before compilation: substituting an EXTERNAL `ShapeDecl`
+//!    with the real definition.
+//! 2. Answer a verdict at validation time for any EXTERNAL that survived
+//!    rewriting.
+//!
+//! Resolvers are consulted by an [`ExternalShapeResolverRegistry`], which is
+//! held inside `shex_validation::ValidatorConfig::external_resolvers`.
+
+use crate::ast;
+use crate::ir::{schema_ir::SchemaIR, shape_label::ShapeLabel};
+use crate::node::Node;
+use crate::{ShapeExprLabel, ShapeLabelIdx};
+use rudof_iri::IriS;
+use std::path::Path;
+use std::sync::Arc;
+use thiserror::Error;
+
+/// Context exposed to a resolver at validation time.
+pub struct ExternalResolveCtx<'a> {
+    pub node: &'a Node,
+    pub shape_idx: ShapeLabelIdx,
+    pub shape_label: Option<&'a ShapeLabel>,
+    pub schema: &'a SchemaIR,
+}
+
+/// A resolver's verdict at validation time. Resolvers that rewrite the AST
+/// typically `Abstain` at validation time, since substituted shapes no longer
+/// appear as EXTERNAL.
+#[derive(Debug, Clone)]
+pub enum ExternalResolution {
+    Conformant { rationale: String },
+    NonConformant { rationale: String },
+    Abstain,
+}
+
+/// Outcome surfaced to the engine after the registry dispatches through its
+/// resolver chain. Carries the resolver's name so the resulting `Reason`/
+/// `ValidatorError` can attribute the decision.
+#[derive(Debug, Clone)]
+pub enum DispatchOutcome {
+    Conformant { resolver: String, rationale: String },
+    NonConformant { resolver: String, rationale: String },
+    Abstain,
+}
+
+/// Pluggable resolution of EXTERNAL shape expressions.
+pub trait ExternalShapeResolver: Send + Sync + std::fmt::Debug {
+    fn name(&self) -> &str;
+
+    /// AST-rewrite pass. Default: identity (no rewriting).
+    fn rewrite_ast(&self, schema: ast::Schema) -> ast::Schema {
+        schema
+    }
+
+    /// Runtime fallback for `ShapeExpr::External {}` that survived rewriting.
+    /// Default: `Abstain`, deferring to the next resolver in the registry.
+    fn resolve(&self, _ctx: &ExternalResolveCtx<'_>) -> ExternalResolution {
+        ExternalResolution::Abstain
+    }
+}
+
+/// Ordered chain of resolvers plus a guaranteed terminator
+/// (`RejectAllExternalResolver` by default).
+#[derive(Debug, Clone)]
+pub struct ExternalShapeResolverRegistry {
+    resolvers: Vec<Arc<dyn ExternalShapeResolver>>,
+}
+
+impl Default for ExternalShapeResolverRegistry {
+    /// Default registry: a single [`RejectAllExternalResolver`]. Clients
+    /// prepend other resolvers via [`Self::with_resolver`], so the rejecting
+    /// terminator always sits at the end of the chain.
+    fn default() -> Self {
+        Self {
+            resolvers: vec![Arc::new(RejectAllExternalResolver::default())],
+        }
+    }
+}
+
+impl ExternalShapeResolverRegistry {
+    /// Build an empty registry. Production callers should prefer
+    /// [`Self::default`] which installs `RejectAllExternalResolver` as a
+    /// terminator. An empty registry surfaces [`DispatchOutcome::Abstain`].
+    pub fn empty() -> Self {
+        Self { resolvers: vec![] }
+    }
+
+    /// Prepend a resolver so it is consulted before all previously-registered
+    /// resolvers (in particular, before the default `RejectAllExternalResolver`).
+    pub fn with_resolver<R: ExternalShapeResolver + 'static>(mut self, r: R) -> Self {
+        self.resolvers.insert(0, Arc::new(r));
+        self
+    }
+
+    /// Same as [`Self::with_resolver`], but accepts an `Arc` directly so the
+    /// caller can share a single resolver across registries.
+    pub fn with_resolver_arc(mut self, r: Arc<dyn ExternalShapeResolver>) -> Self {
+        self.resolvers.insert(0, r);
+        self
+    }
+
+    pub fn resolvers(&self) -> &[Arc<dyn ExternalShapeResolver>] {
+        &self.resolvers
+    }
+
+    /// Apply every resolver's `rewrite_ast` in registry order.
+    pub fn rewrite_ast(&self, mut schema: ast::Schema) -> ast::Schema {
+        for r in &self.resolvers {
+            schema = r.rewrite_ast(schema);
+        }
+        schema
+    }
+
+    /// Consult resolvers in order; the first non-`Abstain` answer wins.
+    pub fn dispatch(&self, ctx: &ExternalResolveCtx<'_>) -> DispatchOutcome {
+        for r in &self.resolvers {
+            match r.resolve(ctx) {
+                ExternalResolution::Abstain => continue,
+                ExternalResolution::Conformant { rationale } => {
+                    return DispatchOutcome::Conformant {
+                        resolver: r.name().to_string(),
+                        rationale,
+                    };
+                },
+                ExternalResolution::NonConformant { rationale } => {
+                    return DispatchOutcome::NonConformant {
+                        resolver: r.name().to_string(),
+                        rationale,
+                    };
+                },
+            }
+        }
+        DispatchOutcome::Abstain
+    }
+}
+
+/// Always-reject resolver. Registered by default; rejects any EXTERNAL that
+/// no other resolver claimed.
+#[derive(Debug, Clone, Default)]
+pub struct RejectAllExternalResolver;
+
+impl ExternalShapeResolver for RejectAllExternalResolver {
+    fn name(&self) -> &str {
+        "reject-all"
+    }
+
+    fn resolve(&self, _ctx: &ExternalResolveCtx<'_>) -> ExternalResolution {
+        ExternalResolution::NonConformant {
+            rationale: "EXTERNAL shape rejected: no resolver supplied a definition".to_string(),
+        }
+    }
+}
+
+/// File-backed resolver. Loads a separate ShEx schema once at construction and,
+/// during the AST-rewrite pass, substitutes any `ShapeDecl` whose body is
+/// `ShapeExpr::External` and whose label exists in the externs file with the
+/// externs shape expression. At validation time it abstains: once a label has
+/// been substituted, the engine sees a regular shape, not EXTERNAL.
+#[derive(Debug, Clone)]
+pub struct SchemaExternalResolver {
+    name: String,
+    externs: ast::Schema,
+}
+
+impl SchemaExternalResolver {
+    /// Parse a ShEx schema file (e.g. `.shex`, `.shextern`) and use it as the
+    /// source of EXTERNAL definitions. Uses the standard ShExC parser.
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, ExternalResolverError> {
+        let path = path.as_ref();
+        let source_iri: IriS = path.try_into().map_err(|e: rudof_iri::error::IriSError| ExternalResolverError::PathToIri {
+            path: path.to_path_buf(),
+            error: e.to_string(),
+        })?;
+        let externs = crate::ShExParser::parse_buf(path, Some(source_iri))
+            .map_err(|e| ExternalResolverError::Parse {
+                path: path.to_path_buf(),
+                error: e.to_string(),
+            })?;
+        Ok(Self {
+            name: format!("schema:{}", path.display()),
+            externs,
+        })
+    }
+
+    /// Construct from an already-parsed `ast::Schema`. Useful in tests.
+    pub fn from_schema(name: impl Into<String>, externs: ast::Schema) -> Self {
+        Self {
+            name: name.into(),
+            externs,
+        }
+    }
+
+    pub fn externs(&self) -> &ast::Schema {
+        &self.externs
+    }
+}
+
+impl ExternalShapeResolver for SchemaExternalResolver {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn rewrite_ast(&self, mut schema: ast::Schema) -> ast::Schema {
+        let lookups = match self.externs.shapes() {
+            Some(s) => s,
+            None => return schema,
+        };
+        if let Some(decls) = schema.shapes_mut() {
+            for decl in decls.iter_mut() {
+                if matches!(decl.shape_expr, ast::ShapeExpr::External) {
+                    if let Some(matching) = lookup_decl(&lookups, &decl.id) {
+                        decl.shape_expr = matching.shape_expr.clone();
+                    }
+                }
+            }
+        }
+        schema
+    }
+}
+
+fn lookup_decl<'a>(
+    decls: &'a [ast::ShapeDecl],
+    label: &ShapeExprLabel,
+) -> Option<&'a ast::ShapeDecl> {
+    decls.iter().find(|d| &d.id == label)
+}
+
+#[derive(Debug, Error)]
+pub enum ExternalResolverError {
+    #[error("Could not convert path {path:?} into IRI: {error}")]
+    PathToIri { path: std::path::PathBuf, error: String },
+
+    #[error("Could not parse external shapes file {path:?}: {error}")]
+    Parse {
+        path: std::path::PathBuf,
+        error: String,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::{Schema, ShapeDecl, ShapeExpr};
+    use crate::ir::actions::semantic_actions_registry::SemanticActionsRegistry;
+
+    fn label(iri: &str) -> ShapeExprLabel {
+        ShapeExprLabel::iri_unchecked(iri)
+    }
+
+    fn schema_with(decls: Vec<ShapeDecl>) -> Schema {
+        Schema::default().with_shapes(Some(decls))
+    }
+
+    fn dummy_ctx<'a>(node: &'a Node, schema: &'a SchemaIR) -> ExternalResolveCtx<'a> {
+        ExternalResolveCtx {
+            node,
+            shape_idx: ShapeLabelIdx::default(),
+            shape_label: None,
+            schema,
+        }
+    }
+
+    #[test]
+    fn default_registry_rejects() {
+        let reg = ExternalShapeResolverRegistry::default();
+        let names: Vec<_> = reg.resolvers().iter().map(|r| r.name().to_string()).collect();
+        assert_eq!(names, vec!["reject-all".to_string()]);
+
+        // The reject-all terminator should answer NonConformant via dispatch.
+        let node = Node::iri(IriS::new_unchecked("http://example/n"));
+        let schema = SchemaIR::new(SemanticActionsRegistry::default());
+        let ctx = dummy_ctx(&node, &schema);
+        assert!(matches!(
+            reg.dispatch(&ctx),
+            DispatchOutcome::NonConformant { .. }
+        ));
+    }
+
+    #[test]
+    fn empty_registry_abstains() {
+        let reg = ExternalShapeResolverRegistry::empty();
+        let node = Node::iri(IriS::new_unchecked("http://example/n"));
+        let schema = SchemaIR::new(SemanticActionsRegistry::default());
+        let ctx = dummy_ctx(&node, &schema);
+        assert!(matches!(reg.dispatch(&ctx), DispatchOutcome::Abstain));
+    }
+
+    #[test]
+    fn schema_resolver_substitutes_matching_label() {
+        let sext = label("http://a.example/Sext");
+        let externs_shape = ShapeExpr::empty_shape();
+        let externs = schema_with(vec![ShapeDecl::new(sext.clone(), externs_shape.clone(), false)]);
+
+        let main = schema_with(vec![ShapeDecl::new(sext.clone(), ShapeExpr::External, false)]);
+
+        let resolver = SchemaExternalResolver::from_schema("test", externs);
+        let rewritten = resolver.rewrite_ast(main);
+
+        let decls = rewritten.shapes().expect("shapes present");
+        assert_eq!(decls.len(), 1);
+        assert!(!matches!(decls[0].shape_expr, ShapeExpr::External));
+        assert_eq!(decls[0].shape_expr, externs_shape);
+    }
+
+    #[test]
+    fn schema_resolver_leaves_unknown_labels_external() {
+        let known = label("http://a.example/Known");
+        let unknown = label("http://a.example/Unknown");
+        let externs = schema_with(vec![ShapeDecl::new(known, ShapeExpr::empty_shape(), false)]);
+        let main = schema_with(vec![ShapeDecl::new(unknown, ShapeExpr::External, false)]);
+
+        let resolver = SchemaExternalResolver::from_schema("test", externs);
+        let rewritten = resolver.rewrite_ast(main);
+
+        let decls = rewritten.shapes().unwrap();
+        assert!(matches!(decls[0].shape_expr, ShapeExpr::External));
+    }
+
+    #[test]
+    fn registry_runs_user_resolvers_before_default() {
+        let sext = label("http://a.example/Sext");
+        let externs = schema_with(vec![ShapeDecl::new(sext.clone(), ShapeExpr::empty_shape(), false)]);
+        let resolver = SchemaExternalResolver::from_schema("test", externs);
+
+        let reg = ExternalShapeResolverRegistry::default().with_resolver(resolver);
+        let names: Vec<_> = reg.resolvers().iter().map(|r| r.name().to_string()).collect();
+        assert_eq!(names, vec!["test".to_string(), "reject-all".to_string()]);
+
+        // rewrite_ast: user resolver substitutes the External; reject-all is a no-op for rewrite.
+        let main = schema_with(vec![ShapeDecl::new(sext, ShapeExpr::External, false)]);
+        let rewritten = reg.rewrite_ast(main);
+        assert!(!matches!(rewritten.shapes().unwrap()[0].shape_expr, ShapeExpr::External));
+    }
+}

--- a/shex_ast/src/ir/mod.rs
+++ b/shex_ast/src/ir/mod.rs
@@ -3,6 +3,7 @@ pub mod annotation;
 pub mod ast2ir;
 pub mod dependency_graph;
 pub mod exclusion;
+pub mod external_resolver;
 pub mod inheritance_graph;
 pub mod node_constraint;
 pub mod node_kind;

--- a/shex_ast/src/lib.rs
+++ b/shex_ast/src/lib.rs
@@ -18,6 +18,7 @@ pub mod shexr;
 use crate::ir::semantic_action_context::SemanticActionContext;
 pub use ast::*;
 pub use compact::*;
+pub use ir::external_resolver::*;
 pub use ir::schema_ir_error::*;
 pub use ir::shape_label_idx::*;
 pub use node::*;

--- a/shex_testsuite/src/manifest_error.rs
+++ b/shex_testsuite/src/manifest_error.rs
@@ -1,6 +1,7 @@
 use rudof_iri::error::IriSError;
 use rudof_rdf::{rdf_core::RDFError, rdf_impl::InMemoryGraphError};
 use shex_ast::compact::ParseError;
+use shex_ast::ir::external_resolver::ExternalResolverError;
 use shex_ast::shapemap::ValidationStatus;
 use shex_ast::{Schema, SchemaIRError, ast::SchemaJsonError};
 use shex_validation::ValidatorError;
@@ -143,4 +144,11 @@ pub enum ManifestError {
 
     #[error("Unable to perform operation in WASM: {0}")]
     WASMError(String),
+
+    #[error("Loading external shapes file for entry {entry_name}. Error: {error}")]
+    ExternalResolverError {
+        entry_name: String,
+        #[source]
+        error: ExternalResolverError,
+    },
 }

--- a/shex_testsuite/src/manifest_validation.rs
+++ b/shex_testsuite/src/manifest_validation.rs
@@ -270,11 +270,12 @@ impl ValidationEntry {
         let mut config = ValidatorConfig::default();
         let schema = if let Some(externs_rel) = &self.action.shape_externs {
             let externs_path = folder.join(externs_rel);
-            let resolver =
-                SchemaExternalResolver::from_path(&externs_path).map_err(|error| ManifestError::ExternalResolverError {
+            let resolver = SchemaExternalResolver::from_path(&externs_path).map_err(|error| {
+                ManifestError::ExternalResolverError {
                     entry_name: self.name.clone(),
                     error,
-                })?;
+                }
+            })?;
             config = config.with_external_resolver(resolver);
             config.external_resolvers().rewrite_ast(schema)
         } else {
@@ -292,8 +293,7 @@ impl ValidationEntry {
             .compile(&schema, &base_iri, &Some(base_iri.clone()), &mut compiled_schema)
             .map_err(|e| Box::new(ManifestError::SchemaIRError(e)))?;
         let schema = compiled_schema.clone();
-        let mut validator =
-            Validator::new(&compiled_schema, &config).map_err(ManifestError::ValidationError)?;
+        let mut validator = Validator::new(&compiled_schema, &config).map_err(ManifestError::ValidationError)?;
         let expected_type = parse_type(&self.type_)?;
         debug!("Schema compiled...expected type: {:?}", expected_type);
         trace!("Schema: {}", schema);

--- a/shex_testsuite/src/manifest_validation.rs
+++ b/shex_testsuite/src/manifest_validation.rs
@@ -23,6 +23,8 @@ use rudof_rdf::{
 use serde::de::{self};
 use serde::{Deserialize, Deserializer, Serialize};
 #[cfg(not(target_family = "wasm"))]
+use shex_ast::ir::external_resolver::SchemaExternalResolver;
+#[cfg(not(target_family = "wasm"))]
 use shex_ast::ir::shape_label::ShapeLabel;
 #[cfg(not(target_family = "wasm"))]
 use shex_ast::ir::{map_state::MapState, schema_ir::SchemaIR, semantic_actions_registry::SemanticActionsRegistry};
@@ -117,6 +119,8 @@ struct Action {
     data: String,
     map: Option<String>,
     focus: Option<Focus>,
+    #[serde(rename = "shapeExterns")]
+    shape_externs: Option<String>,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -258,6 +262,25 @@ impl ValidationEntry {
 
         trace!("Entry action: {:?}", self.action);
 
+        // If the test declares an externs schema (`shapeExterns`), load it as a
+        // `SchemaExternalResolver`, register it in the `ValidatorConfig`, and
+        // run the resolver registry's AST-rewrite pass before compilation. The
+        // default registry's `RejectAllExternalResolver` stays in place as the
+        // terminator for any unsubstituted EXTERNAL shapes.
+        let mut config = ValidatorConfig::default();
+        let schema = if let Some(externs_rel) = &self.action.shape_externs {
+            let externs_path = folder.join(externs_rel);
+            let resolver =
+                SchemaExternalResolver::from_path(&externs_path).map_err(|error| ManifestError::ExternalResolverError {
+                    entry_name: self.name.clone(),
+                    error,
+                })?;
+            config = config.with_external_resolver(resolver);
+            config.external_resolvers().rewrite_ast(schema)
+        } else {
+            schema
+        };
+
         let mut map_state = MapState::default();
         let mut registry = SemanticActionsRegistry::default();
         registry.set_map_state(&mut map_state);
@@ -270,7 +293,7 @@ impl ValidationEntry {
             .map_err(|e| Box::new(ManifestError::SchemaIRError(e)))?;
         let schema = compiled_schema.clone();
         let mut validator =
-            Validator::new(&compiled_schema, &ValidatorConfig::default()).map_err(ManifestError::ValidationError)?;
+            Validator::new(&compiled_schema, &config).map_err(ManifestError::ValidationError)?;
         let expected_type = parse_type(&self.type_)?;
         debug!("Schema compiled...expected type: {:?}", expected_type);
         trace!("Schema: {}", schema);

--- a/shex_testsuite/tests/baseline_failing.txt
+++ b/shex_testsuite/tests/baseline_failing.txt
@@ -11,8 +11,6 @@
 3Eachdot3Extra_pass-iri2
 3EachdotExtra3NLex_pass-iri2
 3EachdotExtra3_pass-iri2
-shapeExternRef_fail
-shapeExtern_fail
 startCode1fail_abort
 startCode1startReffail_abort
 startCode3fail_abort

--- a/shex_validation/Cargo.toml
+++ b/shex_validation/Cargo.toml
@@ -31,3 +31,4 @@ url.workspace = true
 
 [dev-dependencies]
 tracing-test.workspace = true
+rudof_rdf = { workspace = true, default-features = false, features = ["sparql"] }

--- a/shex_validation/src/engine.rs
+++ b/shex_validation/src/engine.rs
@@ -21,6 +21,7 @@ use shex_ast::Expr;
 use shex_ast::Node;
 use shex_ast::Pred;
 use shex_ast::ShapeLabelIdx;
+use shex_ast::ir::external_resolver::{DispatchOutcome, ExternalResolveCtx};
 use shex_ast::ir::preds::Preds;
 use shex_ast::ir::schema_ir::SchemaIR;
 use shex_ast::ir::semantic_action_context::SemanticActionContext;
@@ -540,8 +541,39 @@ impl Engine {
                 }
             },
             ShapeExpr::External {} => {
-                debug!("External shape expression encountered for node {node} with shape {se}");
-                pass(Reason::External { node: node.clone() })
+                let label = schema.shape_label_from_idx(idx);
+                let ctx = ExternalResolveCtx {
+                    node,
+                    shape_idx: *idx,
+                    shape_label: label,
+                    schema,
+                };
+                match self.config.external_resolvers().dispatch(&ctx) {
+                    DispatchOutcome::Conformant { resolver, rationale } => {
+                        debug!("EXTERNAL conformant for {node}@{idx} via '{resolver}': {rationale}");
+                        pass(Reason::External {
+                            node: node.clone(),
+                            resolver,
+                            rationale,
+                        })
+                    },
+                    DispatchOutcome::NonConformant { resolver, rationale } => {
+                        debug!("EXTERNAL non-conformant for {node}@{idx} via '{resolver}': {rationale}");
+                        fail(ValidatorError::ExternalShapeRejected {
+                            node: Box::new(node.clone()),
+                            idx: *idx,
+                            resolver,
+                            rationale,
+                        })
+                    },
+                    DispatchOutcome::Abstain => {
+                        debug!("EXTERNAL unresolved for {node}@{idx}: no resolver answered");
+                        fail(ValidatorError::ExternalShapeUnresolved {
+                            node: Box::new(node.clone()),
+                            idx: *idx,
+                        })
+                    },
+                }
             },
             ShapeExpr::Ref { idx } => self.check_node_ref(node, idx, typing),
             ShapeExpr::Empty => pass(Reason::Empty { node: node.clone() }),

--- a/shex_validation/src/reason.rs
+++ b/shex_validation/src/reason.rs
@@ -47,6 +47,8 @@ pub enum Reason {
     },
     External {
         node: Node,
+        resolver: String,
+        rationale: String,
     },
     ShapeOr {
         node: Node,
@@ -184,9 +186,13 @@ impl Reason {
                 "Node {} passes empty shape",
                 node.show_qualified(nodes_prefixmap)
             )),
-            Reason::External { node } => Ok(format!(
-                "{} passes external shape",
-                node.show_qualified(nodes_prefixmap)
+            Reason::External {
+                node,
+                resolver,
+                rationale,
+            } => Ok(format!(
+                "{} passes EXTERNAL via '{resolver}': {rationale}",
+                node.show_qualified(nodes_prefixmap),
             )),
             Reason::ShapeOr { node, shape_expr, .. } => Ok(format!(
                 "OR passed ({}@{})",
@@ -338,7 +344,11 @@ impl Display for Reason {
                 f,
                 "Shape NOT passed. Node {node}, shape: {shape_expr}, errors: {errors_evidences}"
             ),
-            Reason::External { node } => write!(f, "Shape External passed for node {node}"),
+            Reason::External {
+                node,
+                resolver,
+                rationale,
+            } => write!(f, "Shape External passed for node {node} via '{resolver}': {rationale}"),
             Reason::Empty { node } => write!(f, "Shape Empty passed for node {node}"),
             Reason::ShapeRef { node, idx } => {
                 write!(f, "ShapeRef passed. Node {node}, idx: {idx}")

--- a/shex_validation/src/validator_config.rs
+++ b/shex_validation/src/validator_config.rs
@@ -1,15 +1,17 @@
 use rudof_rdf::rdf_core::RdfDataConfig;
 use serde::{Deserialize, Serialize};
+use shex_ast::ir::external_resolver::{ExternalShapeResolver, ExternalShapeResolverRegistry};
 use shex_ast::shapemap::ShapemapConfig;
 use std::io::Read;
 use std::path::Path;
+use std::sync::Arc;
 
 use crate::{MAX_STEPS, ShExConfig, ValidatorError};
 
 const DEFAULT_WIDTH: usize = 80;
 
 /// This struct can be used to customize the behavour of ShEx validators
-#[derive(Deserialize, Serialize, Debug, PartialEq, Clone)]
+#[derive(Deserialize, Serialize, Debug, Clone)]
 
 pub struct ValidatorConfig {
     /// Maximum numbers of validation steps
@@ -29,6 +31,13 @@ pub struct ValidatorConfig {
 
     /// Width for pretty printing
     pub width: Option<usize>,
+
+    /// Resolvers consulted for EXTERNAL shape expressions. Defaults to a
+    /// registry containing only `RejectAllExternalResolver`. Resolvers cannot
+    /// be loaded from TOML — they must be installed programmatically via
+    /// [`Self::with_external_resolver`].
+    #[serde(skip, default)]
+    pub external_resolvers: ExternalShapeResolverRegistry,
 }
 
 impl Default for ValidatorConfig {
@@ -40,6 +49,7 @@ impl Default for ValidatorConfig {
             shapemap: Some(ShapemapConfig::default()),
             check_negation_requirement: Some(true),
             width: Some(80),
+            external_resolvers: ExternalShapeResolverRegistry::default(),
         }
     }
 }
@@ -105,5 +115,21 @@ impl ValidatorConfig {
 
     pub fn set_check_negation_requirement(&mut self, check: bool) {
         self.check_negation_requirement = Some(check);
+    }
+
+    pub fn external_resolvers(&self) -> &ExternalShapeResolverRegistry {
+        &self.external_resolvers
+    }
+
+    /// Prepend a resolver to the EXTERNAL-shape resolver chain. Returns the
+    /// updated config for builder-style chaining.
+    pub fn with_external_resolver<R: ExternalShapeResolver + 'static>(mut self, r: R) -> Self {
+        self.external_resolvers = std::mem::take(&mut self.external_resolvers).with_resolver(r);
+        self
+    }
+
+    pub fn with_external_resolver_arc(mut self, r: Arc<dyn ExternalShapeResolver>) -> Self {
+        self.external_resolvers = std::mem::take(&mut self.external_resolvers).with_resolver_arc(r);
+        self
     }
 }

--- a/shex_validation/src/validator_error.rs
+++ b/shex_validation/src/validator_error.rs
@@ -220,6 +220,20 @@ pub enum ValidatorError {
 
     #[error("ShapeRef fails for node {node} with idx: {idx}")]
     ShapeRefFailed { node: Box<Node>, idx: ShapeLabelIdx },
+
+    #[error("EXTERNAL shape {idx} rejected for node {node} by resolver '{resolver}': {rationale}")]
+    ExternalShapeRejected {
+        node: Box<Node>,
+        idx: ShapeLabelIdx,
+        resolver: String,
+        rationale: String,
+    },
+
+    #[error("EXTERNAL shape {idx} for node {node} could not be resolved by any registered resolver")]
+    ExternalShapeUnresolved {
+        node: Box<Node>,
+        idx: ShapeLabelIdx,
+    },
 }
 
 fn add_errors_to_tree(
@@ -412,7 +426,9 @@ impl ValidatorError {
             | ValidatorError::AddingPendingError { .. }
             | ValidatorError::ShapeExprNotFound { .. }
             | ValidatorError::NoMatchesFound { .. }
-            | ValidatorError::ShapeRefFailed { .. } => Ok(()),
+            | ValidatorError::ShapeRefFailed { .. }
+            | ValidatorError::ExternalShapeRejected { .. }
+            | ValidatorError::ExternalShapeUnresolved { .. } => Ok(()),
         }
     }
 

--- a/shex_validation/src/validator_error.rs
+++ b/shex_validation/src/validator_error.rs
@@ -230,10 +230,7 @@ pub enum ValidatorError {
     },
 
     #[error("EXTERNAL shape {idx} for node {node} could not be resolved by any registered resolver")]
-    ExternalShapeUnresolved {
-        node: Box<Node>,
-        idx: ShapeLabelIdx,
-    },
+    ExternalShapeUnresolved { node: Box<Node>, idx: ShapeLabelIdx },
 }
 
 fn add_errors_to_tree(

--- a/shex_validation/tests/external_resolver_integration.rs
+++ b/shex_validation/tests/external_resolver_integration.rs
@@ -32,8 +32,7 @@ fn compile(schema_src: &str, config: &ValidatorConfig) -> SchemaIR {
 fn validate(focus: &str, config: ValidatorConfig) -> bool {
     let compiled = compile(SCHEMA, &config);
     let mut validator = Validator::new(&compiled, &config).expect("validator");
-    let graph =
-        InMemoryGraph::from_str(DATA, &RDFFormat::Turtle, None, &ReaderMode::Strict).expect("parse graph");
+    let graph = InMemoryGraph::from_str(DATA, &RDFFormat::Turtle, None, &ReaderMode::Strict).expect("parse graph");
     let node = Node::parse(focus, None).expect("parse focus");
     let shape = ShapeLabel::iri(IriS::new_unchecked("http://a.example/Sext"));
     let result = validator
@@ -54,8 +53,7 @@ fn default_config_rejects_external_shape() {
 #[test]
 fn schema_resolver_substitutes_and_validates() {
     let base = IriS::new_unchecked("http://a.example/");
-    let externs_ast =
-        ShExParser::parse(EXTERNS, Some(base.clone()), &base).expect("parse externs");
+    let externs_ast = ShExParser::parse(EXTERNS, Some(base.clone()), &base).expect("parse externs");
     let resolver = SchemaExternalResolver::from_schema("test-externs", externs_ast);
 
     let config_with_externs = || ValidatorConfig::default().with_external_resolver(resolver.clone());

--- a/shex_validation/tests/external_resolver_integration.rs
+++ b/shex_validation/tests/external_resolver_integration.rs
@@ -1,0 +1,68 @@
+//! End-to-end tests for EXTERNAL shape resolution.
+
+use rudof_iri::IriS;
+use rudof_rdf::rdf_core::RDFFormat;
+use rudof_rdf::rdf_impl::{InMemoryGraph, ReaderMode};
+use shex_ast::ir::external_resolver::SchemaExternalResolver;
+use shex_ast::ir::shape_label::ShapeLabel;
+use shex_ast::ir::{map_state::MapState, schema_ir::SchemaIR, semantic_actions_registry::SemanticActionsRegistry};
+use shex_ast::{Node, ResolveMethod, ShExParser, ir::ast2ir::AST2IR};
+use shex_validation::{Validator, ValidatorConfig};
+
+const SCHEMA: &str = "<http://a.example/Sext> EXTERNAL";
+const EXTERNS: &str = "<http://a.example/Sext> { <http://a.example/p2> . }";
+const DATA: &str = r#"<http://a.example/n1> <http://a.example/p1> <http://a.example/n2> .
+<http://a.example/n2> <http://a.example/p2> "X" ."#;
+
+fn compile(schema_src: &str, config: &ValidatorConfig) -> SchemaIR {
+    let base = IriS::new_unchecked("http://a.example/");
+    let mut ast = ShExParser::parse(schema_src, Some(base.clone()), &base).expect("parse main schema");
+    ast = config.external_resolvers().rewrite_ast(ast);
+    let mut map_state = MapState::default();
+    let mut registry = SemanticActionsRegistry::default();
+    registry.set_map_state(&mut map_state);
+    let mut compiler = AST2IR::new(&ResolveMethod::default(), map_state);
+    let mut compiled = SchemaIR::new(registry);
+    compiler
+        .compile(&ast, &base, &Some(base.clone()), &mut compiled)
+        .expect("compile to IR");
+    compiled
+}
+
+fn validate(focus: &str, config: ValidatorConfig) -> bool {
+    let compiled = compile(SCHEMA, &config);
+    let mut validator = Validator::new(&compiled, &config).expect("validator");
+    let graph =
+        InMemoryGraph::from_str(DATA, &RDFFormat::Turtle, None, &ReaderMode::Strict).expect("parse graph");
+    let node = Node::parse(focus, None).expect("parse focus");
+    let shape = ShapeLabel::iri(IriS::new_unchecked("http://a.example/Sext"));
+    let result = validator
+        .validate_node_shape(&node, &shape, &graph, &compiled, &Some(graph.prefixmap().clone()))
+        .expect("validate");
+    result.get_info(&node, &shape).expect("status").is_conformant()
+}
+
+#[test]
+fn default_config_rejects_external_shape() {
+    // No SchemaExternalResolver registered → RejectAllExternalResolver answers
+    // NonConformant for every EXTERNAL. The focus node has the expected `<p2>`
+    // edge but the validator never gets to check it.
+    assert!(!validate("http://a.example/n2", ValidatorConfig::default()));
+    assert!(!validate("http://a.example/n1", ValidatorConfig::default()));
+}
+
+#[test]
+fn schema_resolver_substitutes_and_validates() {
+    let base = IriS::new_unchecked("http://a.example/");
+    let externs_ast =
+        ShExParser::parse(EXTERNS, Some(base.clone()), &base).expect("parse externs");
+    let resolver = SchemaExternalResolver::from_schema("test-externs", externs_ast);
+
+    let config_with_externs = || ValidatorConfig::default().with_external_resolver(resolver.clone());
+
+    // n2 has <p2> "X" → conforms to <Sext> { <p2> . }
+    assert!(validate("http://a.example/n2", config_with_externs()));
+
+    // n1 has no <p2> → does not conform
+    assert!(!validate("http://a.example/n1", config_with_externs()));
+}


### PR DESCRIPTION
This PR introduces a **resolver registry** for `EXTERNAL` shapes with a clear two‑phase flow: 
1. First, resolvers can rewrite/augment the schema during AST→IR compilation.
2. Then during validation they can answer EXTERNAL conformance decisions. 
 
Two resolver styles are supported and implemented:
- A schema‑backed resolver (`SchemaExternalResolver`) that injects external shapes into the IR (so validation proceeds normally and the resolver can abstain because the shape is now present).
- A decision‑only resolver (`RejectAllExternalResolver`)  that does not modify the IR and instead returns conformant/non‑conformant at validation time. By default, the registry uses `RejectAllExternalResolver`, which rejects every `EXTERNAL` unless a resolver is registered. 
 
This design enables adding additional resolvers in the future without changing validation logic. 

### Tests

- This PR also adds integration tests to cover default rejection and schema substitution.
- `shex‑testsuite` now passes `shapeExtern_pass` and `shapeExternRef_pass`. 

Closes #667 