### PR TITLE
fix: Replaced independent tokio runtimes with a shared one

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dctap"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "calamine",
  "csv",
@@ -2096,7 +2096,7 @@ dependencies = [
 
 [[package]]
 name = "mie"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hashlink",
  "rudof_iri",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "pgschema"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "prefixmap"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "colored",
  "indexmap 2.13.0",
@@ -2907,7 +2907,7 @@ dependencies = [
 
 [[package]]
 name = "pyrudof"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "pyo3",
  "pythonize",
@@ -3134,7 +3134,7 @@ dependencies = [
 
 [[package]]
 name = "rbe"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "criterion",
  "hashbag",
@@ -3153,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "rbe_testsuite"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "indoc",
@@ -3166,7 +3166,7 @@ dependencies = [
 
 [[package]]
 name = "rdf_config"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "hashlink",
  "indexmap 2.13.0",
@@ -3377,7 +3377,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -3412,7 +3412,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_generate"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_iri"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "getrandom 0.3.4",
  "indexmap 2.13.0",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_lib"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "colored",
  "crossterm",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_mcp"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_rdf"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "bollard",
  "colored",
@@ -3990,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "shacl"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -4011,7 +4011,7 @@ dependencies = [
 
 [[package]]
 name = "shapes_comparator"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "prefixmap",
  "rudof_iri",
@@ -4028,7 +4028,7 @@ dependencies = [
 
 [[package]]
 name = "shapes_converter"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "chrono",
  "dctap",
@@ -4063,7 +4063,7 @@ dependencies = [
 
 [[package]]
 name = "shex_ast"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "colored",
  "const_format",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "shex_testsuite"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4112,7 +4112,7 @@ dependencies = [
 
 [[package]]
 name = "shex_validation"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "either",
  "indexmap 2.13.0",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "sparql_service"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "colored",
  "const_format",

--- a/rudof_rdf/src/rdf_impl/oxigraph/endpoint.rs
+++ b/rudof_rdf/src/rdf_impl/oxigraph/endpoint.rs
@@ -1,7 +1,7 @@
 use crate::{
     rdf_core::{
-        query::{QueryRDF, QueryResultFormat, QuerySolution, QuerySolutions, VarName}, Any, AsyncRDF, Matcher, NeighsRDF,
-        Rdf,
+        Any, AsyncRDF, Matcher, NeighsRDF, Rdf,
+        query::{QueryRDF, QueryResultFormat, QuerySolution, QuerySolutions, VarName},
     },
     rdf_impl::OxigraphEndpointError,
 };
@@ -12,9 +12,9 @@ use oxrdf::{
 };
 use prefixmap::PrefixMap;
 use regex::Regex;
-use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
+use reqwest::header::{ACCEPT, HeaderMap, HeaderValue, USER_AGENT};
 use rudof_iri::IriS;
-use serde::{ser::SerializeStruct, Serialize};
+use serde::{Serialize, ser::SerializeStruct};
 use sparesults::{
     QueryResultsFormat, QueryResultsParser, QuerySolution as OxQuerySolution, ReaderQueryResultsParserOutput,
 };

--- a/rudof_rdf/src/rdf_impl/oxigraph/endpoint.rs
+++ b/rudof_rdf/src/rdf_impl/oxigraph/endpoint.rs
@@ -716,7 +716,7 @@ async fn make_sparql_query_select_async(
 
     // Execute request and get response body
     let response = client.get(url).send().await?;
-    let body = response.text().await.unwrap();
+    let body = response.text().await?;
     parse_sparql_json_results(&body)
 }
 

--- a/rudof_rdf/src/rdf_impl/oxigraph/endpoint.rs
+++ b/rudof_rdf/src/rdf_impl/oxigraph/endpoint.rs
@@ -1,7 +1,7 @@
 use crate::{
     rdf_core::{
-        Any, AsyncRDF, Matcher, NeighsRDF, Rdf,
-        query::{QueryRDF, QueryResultFormat, QuerySolution, QuerySolutions, VarName},
+        query::{QueryRDF, QueryResultFormat, QuerySolution, QuerySolutions, VarName}, Any, AsyncRDF, Matcher, NeighsRDF,
+        Rdf,
     },
     rdf_impl::OxigraphEndpointError,
 };
@@ -12,9 +12,9 @@ use oxrdf::{
 };
 use prefixmap::PrefixMap;
 use regex::Regex;
-use reqwest::header::{ACCEPT, HeaderMap, HeaderValue, USER_AGENT};
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT};
 use rudof_iri::IriS;
-use serde::{Serialize, ser::SerializeStruct};
+use serde::{ser::SerializeStruct, Serialize};
 use sparesults::{
     QueryResultsFormat, QueryResultsParser, QuerySolution as OxQuerySolution, ReaderQueryResultsParserOutput,
 };
@@ -614,60 +614,40 @@ impl NeighsRDF for OxigraphEndpoint {
     }
 }
 
+// Shared tokio runtime used by the blocking SPARQL methods.
+#[cfg(not(target_family = "wasm"))]
+static SPARQL_RUNTIME: once_cell::sync::Lazy<tokio::runtime::Runtime> = once_cell::sync::Lazy::new(|| {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("rudof-sparql")
+        .build()
+        .expect("failed to build shared tokio runtime for SPARQL queries")
+});
+
 // QueryRDF is only available on non-WASM platforms.
-// On native platforms, these sync methods use tokio::runtime to run
-// the async implementations.
+// On native platforms, these sync methods bridge to the async implementations
+// through a shared tokio runtime (see `SPARQL_RUNTIME`).
 #[cfg(not(target_family = "wasm"))]
 impl QueryRDF for OxigraphEndpoint {
     /// Executes a SPARQL CONSTRUCT query synchronously.
     ///
     /// This is a blocking wrapper around `query_construct_async`.
-    /// It creates a tokio runtime to run the async method.
-    ///
-    /// # Performance Note
-    ///
-    /// Creates a new runtime for each call. For better performance in
-    /// async contexts, use `query_construct_async` directly.
     fn query_construct(&self, query: &str, format: &QueryResultFormat) -> Result<String> {
-        let runtime = tokio::runtime::Runtime::new().map_err(|e| OxigraphEndpointError::ParsingBody {
-            body: format!("Failed to create runtime: {}", e),
-        })?;
-
-        runtime.block_on(self.query_construct_async(query, format))
+        SPARQL_RUNTIME.block_on(self.query_construct_async(query, format))
     }
 
     /// Executes a SPARQL SELECT query synchronously.
     ///
     /// This is a blocking wrapper around `query_select_async`.
-    /// It creates a tokio runtime to run the async method.
-    ///
-    /// # Performance Note
-    ///
-    /// Creates a new runtime for each call. For better performance in
-    /// async contexts, use `query_select_async` directly.
     fn query_select(&self, query: &str) -> Result<QuerySolutions<Self>> {
-        let runtime = tokio::runtime::Runtime::new().map_err(|e| OxigraphEndpointError::ParsingBody {
-            body: format!("Failed to create runtime: {}", e),
-        })?;
-
-        runtime.block_on(self.query_select_async(query))
+        SPARQL_RUNTIME.block_on(self.query_select_async(query))
     }
 
     /// Executes a SPARQL ASK query synchronously.
     ///
     /// This is a blocking wrapper around `query_ask_async`.
-    /// It creates a tokio runtime to run the async method.
-    ///
-    /// # Performance Note
-    ///
-    /// Creates a new runtime for each call. For better performance in
-    /// async contexts, use `query_ask_async` directly.
     fn query_ask(&self, query: &str) -> Result<bool> {
-        let runtime = tokio::runtime::Runtime::new().map_err(|e| OxigraphEndpointError::ParsingBody {
-            body: format!("Failed to create runtime: {}", e),
-        })?;
-
-        runtime.block_on(self.query_ask_async(query))
+        SPARQL_RUNTIME.block_on(self.query_ask_async(query))
     }
 }
 


### PR DESCRIPTION
Executing thousands of SPARQL queries in a short period of time can make `rudof` fail with no apparent reason.

Building a fresh runtime per call leaves the shared `reqwest::Client`'s hyper connection pool in an inconsistent state: idle connections cached by a previous call's runtime are reused from a new runtime whose I/O driver can't service them, which surfaces as `hyper::Error(IncompleteMessage)`when the response body is read.