### PR TITLE
bench(shex): add validate_precompiled comparing ShExC parse vs .rsir cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bench-shex"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1117,7 +1117,7 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dctap"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "calamine",
  "csv",
@@ -1264,7 +1264,7 @@ dependencies = [
 
 [[package]]
 name = "emacs-rudof"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "emacs",
@@ -2357,7 +2357,7 @@ dependencies = [
 
 [[package]]
 name = "mie"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "hashlink",
  "rudof_iri",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "pgschema"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -2959,7 +2959,7 @@ dependencies = [
 
 [[package]]
 name = "prefixmap"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "colored",
  "indexmap 2.14.0",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "pyrudof"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "pyo3",
  "pythonize",
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "rbe"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bincode",
  "criterion",
@@ -3420,7 +3420,7 @@ dependencies = [
 
 [[package]]
 name = "rbe_testsuite"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "indoc",
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "rdf_config"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "hashlink",
  "indexmap 2.14.0",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_cli"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -3679,7 +3679,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_generate"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3707,7 +3707,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_iri"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "getrandom 0.3.4",
  "indexmap 2.14.0",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_lib"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "colored",
  "crossterm",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_mcp"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_rdf"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bollard",
  "colored",
@@ -4301,7 +4301,7 @@ dependencies = [
 
 [[package]]
 name = "shacl"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -4322,7 +4322,7 @@ dependencies = [
 
 [[package]]
 name = "shapes_comparator"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "prefixmap",
  "rudof_iri",
@@ -4339,7 +4339,7 @@ dependencies = [
 
 [[package]]
 name = "shapes_converter"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "chrono",
  "dctap",
@@ -4374,7 +4374,7 @@ dependencies = [
 
 [[package]]
 name = "shex_ast"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "bincode",
  "colored",
@@ -4404,7 +4404,7 @@ dependencies = [
 
 [[package]]
 name = "shex_testsuite"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -4424,7 +4424,7 @@ dependencies = [
 
 [[package]]
 name = "shex_validation"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "either",
  "indexmap 2.14.0",
@@ -4594,7 +4594,7 @@ dependencies = [
 
 [[package]]
 name = "sparql_service"
-version = "0.3.6"
+version = "0.3.7"
 dependencies = [
  "colored",
  "const_format",

--- a/benchmarks/bench-shex/Cargo.toml
+++ b/benchmarks/bench-shex/Cargo.toml
@@ -42,3 +42,7 @@ harness = false
 [[bench]]
 name = "end_to_end"
 harness = false
+
+[[bench]]
+name = "validate_precompiled"
+harness = false

--- a/benchmarks/bench-shex/README.md
+++ b/benchmarks/bench-shex/README.md
@@ -16,6 +16,7 @@ Each Criterion benchmark splits into two groups (`<stage>_small`, `<stage>_large
 | `validator_init` | IR to `Validator` (negation-cycle check)          |
 | `validate`       | Run validation                                    |
 | `end_to_end`     | Full `rudof_lib` flow: load → validate → serialize |
+| `validate_precompiled` | Same case, two variants: `from_source` (ShExC) vs `from_precompiled` (`.rsir` cache) |
 
 ## Running
 

--- a/benchmarks/bench-shex/benches/validate_precompiled.rs
+++ b/benchmarks/bench-shex/benches/validate_precompiled.rs
@@ -1,0 +1,141 @@
+use bench_shex::corpus::{self, Case, Size};
+use criterion::{BenchmarkId, Criterion};
+use rudof_lib::{
+    Rudof, RudofConfig,
+    formats::{DataFormat, DataReaderMode, InputSpec, ShExFormat, ShapeMapFormat},
+};
+use std::fs::File;
+use std::path::{Path, PathBuf};
+
+fn bench_validate_precompiled(c: &mut Criterion) {
+    let cases = corpus::load_all().expect("load corpus");
+    let config = RudofConfig::new();
+
+    for size in [Size::Small, Size::Large] {
+        let mut group = c.benchmark_group(format!("validate_precompiled_{}", size.tag()));
+        group.sample_size(20);
+        for case in cases.iter().filter(|c| c.size == size) {
+            let cache_path = match ensure_precompiled(case, &config) {
+                Ok(path) => path,
+                Err(err) => {
+                    eprintln!(
+                        "warning: skipping {} — precompiled cache round-trip failed: {err}",
+                        case.id
+                    );
+                    continue;
+                },
+            };
+
+            group.bench_with_input(
+                BenchmarkId::new("from_source", &case.id),
+                case,
+                |b, case| {
+                    b.iter(|| run_from_source(&config, case));
+                },
+            );
+
+            group.bench_with_input(
+                BenchmarkId::new("from_precompiled", &case.id),
+                &(case, cache_path.clone()),
+                |b, (case, cache_path)| {
+                    b.iter(|| run_from_precompiled(&config, case, cache_path));
+                },
+            );
+        }
+        group.finish();
+    }
+}
+
+fn run_from_source(config: &RudofConfig, case: &Case) {
+    let mut rudof = Rudof::new(config.clone());
+
+    rudof
+        .load_shex_schema(&InputSpec::path(&case.schema_path))
+        .with_base(case.base.as_str())
+        .with_shex_schema_format(&ShExFormat::ShExC)
+        .with_reader_mode(&DataReaderMode::Strict)
+        .execute()
+        .unwrap();
+
+    load_data_and_validate(&mut rudof, case);
+}
+
+fn run_from_precompiled(config: &RudofConfig, case: &Case, cache_path: &Path) {
+    let mut rudof = Rudof::new(config.clone());
+
+    rudof
+        .load_shex_schema_precompiled(&InputSpec::path(cache_path))
+        .with_reader_mode(&DataReaderMode::Strict)
+        .execute()
+        .unwrap();
+
+    load_data_and_validate(&mut rudof, case);
+}
+
+fn load_data_and_validate(rudof: &mut Rudof, case: &Case) {
+    rudof
+        .load_data()
+        .with_data(&[InputSpec::path(&case.data_path)])
+        .with_data_format(&DataFormat::Turtle)
+        .with_base(case.base.as_str())
+        .with_reader_mode(&DataReaderMode::Strict)
+        .execute()
+        .unwrap();
+
+    rudof
+        .load_shapemap(&InputSpec::path(&case.shapemap_path))
+        .with_shapemap_format(&ShapeMapFormat::Compact)
+        .execute()
+        .unwrap();
+
+    rudof.validate_shex().execute().unwrap();
+}
+
+/// Writes the precompiled `.rsir` for `case` under `bench-shex/corpus/precompiled/<size>/<case_id>.rsir` if it does not
+/// already exist, and verifies that it can be read back.
+fn ensure_precompiled(case: &Case, config: &RudofConfig) -> anyhow::Result<PathBuf> {
+    let cache_path = precompiled_path(case);
+
+    if !cache_path.exists() {
+        if let Some(parent) = cache_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        let mut rudof = Rudof::new(config.clone());
+        rudof
+            .load_shex_schema(&InputSpec::path(&case.schema_path))
+            .with_base(case.base.as_str())
+            .with_shex_schema_format(&ShExFormat::ShExC)
+            .with_reader_mode(&DataReaderMode::Strict)
+            .execute()?;
+
+        let mut writer = File::create(&cache_path)?;
+        rudof.compile_shex_schema_to_file(&mut writer).execute()?;
+    }
+
+    let mut probe = Rudof::new(config.clone());
+    probe
+        .load_shex_schema_precompiled(&InputSpec::path(&cache_path))
+        .with_reader_mode(&DataReaderMode::Strict)
+        .execute()?;
+
+    Ok(cache_path)
+}
+
+fn precompiled_path(case: &Case) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("corpus")
+        .join("precompiled")
+        .join(case.size.tag())
+        .join(format!("{}.rsir", sanitize(&case.id)))
+}
+
+/// Case ids may contain characters that are awkward in file names (slashes, spaces). Fold them to `_` so a case id maps to exactly one cache file.
+fn sanitize(id: &str) -> String {
+    id.chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' { c } else { '_' })
+        .collect()
+}
+
+criterion::criterion_group!(benches, bench_validate_precompiled);
+criterion::criterion_main!(benches);

--- a/benchmarks/bench-shex/benches/validate_precompiled.rs
+++ b/benchmarks/bench-shex/benches/validate_precompiled.rs
@@ -26,13 +26,9 @@ fn bench_validate_precompiled(c: &mut Criterion) {
                 },
             };
 
-            group.bench_with_input(
-                BenchmarkId::new("from_source", &case.id),
-                case,
-                |b, case| {
-                    b.iter(|| run_from_source(&config, case));
-                },
-            );
+            group.bench_with_input(BenchmarkId::new("from_source", &case.id), case, |b, case| {
+                b.iter(|| run_from_source(&config, case));
+            });
 
             group.bench_with_input(
                 BenchmarkId::new("from_precompiled", &case.id),
@@ -133,7 +129,13 @@ fn precompiled_path(case: &Case) -> PathBuf {
 /// Case ids may contain characters that are awkward in file names (slashes, spaces). Fold them to `_` so a case id maps to exactly one cache file.
 fn sanitize(id: &str) -> String {
     id.chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' { c } else { '_' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
         .collect()
 }
 

--- a/benchmarks/bench-shex/corpus/precompiled/.gitignore
+++ b/benchmarks/bench-shex/corpus/precompiled/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/rudof_rdf/src/rdf_core/term/literal/numeric_literal.rs
+++ b/rudof_rdf/src/rdf_core/term/literal/numeric_literal.rs
@@ -1,5 +1,6 @@
 use core::fmt;
 use std::fmt::Display;
+use std::str::FromStr;
 
 use crate::rdf_core::RDFError;
 use crate::rdf_core::vocabs::XsdVocab;
@@ -7,16 +8,14 @@ use rust_decimal::{
     Decimal,
     prelude::{FromPrimitive, ToPrimitive},
 };
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::hash::Hash;
 
 /// Represents RDF numeric literals with XSD datatype semantics.
 ///
 /// This enum supports all XSD numeric types and provides type-safe
-/// conversions between them. Uses `#[serde(untagged)]` for flexible
-/// deserialization from JSON/other formats.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(untagged)]
+/// conversions between them.
+#[derive(Debug, Clone)]
 pub enum NumericLiteral {
     Integer(i128),
     Byte(i8),
@@ -453,12 +452,14 @@ impl Hash for NumericLiteral {
     }
 }
 
-/// Custom serialization to preserve numeric types in target format.
 impl Serialize for NumericLiteral {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
+        if !serializer.is_human_readable() {
+            return NumericLiteralTagged::from(self).serialize(serializer);
+        }
         match self {
             NumericLiteral::Integer(n) => serializer.serialize_i128(*n),
             NumericLiteral::Decimal(d) => {
@@ -482,6 +483,132 @@ impl Serialize for NumericLiteral {
             NumericLiteral::NegativeInteger(n) => serializer.serialize_i128(*n),
             NumericLiteral::NonPositiveInteger(n) => serializer.serialize_i128(*n),
         }
+    }
+}
+
+/// Deserialize dispatches on the format kind:
+///   * human-readable - untagged behaviour (any scalar → best-fit variant),
+///   * binary - tagged mirror enum with a lossless representation.
+impl<'de> Deserialize<'de> for NumericLiteral {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if deserializer.is_human_readable() {
+            NumericLiteralUntagged::deserialize(deserializer).map(Into::into)
+        } else {
+            NumericLiteralTagged::deserialize(deserializer)
+                .and_then(|t| NumericLiteral::try_from(t).map_err(serde::de::Error::custom))
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum NumericLiteralUntagged {
+    Integer(i128),
+    Byte(i8),
+    Short(i16),
+    NonNegativeInteger(u128),
+    UnsignedLong(u64),
+    UnsignedInt(u32),
+    UnsignedShort(u16),
+    UnsignedByte(u8),
+    PositiveInteger(u128),
+    NegativeInteger(i128),
+    NonPositiveInteger(i128),
+    Long(i64),
+    Decimal(Decimal),
+    Double(f64),
+    Float(f32),
+}
+
+impl From<NumericLiteralUntagged> for NumericLiteral {
+    fn from(u: NumericLiteralUntagged) -> Self {
+        match u {
+            NumericLiteralUntagged::Integer(n) => NumericLiteral::Integer(n),
+            NumericLiteralUntagged::Byte(n) => NumericLiteral::Byte(n),
+            NumericLiteralUntagged::Short(n) => NumericLiteral::Short(n),
+            NumericLiteralUntagged::NonNegativeInteger(n) => NumericLiteral::NonNegativeInteger(n),
+            NumericLiteralUntagged::UnsignedLong(n) => NumericLiteral::UnsignedLong(n),
+            NumericLiteralUntagged::UnsignedInt(n) => NumericLiteral::UnsignedInt(n),
+            NumericLiteralUntagged::UnsignedShort(n) => NumericLiteral::UnsignedShort(n),
+            NumericLiteralUntagged::UnsignedByte(n) => NumericLiteral::UnsignedByte(n),
+            NumericLiteralUntagged::PositiveInteger(n) => NumericLiteral::PositiveInteger(n),
+            NumericLiteralUntagged::NegativeInteger(n) => NumericLiteral::NegativeInteger(n),
+            NumericLiteralUntagged::NonPositiveInteger(n) => NumericLiteral::NonPositiveInteger(n),
+            NumericLiteralUntagged::Long(n) => NumericLiteral::Long(n),
+            NumericLiteralUntagged::Decimal(d) => NumericLiteral::Decimal(d),
+            NumericLiteralUntagged::Double(d) => NumericLiteral::Double(d),
+            NumericLiteralUntagged::Float(f) => NumericLiteral::Float(f),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+enum NumericLiteralTagged {
+    Integer(i128),
+    Byte(i8),
+    Short(i16),
+    NonNegativeInteger(u128),
+    UnsignedLong(u64),
+    UnsignedInt(u32),
+    UnsignedShort(u16),
+    UnsignedByte(u8),
+    PositiveInteger(u128),
+    NegativeInteger(i128),
+    NonPositiveInteger(i128),
+    Long(i64),
+    Decimal(String),
+    Double(f64),
+    Float(f32),
+}
+
+impl From<&NumericLiteral> for NumericLiteralTagged {
+    fn from(n: &NumericLiteral) -> Self {
+        match n {
+            NumericLiteral::Integer(n) => NumericLiteralTagged::Integer(*n),
+            NumericLiteral::Byte(n) => NumericLiteralTagged::Byte(*n),
+            NumericLiteral::Short(n) => NumericLiteralTagged::Short(*n),
+            NumericLiteral::NonNegativeInteger(n) => NumericLiteralTagged::NonNegativeInteger(*n),
+            NumericLiteral::UnsignedLong(n) => NumericLiteralTagged::UnsignedLong(*n),
+            NumericLiteral::UnsignedInt(n) => NumericLiteralTagged::UnsignedInt(*n),
+            NumericLiteral::UnsignedShort(n) => NumericLiteralTagged::UnsignedShort(*n),
+            NumericLiteral::UnsignedByte(n) => NumericLiteralTagged::UnsignedByte(*n),
+            NumericLiteral::PositiveInteger(n) => NumericLiteralTagged::PositiveInteger(*n),
+            NumericLiteral::NegativeInteger(n) => NumericLiteralTagged::NegativeInteger(*n),
+            NumericLiteral::NonPositiveInteger(n) => NumericLiteralTagged::NonPositiveInteger(*n),
+            NumericLiteral::Long(n) => NumericLiteralTagged::Long(*n),
+            NumericLiteral::Decimal(d) => NumericLiteralTagged::Decimal(d.to_string()),
+            NumericLiteral::Double(d) => NumericLiteralTagged::Double(*d),
+            NumericLiteral::Float(f) => NumericLiteralTagged::Float(*f),
+        }
+    }
+}
+
+impl TryFrom<NumericLiteralTagged> for NumericLiteral {
+    type Error = String;
+
+    fn try_from(t: NumericLiteralTagged) -> Result<Self, Self::Error> {
+        Ok(match t {
+            NumericLiteralTagged::Integer(n) => NumericLiteral::Integer(n),
+            NumericLiteralTagged::Byte(n) => NumericLiteral::Byte(n),
+            NumericLiteralTagged::Short(n) => NumericLiteral::Short(n),
+            NumericLiteralTagged::NonNegativeInteger(n) => NumericLiteral::NonNegativeInteger(n),
+            NumericLiteralTagged::UnsignedLong(n) => NumericLiteral::UnsignedLong(n),
+            NumericLiteralTagged::UnsignedInt(n) => NumericLiteral::UnsignedInt(n),
+            NumericLiteralTagged::UnsignedShort(n) => NumericLiteral::UnsignedShort(n),
+            NumericLiteralTagged::UnsignedByte(n) => NumericLiteral::UnsignedByte(n),
+            NumericLiteralTagged::PositiveInteger(n) => NumericLiteral::PositiveInteger(n),
+            NumericLiteralTagged::NegativeInteger(n) => NumericLiteral::NegativeInteger(n),
+            NumericLiteralTagged::NonPositiveInteger(n) => NumericLiteral::NonPositiveInteger(n),
+            NumericLiteralTagged::Long(n) => NumericLiteral::Long(n),
+            NumericLiteralTagged::Decimal(s) => Decimal::from_str(&s)
+                .map(NumericLiteral::Decimal)
+                .map_err(|e| format!("decoding NumericLiteral::Decimal(\"{s}\"): {e}"))?,
+            NumericLiteralTagged::Double(d) => NumericLiteral::Double(d),
+            NumericLiteralTagged::Float(f) => NumericLiteral::Float(f),
+        })
     }
 }
 

--- a/shex_ast/src/ir/schema_ir.rs
+++ b/shex_ast/src/ir/schema_ir.rs
@@ -1225,6 +1225,49 @@ mod tests {
         .expect("SchemaIR::read");
     }
 
+    /// Regression: schemas with numeric facets (`MININCLUSIVE`, `MAXEXCLUSIVE`, …) embed a
+    /// `NumericLiteral` in `CondKind`. Its `Deserialize` impl must be compatible with
+    /// non-self-describing formats like bincode; otherwise the cache round-trip fails with
+    /// `Serde(AnyNotSupported)` for real-world schemas that use XSD numeric bounds
+    /// (e.g. FHIR-R5).
+    #[test]
+    fn schema_ir_cache_round_trip_with_numeric_facets() {
+        use crate::compact::shex_parser::ShExParser;
+        use crate::ir::cache::{CacheFormat, CacheReaderMode};
+        use rudof_iri::IriS;
+        use std::io::Cursor;
+
+        let shexc = r#"prefix : <http://example.org/>
+prefix xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:S {
+  :age xsd:integer MININCLUSIVE 0 MAXINCLUSIVE 150 ;
+  :ratio xsd:decimal MINEXCLUSIVE 0.0 ;
+}
+"#;
+        let base = IriS::new_unchecked("file:///tmp/numeric_facets.shex");
+        let schema = ShExParser::parse(shexc, Some(base.clone()), &base).expect("parse ShExC");
+
+        let mut ir = SchemaIR::new(SemanticActionsRegistry::default());
+        ir.populate_from_schema_json(
+            &schema,
+            &ExternalShapeResolverRegistry::default(),
+            &ResolveMethod::default(),
+            &Some(base),
+        )
+        .expect("populate IR from ShExC-parsed schema");
+
+        let mut buf = Vec::new();
+        ir.write(&mut buf, CacheFormat::Bincode).expect("SchemaIR::write");
+
+        let _restored = SchemaIR::read(
+            Cursor::new(buf),
+            SemanticActionsRegistry::default(),
+            CacheReaderMode::Strict,
+        )
+        .expect("SchemaIR::read must round-trip schemas with numeric facets");
+    }
+
     #[test]
     fn schema_ir_cache_rejects_non_cache_input() {
         use crate::ir::cache::CacheReaderMode;


### PR DESCRIPTION
- Adds a `validate_precompiled` Criterion bench in `benchmarks/bench-shex/` comparing `load_shex_schema` (ShExC parse) vs `load_shex_schema_precompiled` (bincode `.rsir` cache) on the same cases, with committed `.rsir` artifacts under `corpus/precompiled/` (small cases + FHIR-R5).
- Fix `NumericLiteral`'s serde: the untagged `Deserialize` broke the bincode round-trip on schemas with XSD numeric facets; now split by format kind (human-readable stays untagged; binary uses a tagged mirror enum), with a `SchemaIR` regression test covering the round-trip. 