### PR TITLE
feat(rudof_mcp): add Official MCP Registry publication metadata

### DIFF
--- a/rudof_cli/README.md
+++ b/rudof_cli/README.md
@@ -59,3 +59,11 @@ The CLI relies on the following external crates:
 - **`tabled`**: Table formatting for output
 - **`supports-color`**: Terminal color capability detection
 - **`clientele`**: CLI utility helpers
+
+## MCP Registry
+
+The `rudof` binary embeds an MCP (Model Context Protocol) server, invoked as `rudof mcp`, that exposes Rudof's RDF, ShEx, SHACL, and SPARQL capabilities to MCP-compatible clients. See the [`rudof_mcp` crate](https://crates.io/crates/rudof_mcp) for the full feature list.
+
+The line below is a verification token used by the [Official MCP Registry](https://registry.modelcontextprotocol.io) to prove that this crate is the package that backs the published server metadata. The registry parses the rendered crates.io README looking for a `mcp-name: <server-name>` token, and the value must exactly match the `name` field in the published `server.json`. Do not remove or modify it without coordinating a registry re-publish.
+
+- MCP Registry name: `mcp-name: io.github.rudof-project/rudof_mcp`

--- a/rudof_mcp/server.json
+++ b/rudof_mcp/server.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.rudof-project/rudof_mcp",
+  "title": "rudofMCP",
+  "description": "An MCP server exposing the main capabilities of the rudof library: RDF validation (ShEx and SHACL), SPARQL querying, and RDF data management (serialization conversion and visualization).",
+  "websiteUrl": "https://rudof-project.github.io/rudof",
+  "repository": {
+    "url": "https://github.com/rudof-project/rudof",
+    "source": "github",
+    "subfolder": "rudof_mcp"
+  },
+  "version": "0.3.4",
+  "packages": [
+    {
+      "registryType": "cargo",
+      "registryBaseUrl": "https://crates.io",
+      "identifier": "rudof_cli",
+      "version": "0.3.4",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        { "type": "positional", "value": "mcp"}
+      ],
+      "environmentVariables": [
+        {
+          "name": "PLANTUML",
+          "description": "Absolute path to plantuml.jar. Optional; only required by the export_image tool, which uses PlantUML to render RDF graph visualizations as SVG or PNG.",
+          "isRequired": false,
+          "format": "filepath"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds the metadata and documentation needed to list rudofMCP in the [Official MCP Registry](https://registry.modelcontextprotocol.io) under the namespace `io.github.rudof-project/rudof_mcp`.                                                                                                                                                
                                                                                                                                                                                      
### Changes                                                                                                                                                                                                                              
  - **`rudof_mcp/server.json`**: registry metadata.           
  - **`rudof_cli/README.md`**: `mcp-name: io.github.rudof-project/rudof_mcp` ownership-verification token required by the MCP Registry.
  
  
Issues: #699 #533 
                                                                                                                                                                                                                                                                                                                          