### PR TITLE
Raise an error when trying to validate with recursive shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ This ChangeLog follows the Keep a ChangeLog guidelines](https://keepachangelog.c
 ### Changed
 ### Removed
 
+## 0.3.7
+### Added
+### Fixed
+### Changed
+- Solves issue #721. Change the behaviour with recursive shapes in SHACL to give an error. 
+  In the future we should attempt recursive shapes with non-negative cycles and use least-fixpoint semantics as suggested in the paper.
+
+### Removed
+
 ## v0.3.6
 
 ### Fixed

--- a/shacl/src/ir/dg/mod.rs
+++ b/shacl/src/ir/dg/mod.rs
@@ -55,6 +55,11 @@ impl DependencyGraph {
         is_cyclic_directed(&self.graph)
     }
 
+    pub fn cycles(&self) -> Vec<Vec<ShapeLabelIdx>> {
+        let scc = tarjan_scc(&self.graph);
+        scc.into_iter().filter(|component| component.len() > 1).collect()
+    }
+
     pub fn has_neg_cycle(&self) -> bool {
         let neg_cycles = self.neg_cycles();
         !neg_cycles.is_empty()

--- a/shacl/src/ir/error.rs
+++ b/shacl/src/ir/error.rs
@@ -38,6 +38,12 @@ pub enum IRError {
 
     #[error(transparent)]
     RDFError(#[from] Box<RDFError>),
+
+    #[error("Dependency graph has cycles: {cycles:?}")]
+    DependencyGraphHasCycles { cycles: Vec<Vec<Object>> },
+
+    #[error("Dependency graph has negative cycles (non-stratified): {cycles:?}")]
+    DependencyGraphHasNegativeCycles { cycles: Vec<Vec<Object>> },
 }
 
 impl IRError {

--- a/shacl/src/ir/schema.rs
+++ b/shacl/src/ir/schema.rs
@@ -21,8 +21,9 @@ pub struct IRSchema {
     // imports: Vec<IriS>
     // entailments: Vec<IriS>
     labels_idx_map: HashMap<Object, ShapeLabelIdx>,
-
     shapes: HashMap<ShapeLabelIdx, IRShape>,
+    // This map is used to get the label from the index, but it is not used in the IRSchema itself. It is used in the IRShape to get the label of a shape from its index.
+    idx_labels_map: HashMap<ShapeLabelIdx, Object>,
     prefixmap: PrefixMap,
     base: Option<IriS>,
     dependency_graph: DependencyGraph,
@@ -33,6 +34,7 @@ impl IRSchema {
     pub fn new(prefixmap: PrefixMap) -> Self {
         Self {
             labels_idx_map: HashMap::new(),
+            idx_labels_map: HashMap::new(),
             shapes: HashMap::new(),
             prefixmap,
             base: None,
@@ -192,6 +194,7 @@ impl IRSchema {
             None => {
                 let label_idx = ShapeLabelIdx::new(self.get_next_idx());
                 self.labels_idx_map.insert(id.clone(), label_idx);
+                self.idx_labels_map.insert(label_idx, id.clone());
                 let compiled = IRShape::compile(shape, ast, self)?;
                 self.shapes.insert(label_idx, compiled);
                 Ok(label_idx)
@@ -220,12 +223,31 @@ impl IRSchema {
             warn!(
                 "More information about recursive schemas can be found at https://www.w3.org/TR/shacl/#shapes-recursion"
             );
-        }
-
-        if schema_ir.dependency_graph.has_neg_cycle() {
-            warn!(
-                "Warning: The dependency graph has negative cycles. This may lead to unexpected behavior in SHACL validation due to non-stratified negation"
-            );
+            let cycles: Vec<Vec<Object>> = schema_ir
+                .dependency_graph
+                .cycles()
+                .into_iter()
+                .map(|cycle| {
+                    cycle
+                        .into_iter()
+                        .map(|idx| {
+                            schema_ir.idx_labels_map.get(&idx).cloned().unwrap_or_else(|| {
+                                panic!(
+                                    "Internal error: Shape label index {idx} not found in idx_labels_map: {:?}",
+                                    schema_ir.idx_labels_map
+                                )
+                            })
+                        })
+                        .collect()
+                })
+                .collect();
+            if schema_ir.dependency_graph.has_neg_cycle() {
+                warn!(
+                    "Warning: The dependency graph has negative cycles. This may lead to unexpected behavior in SHACL validation due to non-stratified negation"
+                );
+                return Err(IRError::DependencyGraphHasNegativeCycles { cycles });
+            }
+            return Err(IRError::DependencyGraphHasCycles { cycles });
         }
 
         Ok(schema_ir)


### PR DESCRIPTION
Changed the behavour of rudof to raise an error when there are recursive shapes instead of trying to validate