### PR TITLE
fix: removed unnecessary trailing \n in ShEx validation reports

### DIFF
--- a/shex_validation/src/validator.rs
+++ b/shex_validation/src/validator.rs
@@ -356,21 +356,24 @@ fn show_reasons(reasons: &[Reason], nodes_prefixmap: &PrefixMap, schema: &Schema
     let mut result = String::new();
     match reasons.len() {
         0 => {
-            result.push_str("No detailed reason provided.\n");
+            result.push_str("No detailed reason provided.");
         },
         1 => {
             let str = reasons[0].show_qualified(nodes_prefixmap, schema, width)?;
-            result.push_str(&str);
+            result.push_str(str.trim_end_matches('\n'));
         },
         _ => {
             for (idx, reason) in reasons.iter().enumerate() {
                 result.push_str(
                     format!(
-                        "Reason #{idx}: {}\n",
-                        reason.show_qualified(nodes_prefixmap, schema, width)?
+                        "Reason #{idx}: {}",
+                        reason.show_qualified(nodes_prefixmap, schema, width)?.trim_end_matches('\n')
                     )
                     .as_str(),
                 );
+                if idx + 1 < reasons.len() {
+                    result.push('\n');
+                }
             }
         },
     }

--- a/shex_validation/src/validator.rs
+++ b/shex_validation/src/validator.rs
@@ -297,21 +297,24 @@ fn show_errors(
     let mut result = String::new();
     match errors.len() {
         0 => {
-            result.push_str("No detailed error provided.\n");
+            result.push_str("No detailed error provided.");
         },
         1 => {
             let str = errors[0].show_qualified(nodes_prefixmap, schema, width)?;
-            result.push_str(&str);
+            result.push_str(str.trim_end_matches('\n'));
         },
         _ => {
             for (idx, error) in errors.iter().enumerate() {
                 result.push_str(
                     format!(
-                        "Error #{idx}: {}\n",
-                        error.show_qualified(nodes_prefixmap, schema, width)?
+                        "Error #{idx}: {}",
+                        error.show_qualified(nodes_prefixmap, schema, width)?.trim_end_matches('\n')
                     )
                     .as_str(),
                 );
+                if idx + 1 < errors.len() {
+                    result.push('\n');
+                }
             }
         },
     }

--- a/shex_validation/src/validator.rs
+++ b/shex_validation/src/validator.rs
@@ -308,7 +308,9 @@ fn show_errors(
                 result.push_str(
                     format!(
                         "Error #{idx}: {}",
-                        error.show_qualified(nodes_prefixmap, schema, width)?.trim_end_matches('\n')
+                        error
+                            .show_qualified(nodes_prefixmap, schema, width)?
+                            .trim_end_matches('\n')
                     )
                     .as_str(),
                 );
@@ -367,7 +369,9 @@ fn show_reasons(reasons: &[Reason], nodes_prefixmap: &PrefixMap, schema: &Schema
                 result.push_str(
                     format!(
                         "Reason #{idx}: {}",
-                        reason.show_qualified(nodes_prefixmap, schema, width)?.trim_end_matches('\n')
+                        reason
+                            .show_qualified(nodes_prefixmap, schema, width)?
+                            .trim_end_matches('\n')
                     )
                     .as_str(),
                 );


### PR DESCRIPTION
Now, if there is only a single "comment" inside an `error` or `resason` field in a ShEx validation report, the trailing `\n` is removed