### PR TITLE
feat(shex): expose external-shape resolvers to CLI/MCP/Python and auto-apply rewrite during compile

### DIFF
--- a/docs/src/cli_usage/shex_validate.md
+++ b/docs/src/cli_usage/shex_validate.md
@@ -8,24 +8,105 @@ This command can be used to validate RDF data using ShEx. This is a specific com
 
 ```sh
 $ rudof shex-validate -s examples/user.shex -m examples/user.sm examples/user.ttl
-:a@<http://example.org/User> -> OK
-:b@<http://example.org/User> -> OK
-:c@<http://example.org/User> -> OK
-:d@<http://example.org/User> -> Fail
-:e@<http://example.org/User> -> Fail
+
+╭──────┬───────┬────────┬──────────────────────────────────────────────────────────────────────────────────╮
+│ Node │ Shape │ Status │ Details                                                                          │
+├──────┼───────┼────────┼──────────────────────────────────────────────────────────────────────────────────┤
+│ :a   │ :User │ OK     │ Shape passed :a@:User                                                            │
+├──────┼───────┼────────┼──────────────────────────────────────────────────────────────────────────────────┤
+│ :b   │ :User │ OK     │ Shape passed :b@:User                                                            │
+├──────┼───────┼────────┼──────────────────────────────────────────────────────────────────────────────────┤
+│ :c   │ :User │ OK     │ Shape passed :c@:User                                                            │
+├──────┼───────┼────────┼──────────────────────────────────────────────────────────────────────────────────┤
+│ :d   │ :User │ FAIL   │ Datatype error: Datatype expected http://www.w3.org/2001/XMLSchema#string but fo │
+│      │       │        │ und http://www.w3.org/2001/XMLSchema#integer for literal with lexical form "23"^ │
+│      │       │        │ ^<http://www.w3.org/2001/XMLSchema#integer>                                      │
+├──────┼───────┼────────┼──────────────────────────────────────────────────────────────────────────────────┤
+│ :e   │ :User │ FAIL   │ Shape :User failed for node :e                                                   │
+│      │       │        │ └── References failed: (:d@:User)                                                │
+╰──────┴───────┴────────┴──────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 ### Validate data using ShEx schema, a node and a shape
 
 ```sh
-$ rudof shex-validate -s examples/user.shex -n ":a" -l ":User" examples/user.ttl
-:a@<http://example.org/User> -> OK
-:b@<http://example.org/User> -> OK
-:c@<http://example.org/User> -> OK
-:d@<http://example.org/User> -> Fail
-:e@<http://example.org/User> -> Fail
+$ rudof shex-validate -s examples/user.shex -n "http://example.org/a" -l "http://example.org/User" examples/user.ttl
+
+╭──────┬───────┬────────┬───────────────────────╮
+│ Node │ Shape │ Status │ Details               │
+├──────┼───────┼────────┼───────────────────────┤
+│ :a   │ :User │ OK     │ Shape passed :a@:User │
+╰──────┴───────┴────────┴───────────────────────╯
 ```
 
+
+## External-shape resolvers
+
+A ShEx schema may declare a shape as `EXTERNAL`, meaning the definition lives outside the schema and is resolved by an implementation-defined mechanism. By default `rudof` rejects every `EXTERNAL` shape via the built-in `reject-all` resolver, so validation against an unsubstituted external shape always fails.
+
+Without any resolver, `:alice` already fails because `:Address` is rejected outright:
+
+```sh
+$ rudof shex-validate -s examples/person.shex -n "http://example.org/alice" -l "http://example.org/Person" examples/person.ttl
+
+╭────────┬─────────┬────────┬───────────────────────────────────────────────╮
+│ Node   │ Shape   │ Status │ Details                                       │
+├────────┼─────────┼────────┼───────────────────────────────────────────────┤
+│ :alice │ :Person │ FAIL   │ Shape :Person failed for node :alice          │
+│        │         │        │ └── References failed: (:alice_addr@:Address) │
+╰────────┴─────────┴────────┴───────────────────────────────────────────────╯
+```
+
+Use `--external-resolver` (repeatable) to install resolvers that substitute or judge `EXTERNAL` shapes. Resolvers are applied in the order they appear on the command line (the most recently registered is consulted first, and the default `reject-all` always sits at the tail of the chain).
+
+### Listing the available resolver kinds
+
+```sh
+$ rudof shex-validate --list-external-resolvers
+
+Available external-shape resolvers:
+
+  reject-all         Reject any EXTERNAL shape that no earlier resolver claimed
+  schema:<path>      Substitute EXTERNAL shape declarations using definitions from a ShEx file
+```
+
+When `--list-external-resolvers` is set, the other arguments (including `--schema`) are not required.
+
+### `schema:<path>`
+
+The `schema` resolver loads a separate ShEx file and, during AST→IR compilation, replaces any `EXTERNAL` shape declaration in the main schema with the matching definition from the file.
+
+With the externs file plugged in, `:alice` validates and `:bob` still fails because his address is missing `:city`:
+
+```sh
+$ rudof shex-validate -s examples/person.shex --external-resolver schema:examples/address.shex -n "http://example.org/alice" -l "http://example.org/Person" examples/person.ttl
+
+╭────────┬─────────┬────────┬─────────────────────────────╮
+│ Node   │ Shape   │ Status │ Details                     │
+├────────┼─────────┼────────┼─────────────────────────────┤
+│ :alice │ :Person │ OK     │ Shape passed :alice@:Person │
+╰────────┴─────────┴────────┴─────────────────────────────╯
+
+$ rudof shex-validate -s examples/person.shex --external-resolver schema:examples/address.shex -n "http://example.org/bob" -l "http://example.org/Person" examples/person.ttl
+
+╭──────┬─────────┬────────┬─────────────────────────────────────────────╮
+│ Node │ Shape   │ Status │ Details                                     │
+├──────┼─────────┼────────┼─────────────────────────────────────────────┤
+│ :bob │ :Person │ FAIL   │ Shape :Person failed for node :bob          │
+│      │         │        │ └── References failed: (:bob_addr@:Address) │
+╰──────┴─────────┴────────┴─────────────────────────────────────────────╯
+```
+
+### Invalid specs
+
+A malformed spec is reported up-front with a hint listing the recognised kinds:
+
+```sh
+$ rudof shex-validate -s examples/person.shex --external-resolver bogus examples/person.ttl
+
+Error: ShEx error: Invalid external-shape resolver spec 'bogus':
+  Unknown external resolver kind 'bogus'. Available kinds: reject-all, schema
+```
 
 ## IRI normalization modes
 
@@ -61,27 +142,31 @@ Use strict mode in automated pipelines or when the data contains non-`http` IRI 
 ```sh
 Validate RDF using ShEx schemas
 
-Usage: rudof.exe shex-validate [OPTIONS] [DATA]...
+Usage: rudof shex-validate [OPTIONS] [DATA]...
 
 Arguments:
   [DATA]...
 
 Options:
   -s, --schema <INPUT>            Schema file name, URI or - (for stdin)
-  -f, --schema-format <FORMAT>    ShEx Schema format [possible values: internal, simple, shexc, shexj, json, jsonld, turtle, ntriples, rdfxml, trig, n3, nquads]
+  -f, --schema-format <FORMAT>    ShEx Schema format [default: shexc] [possible values: internal, simple, shexc, shexj, json, jsonld, turtle, ntriples, rdfxml, trig, n3, nquads]
   -m, --shapemap <INPUT>          ShapeMap
-      --shapemap-format <FORMAT>  ShapeMap format [default: compact] [possible values: compact, internal, json, details]
+      --shapemap-format <FORMAT>  ShapeMap format [possible values: compact, internal, json, details, csv]
   -n, --node <NODE>               Node to validate
       --sort_by <SORT_MODE>       Sort result by (default = node) [default: node] [possible values: node, shape, status, details]
   -l, --shape-label <LABEL>       shape label (default = START)
-  -t, --data-format <FORMAT>      RDF Data format [default: turtle] [possible values: turtle, ntriples, rdfxml, trig, n3, nquads, jsonld]
+  -t, --data-format <FORMAT>      RDF Data format [default: turtle] [possible values: turtle, ntriples, rdfxml, trig, n3, nquads, jsonld, pg]
       --base-schema <IRI>         Base Schema (used to resolve relative IRIs in Schema)
       --base-data <IRI>           Base RDF Data IRI (used to resolve relative IRIs in RDF data)
       --reader-mode <MODE>        RDF Reader mode [default: strict] [possible values: lax, strict]
   -e, --endpoint <NAME>           Endpoint with RDF data (name or URL)
-  -r, --result-format <FORMAT>    Ouput result format [default: details] [possible values: turtle, ntriples, rdfxml, trig, n3, nquads, compact, details, json]
-  -o, --output-file <FILE>        Output file name, default = terminal
+  -r, --result-format <FORMAT>    Ouput result format [default: details] [possible values: details, turtle, ntriples, rdfxml, trig, n3, nquads, compact, json, csv]
+      --map-state <FILE>          MapState file name
+      --strict-iris               Require <> brackets around IRIs (strict mode). By default bare http://… IRIs are accepted (lax mode).
+      --external-resolver <SPEC>  External-shape resolver spec. Repeatable. Syntax: <kind>[:<arg>]. Built-in kinds: 'reject-all', 'schema:<path>'. Use --list-external-resolvers to enumerate.
+      --list-external-resolvers   Print the available external-shape resolver kinds and exit
   -c, --config-file <FILE>        Config file name
+  -o, --output-file <FILE>        Output file name, default = terminal
       --force-overwrite           Force overwrite to output file if it already exists
   -h, --help                      Print help
 ```

--- a/examples/address.shex
+++ b/examples/address.shex
@@ -1,0 +1,12 @@
+prefix :     <http://example.org/>
+prefix xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+# Externs file consumed by the `schema:<path>` external-shape resolver.
+# Loading this with `--external-resolver schema:examples/address.shex`
+# substitutes `:Address EXTERNAL` in `examples/person.shex` with the
+# definition below.
+
+:Address {
+  :street  xsd:string ;
+  :city    xsd:string
+}

--- a/examples/person.shex
+++ b/examples/person.shex
@@ -1,0 +1,13 @@
+prefix :     <http://example.org/>
+prefix xsd:  <http://www.w3.org/2001/XMLSchema#>
+
+# `:Address` is declared EXTERNAL: its definition lives in a separate file
+# (see `examples/address.shex`) and is plugged in at validation time via the
+# `--external-resolver schema:<path>` flag.
+
+:Person {
+  :name     xsd:string ;
+  :address  @:Address
+}
+
+:Address EXTERNAL

--- a/examples/person.ttl
+++ b/examples/person.ttl
@@ -1,0 +1,14 @@
+prefix : <http://example.org/>
+
+# Alice has a fully-formed address — conforms to :Person once :Address is resolved.
+:alice :name    "Alice" ;
+       :address :alice_addr .
+
+:alice_addr :street "Main 123" ;
+            :city   "Madrid" .
+
+# Bob's address is missing :city — fails :Address, which makes :bob fail :Person.
+:bob :name    "Bob" ;
+     :address :bob_addr .
+
+:bob_addr :street "Oak Avenue" .

--- a/python/src/pyrudof_lib.rs
+++ b/python/src/pyrudof_lib.rs
@@ -579,6 +579,54 @@ impl PyRudof {
         Ok(())
     }
 
+    /// Registers an external-shape resolver from a spec string.
+    ///
+    /// The spec follows the grammar ``<kind>[:<arg>]``. Built-in kinds (see
+    /// :meth:`list_external_resolvers`):
+    ///
+    /// * ``reject-all`` — reject any unhandled EXTERNAL shape.
+    /// * ``schema:<path>`` — substitute EXTERNAL declarations using a ShEx file.
+    ///
+    /// Resolvers are prepended to the chain, so the most recently added is
+    /// consulted first. Call this **before** :meth:`load_shex_schema` because
+    /// the compiler reads the chain during AST→IR.
+    ///
+    /// Args:
+    ///     spec (str): Resolver spec string.
+    ///
+    /// Raises:
+    ///     RudofError: If the spec is malformed or the resolver cannot be built.
+    pub fn add_external_resolver(&mut self, spec: &str) -> PyResult<()> {
+        self.inner.add_external_resolver(spec).map_err(cnv_err)?;
+        Ok(())
+    }
+
+    /// Resets the external-shape resolver chain to the default
+    /// (``reject-all`` only).
+    pub fn clear_external_resolvers(&mut self) {
+        self.inner.clear_external_resolvers();
+    }
+
+    /// Returns the built-in external-shape resolver kinds.
+    ///
+    /// Returns:
+    ///     list[tuple[str, str, str]]: A list of ``(name, description, spec_syntax)``
+    ///     triples that document the kinds accepted by
+    ///     :meth:`add_external_resolver`.
+    #[staticmethod]
+    pub fn list_external_resolvers() -> Vec<(String, String, String)> {
+        rudof_lib::Rudof::list_external_resolvers()
+            .into_iter()
+            .map(|info| {
+                (
+                    info.name.to_string(),
+                    info.description.to_string(),
+                    info.spec_syntax.to_string(),
+                )
+            })
+            .collect()
+    }
+
     /// Validates the current RDF data against the loaded SHACL shapes.
     ///
     /// Performs comprehensive SHACL validation checking all constraints defined

--- a/rudof_cli/src/cli/parser/shex_validate.rs
+++ b/rudof_cli/src/cli/parser/shex_validate.rs
@@ -18,9 +18,10 @@ pub struct ShexValidateArgs {
         short = 's',
         long = "schema",
         value_name = "INPUT",
-        help = "Schema file name, URI or - (for stdin)"
+        help = "Schema file name, URI or - (for stdin)",
+        required_unless_present = "list_external_resolvers"
     )]
-    pub schema: InputSpec,
+    pub schema: Option<InputSpec>,
 
     #[arg(
         short = 'f',
@@ -125,6 +126,22 @@ pub struct ShexValidateArgs {
         help = "Require <> brackets around IRIs (strict mode). By default bare http://… IRIs are accepted (lax mode)."
     )]
     pub strict_iris: bool,
+
+    #[arg(
+        long = "external-resolver",
+        value_name = "SPEC",
+        help = "External-shape resolver spec. Repeatable. Syntax: <kind>[:<arg>]. \
+                Built-in kinds: 'reject-all', 'schema:<path>'. \
+                Use --list-external-resolvers to enumerate.",
+        action = clap::ArgAction::Append
+    )]
+    pub external_resolvers: Vec<String>,
+
+    #[arg(
+        long = "list-external-resolvers",
+        help = "Print the available external-shape resolver kinds and exit"
+    )]
+    pub list_external_resolvers: bool,
 
     #[command(flatten)]
     pub common: CommonArgsAll,

--- a/rudof_cli/src/commands/shex_validate.rs
+++ b/rudof_cli/src/commands/shex_validate.rs
@@ -1,7 +1,9 @@
 use crate::cli::parser::ShexValidateArgs;
 use crate::commands::base::{Command, CommandContext};
-use anyhow::Result;
+use anyhow::{Result, anyhow};
+use rudof_lib::Rudof;
 use rudof_lib::formats::IriNormalizationMode;
+use std::io::Write;
 
 /// Implementation of the `shex-validate` command.
 ///
@@ -26,12 +28,33 @@ impl Command for ShexValidateCommand {
 
     /// Executes the shex-validate logic.
     fn execute(&self, ctx: &mut CommandContext) -> Result<()> {
+        // Discovery flag short-circuits the rest of the command.
+        if self.args.list_external_resolvers {
+            print_external_resolvers(&mut ctx.writer)?;
+            return Ok(());
+        }
+
         let data_format = self.args.data_format.into();
         let reader_mode = self.args.reader_mode.into();
         let schema_format = self.args.schema_format.into();
         let sort_order = self.args.sort_by.into();
         let result_format = self.args.result_format.into();
         let map_state = self.args.map_state.clone();
+
+        // External-shape resolvers must be registered before `load_shex_schema`
+        // runs, since the compiler reads them from the validator config to
+        // rewrite EXTERNAL declarations during AST→IR.
+        for spec in &self.args.external_resolvers {
+            ctx.rudof.add_external_resolver(spec)?;
+        }
+
+        // `schema` is `required_unless_present = list_external_resolvers`, so we
+        // know it must be Some here (the listing case returned earlier).
+        let schema = self
+            .args
+            .schema
+            .as_ref()
+            .ok_or_else(|| anyhow!("--schema is required for shex-validate"))?;
 
         let mut loading = ctx
             .rudof
@@ -49,7 +72,7 @@ impl Command for ShexValidateCommand {
 
         let mut shex_schema_loading = ctx
             .rudof
-            .load_shex_schema(&self.args.schema)
+            .load_shex_schema(schema)
             .with_reader_mode(&reader_mode)
             .with_shex_schema_format(&schema_format);
         if let Some(base) = self.args.base_schema.as_deref() {
@@ -111,4 +134,13 @@ impl Command for ShexValidateCommand {
 
         Ok(())
     }
+}
+
+fn print_external_resolvers<W: Write>(writer: &mut W) -> Result<()> {
+    writeln!(writer, "Available external-shape resolvers:")?;
+    writeln!(writer)?;
+    for info in Rudof::list_external_resolvers() {
+        writeln!(writer, "  {:<18} {}", info.spec_syntax, info.description)?;
+    }
+    Ok(())
 }

--- a/rudof_cli/src/commands/validate.rs
+++ b/rudof_cli/src/commands/validate.rs
@@ -30,11 +30,12 @@ impl ValidateCommand {
     fn to_shex_args(&self) -> Result<ShexValidateArgs> {
         Ok(ShexValidateArgs {
             data: self.args.data.clone(),
-            schema: self
-                .args
-                .schema
-                .clone()
-                .ok_or_else(|| anyhow!("schema is required for ShEx validation"))?,
+            schema: Some(
+                self.args
+                    .schema
+                    .clone()
+                    .ok_or_else(|| anyhow!("schema is required for ShEx validation"))?,
+            ),
             schema_format: self.args.schema_format,
             shapemap: self.args.shapemap.clone(),
             shapemap_format: Some(self.args.shapemap_format),
@@ -49,6 +50,8 @@ impl ValidateCommand {
             result_format: self.args.result_format.into(),
             map_state: self.args.map_state.clone(),
             strict_iris: false,
+            external_resolvers: Vec::new(),
+            list_external_resolvers: false,
             common: self.args.common.clone(),
         })
     }

--- a/rudof_lib/src/api/shex/implementations/load_shex_schema.rs
+++ b/rudof_lib/src/api/shex/implementations/load_shex_schema.rs
@@ -139,8 +139,14 @@ fn compile_shex_schema(rudof: &mut Rudof, base: IriS, schema: ShExSchema, reader
 
     let mut schema_ir = SchemaIR::new(registry);
 
+    let validator_config = rudof.config.validator_config();
     schema_ir
-        .populate_from_schema_json(&schema, &ResolveMethod::default(), &Some(base.clone()))
+        .populate_from_schema_json(
+            &schema,
+            validator_config.external_resolvers(),
+            &ResolveMethod::default(),
+            &Some(base.clone()),
+        )
         .map_err(|error| ShExError::FailedCompilingShExSchema {
             error: error.to_string(),
         })?;

--- a/rudof_lib/src/errors/shex_error.rs
+++ b/rudof_lib/src/errors/shex_error.rs
@@ -75,4 +75,8 @@ pub enum ShExError {
     /// Failed to serialize ShEx validation results to the specified format.
     #[error("Failed to serialize ShEx validation results to {format}: {error}")]
     FailedSerializingShExValidationResults { format: String, error: String },
+
+    /// Failed to parse an external-shape resolver spec.
+    #[error("Invalid external-shape resolver spec '{spec}': {error}")]
+    InvalidExternalResolverSpec { spec: String, error: String },
 }

--- a/rudof_lib/src/rudof.rs
+++ b/rudof_lib/src/rudof.rs
@@ -36,7 +36,7 @@ use crate::{
             SerializeShexSchemaBuilder, SerializeShexValidationResultsBuilder, ValidateShexBuilder,
         },
     },
-    errors::RudofError,
+    errors::{RudofError, ShExError},
     formats::{
         ComparisonFormat, ComparisonMode, ConversionFormat, ConversionMode, GenerationSchemaFormat, InputSpec,
         ResultConversionFormat, ResultConversionMode,
@@ -49,6 +49,9 @@ use rdf_config::RdfConfigModel;
 use rudof_rdf::rdf_core::query::SparqlQuery;
 use shacl::ir::IRSchema;
 use shacl::validator::report::ValidationReport;
+use shex_ast::ir::external_resolver::{
+    ExternalResolverInfo, ExternalShapeResolverRegistry, available_external_resolvers, resolver_from_spec,
+};
 use shex_ast::ir::schema_ir::SchemaIR as ShExSchemaIR;
 use shex_ast::shapemap::{QueryShapeMap, ResultShapeMap};
 use shex_ast::{Schema as ShExSchema, ir::map_state::MapState};
@@ -158,6 +161,43 @@ impl Rudof {
     /// Returns a `ResetAllBuilder` that resets all runtime state in `Rudof`.
     pub fn reset_all<'a>(&'a mut self) -> ResetAllBuilder<'a> {
         ResetAllBuilder::new(self)
+    }
+
+    // ========================================================================
+    // External-shape resolver management
+    // ========================================================================
+
+    /// Register an external-shape resolver from a spec string.
+    ///
+    /// The spec follows the grammar `<kind>[:<arg>]`. Built-in kinds:
+    /// - `reject-all` — reject any EXTERNAL shape not handled by an earlier resolver.
+    /// - `schema:<path>` — substitute EXTERNAL shape declarations using a ShEx file at `<path>`.
+    ///
+    /// Resolvers are prepended to the chain, so the most recently added is consulted first.
+    /// Use [`Self::list_external_resolvers`] to enumerate the built-in kinds.
+    pub fn add_external_resolver(&mut self, spec: &str) -> Result<()> {
+        let resolver = resolver_from_spec(spec).map_err(|e| ShExError::InvalidExternalResolverSpec {
+            spec: spec.to_string(),
+            error: e.to_string(),
+        })?;
+        let vc = self.config.validator_config().with_external_resolver_arc(resolver);
+        self.config.set_validator_config(vc);
+        Ok(())
+    }
+
+    /// Reset the external-shape resolver chain to the default
+    /// (only `RejectAllExternalResolver`).
+    pub fn clear_external_resolvers(&mut self) {
+        let mut vc = self.config.validator_config();
+        vc.external_resolvers = ExternalShapeResolverRegistry::default();
+        self.config.set_validator_config(vc);
+    }
+
+    /// Enumerate the built-in external-shape resolver kinds. Each entry
+    /// describes a `name`, a one-line `description`, and the `spec_syntax`
+    /// accepted by [`Self::add_external_resolver`].
+    pub fn list_external_resolvers() -> Vec<ExternalResolverInfo> {
+        available_external_resolvers()
     }
 
     // ========================================================================

--- a/rudof_lib/src/rudof_config.rs
+++ b/rudof_lib/src/rudof_config.rs
@@ -141,6 +141,11 @@ impl RudofConfig {
         }
     }
 
+    /// Replace the ShEx validator configuration.
+    pub fn set_validator_config(&mut self, config: ValidatorConfig) {
+        self.shex_validator = Some(config);
+    }
+
     // ---------------------------------------------------------------------------
     // RDF data configuration
     // ---------------------------------------------------------------------------

--- a/rudof_mcp/src/service/resources/shex_validate_resources_impl.rs
+++ b/rudof_mcp/src/service/resources/shex_validate_resources_impl.rs
@@ -9,11 +9,14 @@
 //! - `rudof://formats/shex-validation-result` - ShEx validation result formats
 //! - `rudof://formats/validation-reader-modes` - Reader modes (strict/lax)
 //! - `rudof://formats/shex-validation-sort-options` - Result sort options
+//! - `rudof://shex/external-resolvers` - Available external-shape resolver kinds
 
 use rmcp::{
     ErrorData as McpError,
     model::{Annotated, RawResource, ReadResourceResult},
 };
+use rudof_lib::Rudof;
+use serde_json::json;
 
 use crate::service::resources::{json_resource_result, make_resource};
 use crate::service::tools::helpers::{
@@ -48,6 +51,12 @@ pub fn get_shex_validate_resources() -> Vec<Annotated<RawResource>> {
             "Available sort options for ShEx validation results",
             "application/json",
         ),
+        make_resource(
+            "rudof://shex/external-resolvers",
+            "Available External-Shape Resolvers",
+            "Built-in resolvers for ShEx EXTERNAL shape expressions",
+            "application/json",
+        ),
     ]
 }
 
@@ -61,6 +70,7 @@ pub fn handle_shex_validate_resource(uri: &str) -> Option<Result<ReadResourceRes
         "rudof://formats/shex-validation-result" => Some(get_shex_validation_result_formats(uri)),
         "rudof://formats/validation-reader-modes" => Some(get_reader_modes(uri)),
         "rudof://formats/shex-validation-sort-options" => Some(get_shex_validation_sort_options(uri)),
+        "rudof://shex/external-resolvers" => Some(get_external_resolvers(uri)),
         _ => None,
     }
 }
@@ -85,4 +95,23 @@ fn get_reader_modes(uri: &str) -> Result<ReadResourceResult, McpError> {
 fn get_shex_validation_sort_options(uri: &str) -> Result<ReadResourceResult, McpError> {
     let options = option_entries_json("sort_options", SHEX_VALIDATION_SORT_OPTION_ENTRIES, "node");
     json_resource_result(uri, &options)
+}
+
+/// Returns the list of built-in external-shape resolver kinds.
+///
+/// Clients pass entries from `resolvers[].spec_syntax` (substituting `<path>`
+/// where applicable) as the `external_resolvers` argument to `validate_shex`.
+fn get_external_resolvers(uri: &str) -> Result<ReadResourceResult, McpError> {
+    let resolvers: Vec<serde_json::Value> = Rudof::list_external_resolvers()
+        .into_iter()
+        .map(|info| {
+            json!({
+                "name": info.name,
+                "description": info.description,
+                "spec_syntax": info.spec_syntax,
+            })
+        })
+        .collect();
+    let body = json!({ "resolvers": resolvers });
+    json_resource_result(uri, &body)
 }

--- a/rudof_mcp/src/service/tools/shex_validate_tools_impl.rs
+++ b/rudof_mcp/src/service/tools/shex_validate_tools_impl.rs
@@ -67,6 +67,13 @@ pub struct ValidateShexRequest {
     /// false (default): bare "http://..." IRIs are auto-wrapped in "<>".
     /// true: bare IRIs cause a parse error — use "<http://...>" explicitly.
     pub strict_iris: Option<bool>,
+
+    /// External-shape resolver specs (applied in order, before schema loading).
+    /// Each entry follows the grammar `<kind>[:<arg>]`. Built-in kinds:
+    /// "reject-all" (rejects any unhandled EXTERNAL) and "schema:<path>"
+    /// (substitutes EXTERNAL declarations from a ShEx file). Read the
+    /// resource at `rudof://shex/external-resolvers` to enumerate.
+    pub external_resolvers: Option<Vec<String>>,
 }
 
 /// Response containing ShEx validation results.
@@ -109,6 +116,7 @@ pub async fn validate_shex_impl(
         result_format,
         sort_by,
         strict_iris,
+        external_resolvers,
     }): Parameters<ValidateShexRequest>,
 ) -> Result<CallToolResult, McpError> {
     let mut rudof = service.rudof.lock().await;
@@ -239,6 +247,21 @@ pub async fn validate_shex_impl(
             SHAPEMAP_FORMATS,
         )
         .into_call_tool_result());
+    }
+
+    // Register external-shape resolver specs before loading the schema so the
+    // compiler can apply them during AST→IR. Bad specs are reported as a tool
+    // execution error with a hint pointing to the resource that enumerates kinds.
+    if let Some(specs) = external_resolvers.as_ref() {
+        for spec in specs {
+            if let Err(e) = rudof.add_external_resolver(spec) {
+                return Ok(ToolExecutionError::with_hint(
+                    format!("Invalid external resolver spec '{}': {}", spec, e),
+                    "Read the rudof://shex/external-resolvers resource to enumerate valid kinds",
+                )
+                .into_call_tool_result());
+            }
+        }
     }
 
     let mut shex_schema_loading = rudof.load_shex_schema(&parsed_schema);

--- a/shex_ast/src/ir/ast2ir.rs
+++ b/shex_ast/src/ir/ast2ir.rs
@@ -1,5 +1,6 @@
 use super::node_constraint::NodeConstraint;
 use crate::ir::annotation::Annotation;
+use crate::ir::external_resolver::ExternalShapeResolverRegistry;
 use crate::ir::map_action_extension::MapActionExtension;
 use crate::ir::map_state::MapState;
 use crate::ir::object_value::ObjectValue;
@@ -74,7 +75,14 @@ impl AST2IR {
         source_iri: &IriS,
         base: &Option<IriS>,
         compiled_schema: &mut SchemaIR,
+        external_resolvers: &ExternalShapeResolverRegistry,
     ) -> CResult<()> {
+        // Apply the external-shape resolver registry to the root schema before any other
+        // processing. Imported schemas are rewritten as they are resolved inside
+        // `collect_imports_labels`. Cloning is necessary because `rewrite_ast` takes ownership;
+        // it is also cheap relative to the rest of compilation.
+        let rewritten_root = external_resolvers.rewrite_ast(schema_ast.clone());
+        let schema_ast = &rewritten_root;
         let mut visited = Vec::new();
         let mut imported_asts: Vec<(SchemaAST, IriS)> = Vec::new();
         /*trace!(
@@ -92,6 +100,7 @@ impl AST2IR {
             &mut visited,
             base,
             &mut imported_asts,
+            external_resolvers,
         )?;
         // Root schema prefixmap wins (imported schemas' prefix maps are scoped to their own file).
         compiled_schema.set_prefixmap(schema_ast.prefixmap());
@@ -127,6 +136,7 @@ impl AST2IR {
         visited_sources: &mut Vec<IriS>,
         base: &Option<IriS>,
         imported_asts: &mut Vec<(SchemaAST, IriS)>,
+        external_resolvers: &ExternalShapeResolverRegistry,
     ) -> CResult<()> {
         let imports = schema_ast
             .imports_resolved(base)
@@ -137,6 +147,9 @@ impl AST2IR {
                 visited_sources.push(import_iri.clone());
                 // For imported schemas, the base for dereferencing is the source IRI of the importer.
                 let imported_schema = self.resolve(&import_iri, Some(source_iri))?;
+                // Apply the external-resolver registry so EXTERNAL decls inside imported schemas are
+                // substituted before their labels are registered.
+                let imported_schema = external_resolvers.rewrite_ast(imported_schema);
                 // Spec: an imported schema must not declare startActs.
                 if imported_schema.start_actions().is_some() {
                     return Err(Box::new(SchemaIRError::ImportIriError {
@@ -152,6 +165,7 @@ impl AST2IR {
                     visited_sources,
                     &nested_base,
                     imported_asts,
+                    external_resolvers,
                 )?;
                 // Register labels of this imported schema. Per spec, the imported schema's
                 // `start` is ignored — only shape declarations contribute.

--- a/shex_ast/src/ir/external_resolver.rs
+++ b/shex_ast/src/ir/external_resolver.rs
@@ -238,6 +238,80 @@ pub enum ExternalResolverError {
 
     #[error("Could not parse external shapes file {path:?}: {error}")]
     Parse { path: std::path::PathBuf, error: String },
+
+    #[error("Unknown external resolver kind '{kind}'. Available kinds: {}", available.join(", "))]
+    UnknownKind { kind: String, available: Vec<String> },
+
+    #[error("External resolver kind '{kind}' requires an argument: {expected}")]
+    MissingArg { kind: String, expected: String },
+
+    #[error("External resolver kind '{kind}' does not accept any argument")]
+    ForbiddenArg { kind: String },
+}
+
+/// Static metadata describing a built-in external-shape resolver.
+///
+/// Returned by [`available_external_resolvers`] so that clients (CLI, MCP,
+/// Python) can enumerate the resolvers `rudof` knows how to construct from a
+/// spec string.
+#[derive(Debug, Clone)]
+pub struct ExternalResolverInfo {
+    /// Resolver kind identifier used in spec strings.
+    pub name: &'static str,
+    /// One-line human-readable description.
+    pub description: &'static str,
+    /// Spec-string syntax accepted by [`resolver_from_spec`].
+    pub spec_syntax: &'static str,
+}
+
+/// List of built-in resolver kinds recognised by [`resolver_from_spec`].
+pub fn available_external_resolvers() -> Vec<ExternalResolverInfo> {
+    vec![
+        ExternalResolverInfo {
+            name: "reject-all",
+            description: "Reject any EXTERNAL shape that no earlier resolver claimed",
+            spec_syntax: "reject-all",
+        },
+        ExternalResolverInfo {
+            name: "schema",
+            description: "Substitute EXTERNAL shape declarations using definitions from a ShEx file",
+            spec_syntax: "schema:<path>",
+        },
+    ]
+}
+
+/// Parse a resolver spec string of the form `<kind>[:<arg>]` and construct the
+/// corresponding [`ExternalShapeResolver`].
+///
+/// Recognised kinds (see [`available_external_resolvers`]):
+/// - `reject-all` — no argument; constructs a [`RejectAllExternalResolver`].
+/// - `schema:<path>` — argument is a filesystem path; constructs a
+///   [`SchemaExternalResolver`] loaded from that ShEx file.
+pub fn resolver_from_spec(spec: &str) -> Result<Arc<dyn ExternalShapeResolver>, ExternalResolverError> {
+    let (kind, arg) = match spec.split_once(':') {
+        Some((k, a)) => (k.trim(), Some(a.trim())),
+        None => (spec.trim(), None),
+    };
+    match (kind, arg) {
+        ("reject-all", None) => Ok(Arc::new(RejectAllExternalResolver)),
+        ("reject-all", Some(_)) => Err(ExternalResolverError::ForbiddenArg {
+            kind: "reject-all".to_string(),
+        }),
+        ("schema", Some(path)) if !path.is_empty() => {
+            Ok(Arc::new(SchemaExternalResolver::from_path(path)?))
+        },
+        ("schema", _) => Err(ExternalResolverError::MissingArg {
+            kind: "schema".to_string(),
+            expected: "path to a ShEx file".to_string(),
+        }),
+        (other, _) => Err(ExternalResolverError::UnknownKind {
+            kind: other.to_string(),
+            available: available_external_resolvers()
+                .into_iter()
+                .map(|i| i.name.to_string())
+                .collect(),
+        }),
+    }
 }
 
 #[cfg(test)]
@@ -314,6 +388,46 @@ mod tests {
 
         let decls = rewritten.shapes().unwrap();
         assert!(matches!(decls[0].shape_expr, ShapeExpr::External));
+    }
+
+    #[test]
+    fn spec_reject_all() {
+        let r = resolver_from_spec("reject-all").expect("parses");
+        assert_eq!(r.name(), "reject-all");
+    }
+
+    #[test]
+    fn spec_reject_all_with_arg_is_rejected() {
+        let err = resolver_from_spec("reject-all:foo").expect_err("forbidden arg");
+        assert!(matches!(err, ExternalResolverError::ForbiddenArg { .. }));
+    }
+
+    #[test]
+    fn spec_schema_missing_arg() {
+        let err = resolver_from_spec("schema").expect_err("needs arg");
+        assert!(matches!(err, ExternalResolverError::MissingArg { .. }));
+        let err = resolver_from_spec("schema:").expect_err("needs non-empty arg");
+        assert!(matches!(err, ExternalResolverError::MissingArg { .. }));
+    }
+
+    #[test]
+    fn spec_unknown_kind_reports_available() {
+        let err = resolver_from_spec("bogus").expect_err("unknown kind");
+        match err {
+            ExternalResolverError::UnknownKind { kind, available } => {
+                assert_eq!(kind, "bogus");
+                assert!(available.contains(&"reject-all".to_string()));
+                assert!(available.contains(&"schema".to_string()));
+            },
+            other => panic!("expected UnknownKind, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn available_lists_two_built_ins() {
+        let infos = available_external_resolvers();
+        let names: Vec<_> = infos.iter().map(|i| i.name).collect();
+        assert_eq!(names, vec!["reject-all", "schema"]);
     }
 
     #[test]

--- a/shex_ast/src/ir/external_resolver.rs
+++ b/shex_ast/src/ir/external_resolver.rs
@@ -297,9 +297,7 @@ pub fn resolver_from_spec(spec: &str) -> Result<Arc<dyn ExternalShapeResolver>, 
         ("reject-all", Some(_)) => Err(ExternalResolverError::ForbiddenArg {
             kind: "reject-all".to_string(),
         }),
-        ("schema", Some(path)) if !path.is_empty() => {
-            Ok(Arc::new(SchemaExternalResolver::from_path(path)?))
-        },
+        ("schema", Some(path)) if !path.is_empty() => Ok(Arc::new(SchemaExternalResolver::from_path(path)?)),
         ("schema", _) => Err(ExternalResolverError::MissingArg {
             kind: "schema".to_string(),
             expected: "path to a ShEx file".to_string(),

--- a/shex_ast/src/ir/schema_ir.rs
+++ b/shex_ast/src/ir/schema_ir.rs
@@ -781,8 +781,13 @@ mod tests {
         }"#;
         let schema_json: SchemaJson = serde_json::from_str::<SchemaJson>(str).unwrap();
         let mut ir = SchemaIR::new(SemanticActionsRegistry::default());
-        ir.populate_from_schema_json(&schema_json, &ExternalShapeResolverRegistry::default(), &ResolveMethod::default(), &None)
-            .unwrap();
+        ir.populate_from_schema_json(
+            &schema_json,
+            &ExternalShapeResolverRegistry::default(),
+            &ResolveMethod::default(),
+            &None,
+        )
+        .unwrap();
         println!("Schema IR: {ir}");
         let s1_label: ShapeLabel = ShapeLabel::iri(iri!("http://a.example/S1"));
         let s1 = ir
@@ -834,8 +839,13 @@ mod tests {
 }"#;
         let schema: SchemaJson = serde_json::from_str(str).unwrap();
         let mut ir = SchemaIR::new(SemanticActionsRegistry::default());
-        ir.populate_from_schema_json(&schema, &ExternalShapeResolverRegistry::default(), &ResolveMethod::default(), &None)
-            .unwrap();
+        ir.populate_from_schema_json(
+            &schema,
+            &ExternalShapeResolverRegistry::default(),
+            &ResolveMethod::default(),
+            &None,
+        )
+        .unwrap();
         println!("Schema IR: {ir}");
         let s: ShapeLabel = ShapeLabel::iri(iri!("http://example.org/S"));
         let idx = ir.get_shape_label_idx(&s).unwrap();
@@ -901,8 +911,13 @@ mod tests {
 }"#;
         let schema: SchemaJson = serde_json::from_str(str).unwrap();
         let mut ir = SchemaIR::new(SemanticActionsRegistry::default());
-        ir.populate_from_schema_json(&schema, &ExternalShapeResolverRegistry::default(), &ResolveMethod::default(), &None)
-            .unwrap();
+        ir.populate_from_schema_json(
+            &schema,
+            &ExternalShapeResolverRegistry::default(),
+            &ResolveMethod::default(),
+            &None,
+        )
+        .unwrap();
         let s: ShapeLabel = ShapeLabel::iri(iri!("http://example.org/S"));
         let idx = ir.get_shape_label_idx(&s).unwrap();
         println!("Schema IR: {ir}");

--- a/shex_ast/src/ir/schema_ir.rs
+++ b/shex_ast/src/ir/schema_ir.rs
@@ -1,6 +1,7 @@
 use super::dependency_graph::{DependencyGraph, PosNeg};
 use super::shape_expr::ShapeExpr;
 use super::shape_label::ShapeLabel;
+use crate::ir::external_resolver::ExternalShapeResolverRegistry;
 use crate::ir::inheritance_graph::InheritanceGraph;
 use crate::ir::map_state::MapState;
 use crate::ir::node_constraint::NodeConstraint;
@@ -270,6 +271,7 @@ impl SchemaIR {
     pub fn populate_from_schema_json(
         &mut self,
         schema_json: &SchemaJson,
+        external_resolvers: &ExternalShapeResolverRegistry,
         resolve_method: &ResolveMethod,
         base: &Option<IriS>,
     ) -> Result<()> {
@@ -278,7 +280,8 @@ impl SchemaIR {
         // same Arc<Mutex<MapState>> that callers can later read back via get_map_state_arc).
         let registry = self.semantic_actions_registry.clone();
         let mut compiler = AST2IR::with_registry(resolve_method, registry);
-        compiler.compile(schema_json, &schema_json.source_iri(), base, self)?;
+        // `AST2IR::compile` applies `external_resolvers` to the root and imported schemas.
+        compiler.compile(schema_json, &schema_json.source_iri(), base, self, external_resolvers)?;
         if let Some(base) = base {
             self.set_default_base_prefixes(base);
         }
@@ -750,6 +753,7 @@ mod tests {
     use rudof_iri::iri;
 
     use super::SchemaIR;
+    use crate::ir::external_resolver::ExternalShapeResolverRegistry;
     use crate::{
         Pred, ResolveMethod, ShapeLabelIdx,
         ast::Schema as SchemaJson,
@@ -777,7 +781,7 @@ mod tests {
         }"#;
         let schema_json: SchemaJson = serde_json::from_str::<SchemaJson>(str).unwrap();
         let mut ir = SchemaIR::new(SemanticActionsRegistry::default());
-        ir.populate_from_schema_json(&schema_json, &ResolveMethod::default(), &None)
+        ir.populate_from_schema_json(&schema_json, &ExternalShapeResolverRegistry::default(), &ResolveMethod::default(), &None)
             .unwrap();
         println!("Schema IR: {ir}");
         let s1_label: ShapeLabel = ShapeLabel::iri(iri!("http://a.example/S1"));
@@ -830,7 +834,7 @@ mod tests {
 }"#;
         let schema: SchemaJson = serde_json::from_str(str).unwrap();
         let mut ir = SchemaIR::new(SemanticActionsRegistry::default());
-        ir.populate_from_schema_json(&schema, &ResolveMethod::default(), &None)
+        ir.populate_from_schema_json(&schema, &ExternalShapeResolverRegistry::default(), &ResolveMethod::default(), &None)
             .unwrap();
         println!("Schema IR: {ir}");
         let s: ShapeLabel = ShapeLabel::iri(iri!("http://example.org/S"));
@@ -897,7 +901,7 @@ mod tests {
 }"#;
         let schema: SchemaJson = serde_json::from_str(str).unwrap();
         let mut ir = SchemaIR::new(SemanticActionsRegistry::default());
-        ir.populate_from_schema_json(&schema, &ResolveMethod::default(), &None)
+        ir.populate_from_schema_json(&schema, &ExternalShapeResolverRegistry::default(), &ResolveMethod::default(), &None)
             .unwrap();
         let s: ShapeLabel = ShapeLabel::iri(iri!("http://example.org/S"));
         let idx = ir.get_shape_label_idx(&s).unwrap();

--- a/shex_testsuite/src/manifest_validation.rs
+++ b/shex_testsuite/src/manifest_validation.rs
@@ -263,12 +263,10 @@ impl ValidationEntry {
         trace!("Entry action: {:?}", self.action);
 
         // If the test declares an externs schema (`shapeExterns`), load it as a
-        // `SchemaExternalResolver`, register it in the `ValidatorConfig`, and
-        // run the resolver registry's AST-rewrite pass before compilation. The
-        // default registry's `RejectAllExternalResolver` stays in place as the
-        // terminator for any unsubstituted EXTERNAL shapes.
+        // `SchemaExternalResolver` and register it in the `ValidatorConfig`. The
+        // compiler now applies the registry automatically; no manual rewrite is needed.
         let mut config = ValidatorConfig::default();
-        let schema = if let Some(externs_rel) = &self.action.shape_externs {
+        if let Some(externs_rel) = &self.action.shape_externs {
             let externs_path = folder.join(externs_rel);
             let resolver = SchemaExternalResolver::from_path(&externs_path).map_err(|error| {
                 ManifestError::ExternalResolverError {
@@ -277,10 +275,7 @@ impl ValidationEntry {
                 }
             })?;
             config = config.with_external_resolver(resolver);
-            config.external_resolvers().rewrite_ast(schema)
-        } else {
-            schema
-        };
+        }
 
         let mut map_state = MapState::default();
         let mut registry = SemanticActionsRegistry::default();
@@ -290,7 +285,13 @@ impl ValidationEntry {
         let base_iri = path_to_iri(&path_schema)?;
         trace!("Compiling schema, base: {base_iri}");
         compiler
-            .compile(&schema, &base_iri, &Some(base_iri.clone()), &mut compiled_schema)
+            .compile(
+                &schema,
+                &base_iri,
+                &Some(base_iri.clone()),
+                &mut compiled_schema,
+                config.external_resolvers(),
+            )
             .map_err(|e| Box::new(ManifestError::SchemaIRError(e)))?;
         let schema = compiled_schema.clone();
         let mut validator = Validator::new(&compiled_schema, &config).map_err(ManifestError::ValidationError)?;

--- a/shex_validation/tests/external_resolver_integration.rs
+++ b/shex_validation/tests/external_resolver_integration.rs
@@ -16,15 +16,22 @@ const DATA: &str = r#"<http://a.example/n1> <http://a.example/p1> <http://a.exam
 
 fn compile(schema_src: &str, config: &ValidatorConfig) -> SchemaIR {
     let base = IriS::new_unchecked("http://a.example/");
-    let mut ast = ShExParser::parse(schema_src, Some(base.clone()), &base).expect("parse main schema");
-    ast = config.external_resolvers().rewrite_ast(ast);
+    let ast = ShExParser::parse(schema_src, Some(base.clone()), &base).expect("parse main schema");
     let mut map_state = MapState::default();
     let mut registry = SemanticActionsRegistry::default();
     registry.set_map_state(&mut map_state);
     let mut compiler = AST2IR::new(&ResolveMethod::default(), map_state);
     let mut compiled = SchemaIR::new(registry);
+    // The compiler now applies the registry's `rewrite_ast` internally — no
+    // manual call needed.
     compiler
-        .compile(&ast, &base, &Some(base.clone()), &mut compiled)
+        .compile(
+            &ast,
+            &base,
+            &Some(base.clone()),
+            &mut compiled,
+            config.external_resolvers(),
+        )
         .expect("compile to IR");
     compiled
 }


### PR DESCRIPTION
### Why                                                                                                                                                               
   
#673 landed the resolver chain on `ValidatorConfig` but never wired it to anything users can reach. Every CLI, MCP, and Python invocation today gets the  default `RejectAllExternalResolver`, so any schema containing `EXTERNAL` fails immediately. In parallel, the AST rewriting step (which actually substitutes `EXTERNAL` declarations) had to be invoked manually before `AST2IR::compile` (meaning even Rust callers other than the testsuite couldn't use the feature without knowing that subtle pre-step).                                              

**This PR closes both gaps**:
- It makes the registry part of the compile pipeline (so callers never need to think about `rewrite_ast`).
- Surfaces a uniform spec-based selection API across all three clients with a discovery endpoint per client.

Closes #674 
                                                                                                                                                                        
### What changed                                                                                                                                                      

**Core (`shex_ast`)**                                                                                                                                                 
- New public items in `ir/external_resolver.rs`: `ExternalResolverInfo`, `available_external_resolvers()`, `resolver_from_spec()`. Spec grammar is `<kind>[:<arg>]`; built-in kinds are `reject-all` and `schema:<path>`.                                                                                                                  
- New error variants: `UnknownKind { kind, available }`, `MissingArg { kind, expected }`, `ForbiddenArg { kind }`.
- `SchemaIR::populate_from_schema_json` and `AST2IR::compile` now take `&ExternalShapeResolverRegistry`. `compile` applies `registry.rewrite_ast` to the root schema before processing and to each imported schema as it is resolved in `collect_imports_labels`. Callers no longer call `rewrite_ast` themselves.                         
   
**Cleanup of the manual rewrite**                                                                                                                                     
- `shex_testsuite/src/manifest_validation.rs`
- `shex_validation/tests/external_resolver_integration.rs`                                                                                                        
                                                                                                                                                                        
**`rudof_lib`**                                                                                                                                                       
- New `Rudof::add_external_resolver(spec)`, `Rudof::clear_external_resolvers()`, `Rudof::list_external_resolvers() -> Vec<ExternalResolverInfo>`.                                                                   
- `load_shex_schema` reads `validator_config().external_resolvers()` and threads it into `populate_from_schema_json`.                                                 
- New error variant `ShExError::InvalidExternalResolverSpec { spec, error }` for surface-area-friendly diagnostics.                                                   
                                                                                                                                                                        
**CLI (`rudof_cli`)**                                                                                                                                                 
- `--external-resolver <SPEC>`: repeatable, applied left-to-right before schema loading.                                                                             
- `--list-external-resolvers`: prints the built-in kinds; `--schema` is now `required_unless_present = "list_external_resolvers"`.
- The `validate` aggregator command was updated to wrap `schema` in `Some(...)` after the type change.                                                                
                                                                                                                                                                        
**MCP (`rudof_mcp`)**                                                                                                                                                 
- `ValidateShexRequest.external_resolvers: Option<Vec<String>>`: applied with `add_external_resolver` before the schema is loaded; bad specs return a `ToolExecutionError` pointing at the listing resource.                                                                                                                
- New read-only resource `rudof://shex/external-resolvers` returning the kind list as JSON. Implemented as a resource (not a tool) because the data is static reference, matching the pattern in `shex_validate_resources_impl.rs`.                                                                                                 
                                                                
**Python (`pyrudof`)**                                                                                                                                                
- `PyRudof.add_external_resolver(spec)`, `PyRudof.clear_external_resolvers()`.                                                                                        
- Staticmethod `PyRudof.list_external_resolvers()` returning `list[tuple[str, str, str]]` of `(name, description, spec_syntax)`.
                                                                                                                                                                        
**Examples + docs**                                           
- New `examples/person.shex` (declares `:Address EXTERNAL`), `examples/address.shex` (externs definition), `examples/person.ttl` (`:alice` complete, `:bob` missing `:city`).                                                                                                                                                             - `docs/src/cli_usage/shex_validate.md` got an "External-shape resolvers" section walking through the listing flag, the `schema:<path>` resolver, and the error message for invalid specs. The "Usage" block was refreshed to match the current `--help`.