### PR TITLE
 fix(shex_validation): implement ShEx EXTRA semantics (partition M^∈/M^∉ before RBE)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ python/docs/_build/
 
 # Nix flake build result
 result
+
+.codegraph/

--- a/shex_testsuite/tests/baseline_failing.txt
+++ b/shex_testsuite/tests/baseline_failing.txt
@@ -1,14 +1,6 @@
 1dot-relative_pass-relative-shape
 1dot-relative_pass-short-shape
 1dotNoCode3_pass
-1val1IRIREFClosedExtra1_pass-iri2
-1val1IRIREFExtra1Closed_pass-iri2
-1val1IRIREFExtra1One_pass-iri2
-1val1IRIREFExtra1_pass-iri2
-1val2IRIREFExtra1_pass-iri-bnode
-3Eachdot3Extra_pass-iri2
-3EachdotExtra3NLex_pass-iri2
-3EachdotExtra3_pass-iri2
 startCode1fail_abort
 startCode1startReffail_abort
 startCode3fail_abort

--- a/shex_validation/src/engine.rs
+++ b/shex_validation/src/engine.rs
@@ -615,15 +615,31 @@ impl Engine {
         R: QueryRDF + NeighsRDF,
     {
         // trace!("check_node_shape: node = {node}, shape = {idx} [No extends]");
-        let (values, reminder) = self.neighs(node, shape.preds(), rdf)?;
+        let extra_preds = shape.extra().clone();
+        let mut candidate_preds = shape.preds();
+        for p in &extra_preds {
+            if !candidate_preds.contains(p) {
+                candidate_preds.push(p.clone());
+            }
+        }
+        let (values, reminder) = self.neighs(node, candidate_preds.clone(), rdf)?;
         let values_ctx = values
             .iter()
             .map(|(p, v)| (p.clone(), v.clone(), SemanticActionContext::triple(node, p, v)))
+            .filter(|(pred, value, ctx)| {
+                // Strict predicates (not in EXTRA) always go into M^∈.
+                if !extra_preds.contains(pred) {
+                    return true;
+                }
+                // Lenient predicates (in EXTRA): only values that satisfy a leaf condition
+                // participate in the RBE; non-matching values fall into M^∉ and are ignored.
+                matches_any_leaf(shape.triple_expr(), pred, value, ctx)
+            })
             .collect::<Vec<_>>();
         if shape.is_closed() && !reminder.is_empty() {
             return fail(ValidatorError::ClosedShapeWithRemainderPreds {
                 remainder: Preds::new(reminder),
-                declared: Preds::new(shape.preds().into_iter().collect()),
+                declared: Preds::new(candidate_preds),
             });
         }
         check_expr_neigh(shape.triple_expr(), &values_ctx, node, shape, idx, typing)
@@ -642,12 +658,18 @@ impl Engine {
         R: NeighsRDF + QueryRDF,
     {
         // trace!("check_node_shape_extends: node={node}, shape={idx}");
-        let preds_extends = Vec::from_iter(schema.get_preds_extends(idx));
+        let extra_preds = shape.extra().clone();
+        let mut candidate_preds = Vec::from_iter(schema.get_preds_extends(idx));
+        for p in &extra_preds {
+            if !candidate_preds.contains(p) {
+                candidate_preds.push(p.clone());
+            }
+        }
         /*trace!(
             "Predicates in this shape with extends: [{}]",
-            preds_extends.iter().map(|p| p.to_string()).join(", ")
+            candidate_preds.iter().map(|p| p.to_string()).join(", ")
         );*/
-        let (values, reminder) = self.neighs(node, preds_extends, rdf)?;
+        let (values, reminder) = self.neighs(node, candidate_preds.clone(), rdf)?;
 
         if shape.is_closed() && !reminder.is_empty() {
             /*debug!(
@@ -656,7 +678,7 @@ impl Engine {
             );*/
             return fail(ValidatorError::ClosedShapeWithRemainderPreds {
                 remainder: Preds::new(reminder),
-                declared: Preds::new(shape.preds().into_iter().collect()),
+                declared: Preds::new(candidate_preds),
             });
         }
         /*if !reminder.is_empty() {
@@ -710,15 +732,21 @@ impl Engine {
         let values_ctx: Vec<_> = values_ctx_raw
             .into_iter()
             .filter(|(pred, value, ctx)| {
-                // Keep if the triple satisfies at least one leaf-bucket condition.
+                // Keep if the triple satisfies at least one leaf-bucket condition
+                // (conservatively: Ref conditions count as matching for M^∈ placement).
                 let matches_leaf = triple_exprs.values().any(|rbes| {
                     rbes.iter().any(|rbe| {
-                        rbe.components()
-                            .any(|(_, key, cond)| &key == pred && cond.matches(value, ctx).is_ok())
+                        rbe.components().any(|(_, key, cond)| {
+                            &key == pred && (cond_has_ref(&cond) || cond.matches(value, ctx).is_ok())
+                        })
                     })
                 });
                 if matches_leaf {
                     return true;
+                }
+                // EXTRA predicate with no satisfying leaf → goes into M^∉, exclude from partition.
+                if extra_preds.contains(pred) {
+                    return false;
                 }
                 // Triple is not needed by any leaf bucket.
                 // Keep it only if it is also NOT covered by any ancestor (case b: truly invalid).
@@ -1434,6 +1462,22 @@ fn cond_has_ref(cond: &MatchCond<Pred, Node, ShapeLabelIdx, SemanticActionContex
         MatchCond::And(vs) => vs.iter().any(cond_has_ref),
         MatchCond::Single(_) => false,
     }
+}
+
+/// Returns true if `(pred, value)` satisfies at least one leaf condition in `expr`.
+///
+/// For `MatchCond::Ref` leaves the value is kept in M^∈ conservatively — the RBE /
+/// pending-typing path already handles shape-reference validation correctly.
+fn matches_any_leaf(expr: &Expr, pred: &Pred, value: &Node, ctx: &SemanticActionContext) -> bool {
+    for (_, key, cond) in expr.components() {
+        if &key != pred {
+            continue;
+        }
+        if cond_has_ref(&cond) || cond.matches(value, ctx).is_ok() {
+            return true;
+        }
+    }
+    false
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Problem

`shape.extra()` was never consulted during validation. The engine fetched arcs only for the TE predicates (`shape.preds()`) and fed every arc to the RBE unconditionally. For a predicate listed in `EXTRA`, the RBE would see all arcs (including those whose value does not satisfy the value condition) and fail on cardinality. 8 tests from the shex_testsuite that should pass were failing.                                                                                     

## Solution                                                                                                                                                                     

Per ShEx specification, arcs are partitioned into M^∈ (fed to the RBE) and M^∉ (silently ignored) before matching. For predicates in `EXTRA`, only arcs that satisfy at least one leaf condition go into M^∈; the rest fall into M^∉.                                                                                           
   
**Changes in `shex_validation/src/engine.rs`:**                                                                                                                                 
                                                                    
- `check_node_shape`: widens the `neighs` call to `te ∪ extras`, filters the resulting arcs using a new `matches_any_leaf` helper, and fixes the `declared` set in the `CLOSED` error.                                                                                    
- `check_node_shape_extends`: same union and filter applied to the extends path; adds an early-exit branch in the existing triple filter for EXTRA predicates with no satisfying leaf. `MatchCond::Ref` leaves are treated conservatively (kept in M^∈) so shape-reference resolution is unaffected.                                                                                                                                                     
- Adds private helper `matches_any_leaf(expr, pred, value, ctx) -> bool`.
                                                                                                                                                                                  
## Test results                                                   

| | Before | After |
|---|---|---|
| Targeted tests (should pass) | 0 / 8 | **8 / 8** |
| Full suite failures | 14 | **6** (`−8`) |