### PR TITLE
fix(qlever): detect built index via the file QLever actually writes  

### DIFF
--- a/rudof_rdf/src/rdf_impl/qlever/index_builder.rs
+++ b/rudof_rdf/src/rdf_impl/qlever/index_builder.rs
@@ -53,8 +53,9 @@ impl IndexHandle {
 
     /// `true` if the index files already exist on disk (used to skip the indexing step on repeated runs).
     pub fn is_built(&self) -> bool {
-        // QLever writes a `<name>.meta` file at the very end of indexing, along with several `*.permutation` files.
-        self.dir.join(format!("{}.meta", self.name)).exists()
+        // QLever writes `<name>.meta-data.json` last, after every permutation and the vocabulary are flushed,
+        // so its presence is a reliable "indexing finished" marker.
+        self.dir.join(format!("{}.meta-data.json", self.name)).exists()
     }
 }
 
@@ -472,7 +473,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let handle = IndexHandle::new(tmp.path(), "default");
         assert!(!handle.is_built());
-        std::fs::write(tmp.path().join("default.meta"), b"").unwrap();
+        std::fs::write(tmp.path().join("default.meta-data.json"), b"{}").unwrap();
         assert!(handle.is_built());
     }
 }


### PR DESCRIPTION
`IndexHandle::is_built()` looked for `<name>.meta`, but QLever never writes that file (it writes per-permutation `<name>.index.*.meta` files plus `<name>.meta-data.json`). The check always returned `false`, so every `rudof … --backend qlever` invocation re-ran `IndexBuilderMain` instead of reusing the on-disk index.                                                                         
                                                                                                  
                                                                                                                                                                               
Verified: a second run against the same input now logs `QLever index already built at …` and skips straight to `ServerMain`. On the example file this halves wall-clock time (3.2s to 1.5s); on a Wikidata-truthy-sized index it's the difference between hours and seconds. 