### PR TITLE
fix(shex-ast): prevent stack overflow on cyclic extends solving issue #739

### DIFF
--- a/shex_ast/src/ir/shape.rs
+++ b/shex_ast/src/ir/shape.rs
@@ -6,7 +6,10 @@ use super::{
 use crate::{Expr, Pred, ShapeLabelIdx, ir::schema_ir::SchemaIR};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt::Display};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Display,
+};
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Shape {
@@ -57,12 +60,27 @@ impl Shape {
 
     /// Get the references in this shape expression.
     pub fn references(&self, schema: &SchemaIR) -> HashMap<Pred, Vec<ShapeLabelIdx>> {
+        let mut visited = HashSet::new();
+        self.references_visited(schema, &mut visited)
+    }
+
+    /// Like [`Self::references`] but threads a `visited` set through the traversal so
+    /// that cycles through `extends` (or through references reached from them) terminate
+    /// instead of recursing forever.
+    pub(crate) fn references_visited(
+        &self,
+        schema: &SchemaIR,
+        visited: &mut HashSet<ShapeLabelIdx>,
+    ) -> HashMap<Pred, Vec<ShapeLabelIdx>> {
         let mut result = self.get_value_expr_references();
         for e in &self.extends {
-            let info = schema.find_shape_idx(e).unwrap();
-            let refs = info.expr().references(schema);
-            for (p, v) in refs {
-                result.entry(p).or_default().extend(v);
+            if visited.insert(*e)
+                && let Some(info) = schema.find_shape_idx(e)
+            {
+                let refs = info.expr().references_visited(schema, visited);
+                for (p, v) in refs {
+                    result.entry(p).or_default().extend(v);
+                }
             }
         }
         result

--- a/shex_ast/src/ir/shape_expr.rs
+++ b/shex_ast/src/ir/shape_expr.rs
@@ -83,38 +83,52 @@ impl ShapeExpr {
         self.references_visited(schema, &mut visited)
     }
 
-    fn references_visited(
+    pub(crate) fn references_visited(
         &self,
         schema: &SchemaIR,
         visited: &mut HashSet<ShapeLabelIdx>,
     ) -> HashMap<Pred, Vec<ShapeLabelIdx>> {
         match self {
             ShapeExpr::ShapeOr { exprs, .. } => exprs.iter().fold(HashMap::new(), |mut acc, expr| {
-                let refs = schema
-                    .find_shape_idx(expr)
-                    .map(|info| info.expr().references_visited(schema, visited))
-                    .unwrap_or_default();
+                let refs = if visited.insert(*expr) {
+                    schema
+                        .find_shape_idx(expr)
+                        .map(|info| info.expr().references_visited(schema, visited))
+                        .unwrap_or_default()
+                } else {
+                    HashMap::new()
+                };
                 for (p, v) in refs {
                     acc.entry(p).or_default().extend(v);
                 }
                 acc
             }),
             ShapeExpr::ShapeAnd { exprs, .. } => exprs.iter().fold(HashMap::new(), |mut acc, expr| {
-                let refs = schema
-                    .find_shape_idx(expr)
-                    .map(|info| info.expr().references_visited(schema, visited))
-                    .unwrap_or_default();
+                let refs = if visited.insert(*expr) {
+                    schema
+                        .find_shape_idx(expr)
+                        .map(|info| info.expr().references_visited(schema, visited))
+                        .unwrap_or_default()
+                } else {
+                    HashMap::new()
+                };
                 for (p, v) in refs {
                     acc.entry(p).or_default().extend(v);
                 }
                 acc
             }),
-            ShapeExpr::ShapeNot { expr, .. } => schema
-                .find_shape_idx(expr)
-                .map(|info| info.expr().references_visited(schema, visited))
-                .unwrap_or_default(),
+            ShapeExpr::ShapeNot { expr, .. } => {
+                if visited.insert(*expr) {
+                    schema
+                        .find_shape_idx(expr)
+                        .map(|info| info.expr().references_visited(schema, visited))
+                        .unwrap_or_default()
+                } else {
+                    HashMap::new()
+                }
+            },
             ShapeExpr::NodeConstraint(_nc) => HashMap::new(),
-            ShapeExpr::Shape(s) => s.references(schema).clone(),
+            ShapeExpr::Shape(s) => s.references_visited(schema, visited),
             ShapeExpr::External {} => HashMap::new(),
             ShapeExpr::Ref { idx } => {
                 let mut map = HashMap::new();


### PR DESCRIPTION
Solves issue #739 
Shape::references() reset its `visited` set on every call, and the ShapeOr/ShapeAnd/ShapeNot arms of ShapeExpr::references_visited never populated `visited` before recursing. Cyclic `extends` chains (common in FHIR schemas) caused infinite recursion. Thread the visited set through Shape::references_visited and guard all recursive arms.