### PR TITLE
Removed some noise of ShEx validation output

### DIFF
--- a/rudof_lib/src/api/shex/implementations/serialize_shex_validation_results.rs
+++ b/rudof_lib/src/api/shex/implementations/serialize_shex_validation_results.rs
@@ -20,8 +20,6 @@ pub fn serialize_shex_validation_results<W: io::Write>(
 
     match result_shex_validation_format {
         ResultShExValidationFormat::Compact => {
-            writeln!(writer, "Results:").map_err(|e| ShExError::FailedIoOperation { error: e.to_string() })?;
-
             shex_validation_results
                 .as_table(writer, Some(&sort_order.into()), Some(false), Some(terminal_width()))
                 .map_err(|e| ShExError::FailedSerializingShExValidationResults {
@@ -38,8 +36,6 @@ pub fn serialize_shex_validation_results<W: io::Write>(
                 })?;
         },
         ResultShExValidationFormat::Details => {
-            writeln!(writer, "Results:").map_err(|e| ShExError::FailedIoOperation { error: e.to_string() })?;
-
             shex_validation_results
                 .as_table(writer, Some(&sort_order.into()), Some(true), Some(terminal_width()))
                 .map_err(|e| ShExError::FailedSerializingShExValidationResults {
@@ -48,8 +44,6 @@ pub fn serialize_shex_validation_results<W: io::Write>(
                 })?;
         },
         ResultShExValidationFormat::Json => {
-            writeln!(writer, "Results:").map_err(|e| ShExError::FailedIoOperation { error: e.to_string() })?;
-
             let str = serde_json::to_string_pretty(&shex_validation_results).map_err(|e| {
                 ShExError::FailedSerializingShExValidationResults {
                     format: "json".to_string(),

--- a/rudof_lib/src/api/shex/implementations/tests/validate_shex_tests.rs
+++ b/rudof_lib/src/api/shex/implementations/tests/validate_shex_tests.rs
@@ -9,6 +9,7 @@ use crate::{
         DataFormat, InputSpec, ResultShExValidationFormat, ShExFormat, ShExValidationSortByMode, ShapeMapFormat,
     },
 };
+use regex::Regex;
 //use std::str::FromStr;
 
 /// Helper: serialize validation results to string
@@ -86,7 +87,9 @@ fn test_validate_shex_success() {
     let serialized =
         serialize_validation_results_to_string(&mut rudof, None, Some(ResultShExValidationFormat::Compact));
 
-    assert!(serialized.contains("Results"));
+    let re = Regex::new(r"(?m)^│\s+Node\s+│\s+Shape\s+│\s+Status\s+│$").unwrap();
+
+    assert!(re.is_match(&serialized));
 
     println!(
         "\n===== test_validate_shex_success =====\n{}============================================",
@@ -266,7 +269,9 @@ fn test_serialize_validation_results_compact() {
     let serialized =
         serialize_validation_results_to_string(&mut rudof, None, Some(ResultShExValidationFormat::Compact));
 
-    assert!(serialized.contains("Results"));
+    let re = Regex::new(r"(?m)^│\s+Node\s+│\s+Shape\s+│\s+Status\s+│$").unwrap();
+
+    assert!(re.is_match(&serialized));
 
     println!(
         "\n===== test_serialize_validation_results_compact =====\n{}============================================",
@@ -317,7 +322,6 @@ fn test_serialize_validation_results_json() {
     // Test JSON format
     let serialized = serialize_validation_results_to_string(&mut rudof, None, Some(ResultShExValidationFormat::Json));
 
-    assert!(serialized.contains("Results"));
     assert!(serialized.contains("{"));
     assert!(serialized.contains("}"));
 
@@ -423,7 +427,9 @@ fn test_serialize_validation_results_details() {
     let serialized =
         serialize_validation_results_to_string(&mut rudof, None, Some(ResultShExValidationFormat::Details));
 
-    assert!(serialized.contains("Results"));
+    let re = Regex::new(r"(?m)^│\s+Node\s+│\s+Shape\s+│\s+Status\s+│\s+Details\s+│$").unwrap();
+
+    assert!(re.is_match(&serialized));
 
     println!(
         "\n===== test_serialize_validation_results_details =====\n{}============================================",
@@ -496,7 +502,9 @@ fn test_validate_shex_multiple_nodes() {
     let serialized =
         serialize_validation_results_to_string(&mut rudof, None, Some(ResultShExValidationFormat::Compact));
 
-    assert!(serialized.contains("Results"));
+    let re = Regex::new(r"(?m)^│\s+Node\s+│\s+Shape\s+│\s+Status\s+│$").unwrap();
+
+    assert!(re.is_match(&serialized));
 
     println!(
         "\n===== test_validate_shex_multiple_nodes =====\n{}============================================",


### PR DESCRIPTION
Before, in some cases, the text "Results:" was printed alongside the ShEx validation results.
Now the results are just displayed.

Closes #731