### PR TITLE
refactor(shex): replace bincode with postcard for SchemaIR cache serialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,6 +215,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,26 +333,6 @@ dependencies = [
  "toml",
  "walkdir",
  "zip 2.4.2",
-]
-
-[[package]]
-name = "bincode"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36eaf5d7b090263e8150820482d5d93cd964a81e4019913c972f4edcc6edb740"
-dependencies = [
- "bincode_derive",
- "serde",
- "unty",
-]
-
-[[package]]
-name = "bincode_derive"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
-dependencies = [
- "virtue",
 ]
 
 [[package]]
@@ -772,6 +761,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "codepage"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -937,6 +935,12 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-deque"
@@ -1312,6 +1316,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "288020fbdb901ce8d3f1dcaa6be8876fd14291ee664136bd1b29fcdb1d99777a"
 
 [[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1653,6 +1669,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbag"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1695,6 +1720,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
 dependencies = [
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version 0.4.1",
+ "serde",
+ "spin",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2980,6 +3019,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,7 +3499,6 @@ dependencies = [
 name = "rbe"
 version = "0.3.7"
 dependencies = [
- "bincode",
  "criterion",
  "either",
  "hashbag",
@@ -4453,7 +4504,6 @@ dependencies = [
 name = "shex_ast"
 version = "0.3.7"
 dependencies = [
- "bincode",
  "colored",
  "const_format",
  "csv",
@@ -4463,6 +4513,7 @@ dependencies = [
  "nom_locate",
  "oxrdf",
  "petgraph 0.8.3",
+ "postcard",
  "prefixmap",
  "pretty",
  "rbe",
@@ -4694,6 +4745,15 @@ dependencies = [
  "thiserror 2.0.18",
  "toml",
  "tracing",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -5416,12 +5476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
-name = "unty"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d49784317cd0d1ee7ec5c716dd598ec5b4483ea832a2dced265471cc0f690ae"
-
-[[package]]
 name = "ureq"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5501,12 +5555,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "virtue"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051eb1abcf10076295e815102942cc58f9d5e3b4560e46e53c21e8ff6f3af7b1"
 
 [[package]]
 name = "vte"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,7 +251,6 @@ anyhow = "1.0"
 axum = "0.8.4"
 axum-server = "0.7"
 base64 = "0.22.1"
-bincode = {version = "2.0", features = ["serde"]}
 calamine = { version = "0.31" }
 chrono = { version = "0.4", features = ["serde"] }
 criterion = { version = "0.5", features = ["html_reports"] }
@@ -300,6 +299,7 @@ oxttl = { version = "0.2.0", features = ["rdf-12"] }
 paste = "1.0.15"
 pgschema = { version = "0.3.7", path = "./pgschema" }
 petgraph = { version = "0.8", features = ["serde-1"] }
+postcard = { version = "1", features = ["use-std"] }
 prefixmap = { version = "0.3.7", path = "./prefixmap" }
 pretty = { version = "0.12" }
 proptest = { version = "1.11.0", default-features = false, features = ["std", "bit-set"] }

--- a/docs/src/using-rudof/precompiled-shex-schemas.md
+++ b/docs/src/using-rudof/precompiled-shex-schemas.md
@@ -34,9 +34,9 @@ rudof shex --schema examples/user.shex --compile-to user.ircache
 `rudof` loads the schema exactly as it would for validation
 and writes the resulting `SchemaIR` to `user.ircache`. The file is a pure
 binary artefact: it starts with the magic bytes `RSIR`, followed by an on-disk
-envelope version, a length-prefixed [bincode](https://docs.rs/bincode)
+envelope version, a length-prefixed [postcard](https://docs.rs/postcard)
 header (body format, `rudof` version, negation-cycle flag), and the
-bincode-encoded `SchemaIR` body. Because the file is not text, do not open it in
+postcard-encoded `SchemaIR` body. Because the file is not text, do not open it in
 editors that may rewrite line endings or normalise encoding.
 
 You can also compile as a side-effect of a validation run:

--- a/rbe/Cargo.toml
+++ b/rbe/Cargo.toml
@@ -22,7 +22,6 @@ toml.workspace = true
 tracing = { workspace = true }
 
 [dev-dependencies]
-bincode.workspace = true
 indoc.workspace = true
 proptest.workspace = true
 tracing-test.workspace = true

--- a/rudof_lib/src/api/shex/implementations/compile_shex_schema_to_file.rs
+++ b/rudof_lib/src/api/shex/implementations/compile_shex_schema_to_file.rs
@@ -8,7 +8,7 @@ pub fn compile_shex_schema_to_file<W: Write>(rudof: &Rudof, writer: &mut W) -> R
     let schema_ir = rudof.shex_schema_ir.as_ref().ok_or(ShExError::NoShExSchemaLoaded)?;
 
     schema_ir
-        .write(writer, CacheFormat::Bincode)
+        .write(writer, CacheFormat::Postcard)
         .map_err(|error| ShExError::FailedWritingShExCache {
             error: error.to_string(),
         })?;

--- a/shex_ast/Cargo.toml
+++ b/shex_ast/Cargo.toml
@@ -10,7 +10,6 @@ homepage.workspace = true
 repository.workspace = true
 
 [dependencies]
-bincode.workspace = true
 colored.workspace = true
 const_format.workspace = true
 csv.workspace = true
@@ -21,6 +20,7 @@ lazy-regex.workspace = true
 nom.workspace = true
 nom_locate.workspace = true
 petgraph.workspace = true
+postcard.workspace = true
 prefixmap.workspace = true
 pretty.workspace = true
 rbe.workspace = true

--- a/shex_ast/src/ir/cache.rs
+++ b/shex_ast/src/ir/cache.rs
@@ -82,8 +82,8 @@ impl CacheHeader {
     }
 
     pub(crate) fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), Box<SchemaIRError>> {
-        let header_bytes = postcard::to_stdvec(self)
-            .map_err(|e| Box::new(SchemaIRError::CacheWriteError { msg: e.to_string() }))?;
+        let header_bytes =
+            postcard::to_stdvec(self).map_err(|e| Box::new(SchemaIRError::CacheWriteError { msg: e.to_string() }))?;
         let header_len: u32 = header_bytes.len().try_into().map_err(|_| {
             Box::new(SchemaIRError::CacheWriteError {
                 msg: "cache header exceeds u32::MAX bytes".to_string(),
@@ -134,8 +134,11 @@ impl CacheHeader {
         let mut header_bytes = vec![0u8; header_len];
         read_exact(reader, &mut header_bytes, "header body")?;
 
-        let header: CacheHeader = postcard::from_bytes(&header_bytes)
-            .map_err(|e| Box::new(SchemaIRError::CacheReadError { msg: format!("decoding header: {e}") }))?;
+        let header: CacheHeader = postcard::from_bytes(&header_bytes).map_err(|e| {
+            Box::new(SchemaIRError::CacheReadError {
+                msg: format!("decoding header: {e}"),
+            })
+        })?;
         Ok(header)
     }
 }

--- a/shex_ast/src/ir/cache.rs
+++ b/shex_ast/src/ir/cache.rs
@@ -27,15 +27,14 @@ impl CacheReaderMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum CacheFormat {
     #[default]
-    Bincode,
+    Postcard,
 }
 
 impl CacheFormat {
     pub(crate) fn write_to<W: Write>(&self, schema_ir: &SchemaIR, writer: &mut W) -> Result<(), Box<SchemaIRError>> {
         match self {
-            CacheFormat::Bincode => {
-                let config = bincode::config::standard();
-                let bytes = bincode::serde::encode_to_vec(schema_ir, config)
+            CacheFormat::Postcard => {
+                let bytes = postcard::to_stdvec(schema_ir)
                     .map_err(|e| Box::new(SchemaIRError::CacheWriteError { msg: e.to_string() }))?;
                 writer
                     .write_all(&bytes)
@@ -47,13 +46,12 @@ impl CacheFormat {
 
     pub(crate) fn read_from<R: Read>(&self, reader: &mut R) -> Result<SchemaIR, Box<SchemaIRError>> {
         match self {
-            CacheFormat::Bincode => {
+            CacheFormat::Postcard => {
                 let mut body = Vec::new();
                 reader
                     .read_to_end(&mut body)
                     .map_err(|e| Box::new(SchemaIRError::CacheReadError { msg: e.to_string() }))?;
-                let config = bincode::config::standard();
-                let (ir, _consumed): (SchemaIR, usize) = bincode::serde::decode_from_slice(&body, config)
+                let ir: SchemaIR = postcard::from_bytes(&body)
                     .map_err(|e| Box::new(SchemaIRError::CacheReadError { msg: e.to_string() }))?;
                 Ok(ir)
             },
@@ -84,8 +82,7 @@ impl CacheHeader {
     }
 
     pub(crate) fn write_to<W: Write>(&self, writer: &mut W) -> Result<(), Box<SchemaIRError>> {
-        let config = bincode::config::standard();
-        let header_bytes = bincode::serde::encode_to_vec(self, config)
+        let header_bytes = postcard::to_stdvec(self)
             .map_err(|e| Box::new(SchemaIRError::CacheWriteError { msg: e.to_string() }))?;
         let header_len: u32 = header_bytes.len().try_into().map_err(|_| {
             Box::new(SchemaIRError::CacheWriteError {
@@ -137,13 +134,8 @@ impl CacheHeader {
         let mut header_bytes = vec![0u8; header_len];
         read_exact(reader, &mut header_bytes, "header body")?;
 
-        let config = bincode::config::standard();
-        let (header, _consumed): (CacheHeader, usize) = bincode::serde::decode_from_slice(&header_bytes, config)
-            .map_err(|e| {
-                Box::new(SchemaIRError::CacheReadError {
-                    msg: format!("decoding header: {e}"),
-                })
-            })?;
+        let header: CacheHeader = postcard::from_bytes(&header_bytes)
+            .map_err(|e| Box::new(SchemaIRError::CacheReadError { msg: format!("decoding header: {e}") }))?;
         Ok(header)
     }
 }

--- a/shex_ast/src/ir/schema_ir.rs
+++ b/shex_ast/src/ir/schema_ir.rs
@@ -1094,12 +1094,10 @@ mod tests {
         )
         .unwrap_or_else(|e| panic!("[{name}] AST -> IR compile: {e}"));
 
-        let config = bincode::config::standard();
-        let bytes: Vec<u8> =
-            bincode::serde::encode_to_vec(&ir, config).unwrap_or_else(|e| panic!("[{name}] bincode encode: {e}"));
-        let (restored, consumed): (SchemaIR, usize) = bincode::serde::decode_from_slice(&bytes, config)
-            .unwrap_or_else(|e| panic!("[{name}] bincode decode: {e}"));
-        assert_eq!(consumed, bytes.len(), "[{name}] bincode did not consume every byte");
+    let bytes: Vec<u8> =
+        postcard::to_stdvec(&ir).unwrap_or_else(|e| panic!("[{name}] postcard encode: {e}"));
+    let restored: SchemaIR =
+        postcard::from_bytes(&bytes).unwrap_or_else(|e| panic!("[{name}] postcard decode: {e}"));
 
         fn sorted_lines(s: &str) -> Vec<String> {
             let mut lines: Vec<String> = s.lines().map(str::to_string).collect();
@@ -1109,7 +1107,7 @@ mod tests {
         assert_eq!(
             sorted_lines(&format!("{ir}")),
             sorted_lines(&format!("{restored}")),
-            "[{name}] Display differs after bincode round-trip",
+            "[{name}] Display differs after postcard round-trip",
         );
 
         assert_eq!(
@@ -1138,7 +1136,7 @@ mod tests {
     }
 
     #[test]
-    fn schema_ir_bincode_round_trip_and_of_two_shapes() {
+    fn schema_ir_postcard_round_trip_and_of_two_shapes() {
         let str = r#"{
           "type": "Schema",
           "@context": "http://www.w3.org/ns/shex.jsonld",
@@ -1164,7 +1162,7 @@ mod tests {
     }
 
     #[test]
-    fn schema_ir_bincode_round_trip_value_set_literal() {
+    fn schema_ir_postcard_round_trip_value_set_literal() {
         let json = r#"{
           "@context": "http://www.w3.org/ns/shex.jsonld",
           "type": "Schema",
@@ -1217,7 +1215,7 @@ mod tests {
         .expect("populate IR from ShExC-parsed schema");
 
         let mut buf = Vec::new();
-        ir.write(&mut buf, CacheFormat::Bincode).expect("SchemaIR::write");
+        ir.write(&mut buf, CacheFormat::Postcard).expect("SchemaIR::write");
 
         let _restored = SchemaIR::read(
             Cursor::new(buf),
@@ -1229,7 +1227,7 @@ mod tests {
 
     /// Regression: schemas with numeric facets (`MININCLUSIVE`, `MAXEXCLUSIVE`, …) embed a
     /// `NumericLiteral` in `CondKind`. Its `Deserialize` impl must be compatible with
-    /// non-self-describing formats like bincode; otherwise the cache round-trip fails with
+    /// non-self-describing formats like postcard; otherwise the cache round-trip fails with
     /// `Serde(AnyNotSupported)` for real-world schemas that use XSD numeric bounds
     /// (e.g. FHIR-R5).
     #[test]
@@ -1260,7 +1258,7 @@ prefix xsd: <http://www.w3.org/2001/XMLSchema#>
         .expect("populate IR from ShExC-parsed schema");
 
         let mut buf = Vec::new();
-        ir.write(&mut buf, CacheFormat::Bincode).expect("SchemaIR::write");
+        ir.write(&mut buf, CacheFormat::Postcard).expect("SchemaIR::write");
 
         let _restored = SchemaIR::read(
             Cursor::new(buf),
@@ -1275,7 +1273,7 @@ prefix xsd: <http://www.w3.org/2001/XMLSchema#>
         use crate::ir::cache::CacheReaderMode;
         use std::io::Cursor;
 
-        let junk = br#"{"version":1,"body_format":"bincode"}"#;
+        let junk = br#"{"version":1,"body_format":"postcard"}"#;
 
         let err = SchemaIR::read(
             Cursor::new(junk.as_slice()),

--- a/shex_ast/src/ir/schema_ir.rs
+++ b/shex_ast/src/ir/schema_ir.rs
@@ -1094,10 +1094,9 @@ mod tests {
         )
         .unwrap_or_else(|e| panic!("[{name}] AST -> IR compile: {e}"));
 
-    let bytes: Vec<u8> =
-        postcard::to_stdvec(&ir).unwrap_or_else(|e| panic!("[{name}] postcard encode: {e}"));
-    let restored: SchemaIR =
-        postcard::from_bytes(&bytes).unwrap_or_else(|e| panic!("[{name}] postcard decode: {e}"));
+        let bytes: Vec<u8> = postcard::to_stdvec(&ir).unwrap_or_else(|e| panic!("[{name}] postcard encode: {e}"));
+        let restored: SchemaIR =
+            postcard::from_bytes(&bytes).unwrap_or_else(|e| panic!("[{name}] postcard decode: {e}"));
 
         fn sorted_lines(s: &str) -> Vec<String> {
             let mut lines: Vec<String> = s.lines().map(str::to_string).collect();


### PR DESCRIPTION
Swap the on-disk encoding used by the precompiled ShEx schema cache (.ircache) from bincode to postcard, updating cache.rs read/write paths, the compile-to-file implementation, and dependent Cargo.toml files (root, rbe, shex_ast). Renames and updates round-trip tests and docs accordingly.