### PR TITLE
fix: Fix shapemap default fail color to be RED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ This ChangeLog follows the Keep a ChangeLog guidelines](https://keepachangelog.c
 ### Changed
 ### Removed
 
+## 0.3.9 (Unpublished)
+
+### Fixed
+- fix(shapemap fail color): It was printing the default FAIL color in Green instead of Red
+
+### Changed
+- We moved NoMatchReason to its own module
+
 ## 0.3.8
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ default-members = ["rudof_cli"]
 version = "0.3.7"
 edition = "2024"
 license = "MIT OR Apache-2.0"
-description = "RDF data shapes implementation in Rust"
+description = "RDF and Knowledge Graphs processing tool"
 repository = "https://github.com/rudof-project/rudof"
 homepage = "https://rudof-project.github.io/rudof"
 readme = "./README.md"
@@ -302,7 +302,10 @@ petgraph = { version = "0.8", features = ["serde-1"] }
 postcard = { version = "1", features = ["use-std"] }
 prefixmap = { version = "0.3.7", path = "./prefixmap" }
 pretty = { version = "0.12" }
-proptest = { version = "1.11.0", default-features = false, features = ["std", "bit-set"] }
+proptest = { version = "1.11.0", default-features = false, features = [
+    "std",
+    "bit-set",
+] }
 pyrudof = { version = "0.3.7", path = "./bindings/python" }
 rand = "0.8"
 rayon = "1.7"

--- a/README.md
+++ b/README.md
@@ -8,11 +8,13 @@
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://github.com/pre-commit/pre-commit)
 
 
-This repo contains an RDF data shapes library implemented in Rust.
-The implementation supports
+This repo contains an RDF and Knowledge Graphs processing tool implemented in Rust.
+
+The implementation supports RDF and property graphs data, as well as 
 [ShEx](http://shex.io/),
 [SHACL](https://www.w3.org/TR/shacl/),
-[DCTap](https://www.dublincore.org/specifications/dctap/)
+[DCTap](https://www.dublincore.org/specifications/dctap/), 
+[PGSchema](https://dl.acm.org/doi/10.1145/3589778),
 and conversions between different RDF data modeling formalisms.
 
 The code can be used as a Rust library
@@ -32,12 +34,14 @@ as well as Python bindings.
 - [How to guides](https://github.com/rudof-project/rudof/wiki/How%E2%80%90to-guides)
 - [Roadmap](https://github.com/rudof-project/rudof/issues/1)
 
+<!-- 
 >[!NOTE]
 >Starting from version 0.2.17, all `rudof` dependencies are version-aligned. Therefore, if you need to use a specific dependency, it must match the same version used by rudof.
 
 >[!WARNING]
 >The use of versions between 0.2.19 and 0.3.0 (inclusive) is discouraged due to some problems with the CI/CD pipeline.
 >Its possible that some of the published versions in that range may not work as expected, or even does not exist. 
+-->
 
 ## Features
 
@@ -49,7 +53,7 @@ as well as Python bindings.
 - ShEx
 - SHACL
 - DCTAP
-- Property graphs and Schemas for Property Graphs (PGSchema)
+- Property graphs and Schemas for Property Graphs ([PGSchema]()https://dl.acm.org/doi/10.1145/3589778)
 
 Future features we are planning to add:
 
@@ -64,9 +68,11 @@ You can download a binary from the [latest release](https://github.com/rudof-pro
 There you will also find the compiled packages
 for the installation on your system using a package manager.
 
-#### Ubuntu
+#### Published Debian packages
 
-Download the binary from <https://github.com/rudof-project/rudof/releases>
+rudof is available as a [Debian package](https://packages.debian.org/source/sid/rudof) for Debian-based distributions (like Ubuntu).
+
+It is also possible to download the binary from <https://github.com/rudof-project/rudof/releases>
 and install the `.deb` package running the following commands after replacing X.X.X by the latest version:
 
 ```sh
@@ -136,7 +142,7 @@ cargo deb
 And run:
 
 ```sh
-sudo dpkg -i target/debian/rudof_0.0.11-1_amd64.deb
+sudo dpkg -i target/debian/rudof_<VERSION>_amd64.deb
 ```
 
 ### Alternative for Linux
@@ -201,32 +207,37 @@ $env.RUST_LOG = 'info,shacl_validation=trace,hyper=off,reqwest=off'
 ## Command line usage
 
 ```sh
-RDF data shapes implementation in Rust
+RDF and Knowledge Graphs processing tool
 
 Usage: rudof [OPTIONS] [COMMAND]
 
 Commands:
-  mcp             Export rudof as an MCP server
-  shapemap        Show information about ShEx ShapeMaps
-  shex            Show information about ShEx schemas
-  validate        Validate RDF data using ShEx or SHACL
-  shex-validate   Validate RDF using ShEx schemas
-  shacl-validate  Validate RDF data using SHACL shapes
-  data            Show information about RDF data
-  node            Show information about a node in an RDF Graph
-  shacl           Show information about SHACL shapes The SHACL schema can be passed through the data options or the optional schema options to provide an interface similar to Shacl-validate
-  dctap           Show information and process DCTAP files
-  convert         Convert between different Data modeling technologies
-  compare         Compare two shapes (which can be in different formats)
-  rdf-config      Show information about SPARQL service
-  service         Show information about SPARQL service
-  query           Run SPARQL queries
-  generate        Generate synthetic RDF data from ShEx or SHACL schemas
-  help            Print this message or the help of the given subcommand(s)
+  mcp                Export rudof as an MCP server
+  shapemap           Show information about ShEx ShapeMaps
+  shex               Show information about ShEx schemas
+  pgschema           Show information about Property Graph Schemas
+  validate           Validate RDF data using ShEx or SHACL
+  shex-validate      Validate RDF using ShEx schemas
+  shacl-validate     Validate RDF data using SHACL shapes
+  data               Show information about RDF data
+  node               Show information about a node in an RDF Graph
+  shacl              Show information about SHACL shapes
+  dctap              Arguments for the `dctap` command
+  convert            Arguments for the `convert` command
+  compare            Compare two shapes (which can be in different formats)
+  rdf-config         Show information about rdf config
+  service            Show information about SPARQL service
+  query              Run SPARQL queries
+  generate           Generate synthetic RDF data from ShEx or SHACL schemas
+  materialize        Materialize an RDF graph from a ShEx schema and Map semantic-action state
+  pgschema-validate  Validate Property Graph data using PGSchema
+  completion         Generates a shell completion script for the specified shell
+  config             Dump the effective configuration rudof is using as TOML
+  help               Print this message or the help of the given subcommand(s)
 
 Options:
-  -d, --debug...
-  -h, --help      Print help (see more with '--help')
+  -d, --debug...  Increase logging verbosity
+  -h, --help      Print help
   -V, --version   Print version
 ```
 

--- a/rbe/src/rbe_error.rs
+++ b/rbe/src/rbe_error.rs
@@ -209,7 +209,7 @@ where
                 values.show_qualified(show_key, show_value)
             ),
             RbeError::EmptyCandidatesNoValues { rbe } => format!(
-                "No values to match expression. Mandatory values: [{}]",
+                "No candidates to match. Missing: [{}]",
                 show_mandatory_values(rbe, show_key, show_value)
             ),
             RbeError::RbeTableKeyWithoutComponent { key, available_keys } => format!(

--- a/rudof_cli/src/cli/parser/base.rs
+++ b/rudof_cli/src/cli/parser/base.rs
@@ -48,8 +48,6 @@ pub enum Command {
     /// Show information about a node in an RDF Graph
     Node(NodeArgs),
     /// Show information about SHACL shapes
-    /// The SHACL schema can be passed through the data options or the optional schema options to provide an interface similar
-    /// to Shacl-validate
     Shacl(ShaclArgs),
     // Show information and process DCTAP files
     #[command(name = "dctap")]

--- a/shex_ast/src/shapemap/shapemap_config.rs
+++ b/shex_ast/src/shapemap/shapemap_config.rs
@@ -113,7 +113,7 @@ impl ShapemapConfig {
     #[inline] fn default_ok_text() -> String { "OK".to_string() }
     #[inline] fn default_fail_text() -> String { "FAIL".to_string() }
     #[inline] fn default_ok_color() -> Color { Color::Green }
-    #[inline] fn default_fail_color() -> Color { Color::Green }
+    #[inline] fn default_fail_color() -> Color { Color::Red }
     #[inline] fn default_pending_color() -> Color { Color::Magenta }
 }
 

--- a/shex_validation/src/engine.rs
+++ b/shex_validation/src/engine.rs
@@ -5,6 +5,7 @@ use crate::Reasons;
 use crate::ValidatorConfig;
 use crate::ValidatorErrors;
 use crate::atom;
+use crate::no_match_reason::NoMatchReason;
 use crate::ref_typing::RefTyping;
 use crate::validator_error::*;
 use either::Either;

--- a/shex_validation/src/lib.rs
+++ b/shex_validation/src/lib.rs
@@ -5,6 +5,7 @@ pub mod atom;
 pub mod class_partitions;
 pub mod engine;
 pub mod k_partitions;
+pub mod no_match_reason;
 pub mod partition;
 pub mod reason;
 pub mod reasons;

--- a/shex_validation/src/no_match_reason.rs
+++ b/shex_validation/src/no_match_reason.rs
@@ -1,0 +1,73 @@
+use prefixmap::PrefixMap;
+use rbe::{Cardinality, RbeError};
+use shex_ast::{Node, Pred, ShapeLabelIdx, cond_kind::CondKind, ir::semantic_action_context::SemanticActionContext};
+
+/// Why a single candidate assignment of neighbors to a triple expression was
+/// rejected, attached as children of a [`ValidatorError::NoMatchesFound`]
+/// error so the user can see, per candidate, why it didn't work.
+#[derive(Debug, Clone)]
+pub enum NoMatchReason {
+    /// `value` didn't satisfy `predicate`'s own condition (e.g. a node
+    /// constraint or shape reference).
+    ConditionFailed {
+        candidate: Vec<(Pred, Node)>,
+        predicate: Pred,
+        value: Node,
+        error: RbeError<Pred, Node, ShapeLabelIdx, SemanticActionContext, CondKind>,
+    },
+    /// `predicate` needed to occur `expected` times but occurred `current`
+    /// times among the candidate's neighbors.
+    CardinalityFailed {
+        candidate: Vec<(Pred, Node)>,
+        predicate: Pred,
+        expected: Cardinality,
+        current: usize,
+    },
+    /// A candidate was rejected for a reason that couldn't be attributed to
+    /// a single predicate's cardinality (e.g. `Or`-branch interactions).
+    Other {
+        candidate: Vec<(Pred, Node)>,
+        detail: String,
+    },
+}
+
+impl NoMatchReason {
+    pub fn show_qualified(&self, nodes_prefixmap: &PrefixMap) -> String {
+        let show_pred = |p: &Pred| nodes_prefixmap.qualify(p.iri());
+        let show_node = |n: &Node| n.show_qualified(nodes_prefixmap);
+        let show_candidate = |candidate: &[(Pred, Node)]| {
+            candidate
+                .iter()
+                .map(|(p, v)| format!("{} {}", show_pred(p), v.show_qualified(nodes_prefixmap)))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        match self {
+            NoMatchReason::ConditionFailed {
+                candidate: _,
+                predicate,
+                value,
+                error,
+            } => format!(
+                "Condition failed for predicate {} on node {}: {}",
+                // show_candidate(candidate),
+                show_pred(predicate),
+                value.show_qualified(nodes_prefixmap),
+                error.show_qualified(&show_pred, &show_node),
+            ),
+            NoMatchReason::CardinalityFailed {
+                candidate,
+                predicate,
+                expected,
+                current,
+            } => format!(
+                "Candidate [{}] rejected: predicate {} required cardinality {expected:?} but got {current}",
+                show_candidate(candidate),
+                show_pred(predicate),
+            ),
+            NoMatchReason::Other { candidate, detail } => {
+                format!("Candidate [{}] rejected: {detail}", show_candidate(candidate))
+            },
+        }
+    }
+}

--- a/shex_validation/src/validator_error.rs
+++ b/shex_validation/src/validator_error.rs
@@ -1,9 +1,9 @@
 use crate::PartitionsDisplay;
 use crate::Reasons;
 use crate::ValidatorErrors;
+use crate::no_match_reason::NoMatchReason;
 use prefixmap::PrefixMap;
 use prefixmap::error::PrefixMapError;
-use rbe::Cardinality;
 use rbe::RbeError;
 use rudof_iri::IriS;
 use rudof_rdf::rdf_core::term::Object;
@@ -18,76 +18,6 @@ use shex_ast::ir::shape_expr::ShapeExpr;
 use shex_ast::{Node, Pred, ShapeExprLabel, ShapeLabelIdx, ast::cond_kind::CondKind, ir::shape_label::ShapeLabel};
 use termtree::Tree;
 use thiserror::Error;
-
-/// Why a single candidate assignment of neighbors to a triple expression was
-/// rejected, attached as children of a [`ValidatorError::NoMatchesFound`]
-/// error so the user can see, per candidate, why it didn't work.
-#[derive(Debug, Clone)]
-pub enum NoMatchReason {
-    /// `value` didn't satisfy `predicate`'s own condition (e.g. a node
-    /// constraint or shape reference).
-    ConditionFailed {
-        candidate: Vec<(Pred, Node)>,
-        predicate: Pred,
-        value: Node,
-        error: RbeError<Pred, Node, ShapeLabelIdx, SemanticActionContext, CondKind>,
-    },
-    /// `predicate` needed to occur `expected` times but occurred `current`
-    /// times among the candidate's neighbors.
-    CardinalityFailed {
-        candidate: Vec<(Pred, Node)>,
-        predicate: Pred,
-        expected: Cardinality,
-        current: usize,
-    },
-    /// A candidate was rejected for a reason that couldn't be attributed to
-    /// a single predicate's cardinality (e.g. `Or`-branch interactions).
-    Other {
-        candidate: Vec<(Pred, Node)>,
-        detail: String,
-    },
-}
-
-impl NoMatchReason {
-    fn show_qualified(&self, nodes_prefixmap: &PrefixMap) -> String {
-        let show_pred = |p: &Pred| nodes_prefixmap.qualify(p.iri());
-        let show_node = |n: &Node| n.show_qualified(nodes_prefixmap);
-        let show_candidate = |candidate: &[(Pred, Node)]| {
-            candidate
-                .iter()
-                .map(|(p, v)| format!("{} {}", show_pred(p), v.show_qualified(nodes_prefixmap)))
-                .collect::<Vec<_>>()
-                .join(", ")
-        };
-        match self {
-            NoMatchReason::ConditionFailed {
-                candidate,
-                predicate,
-                value,
-                error,
-            } => format!(
-                "Candidate [{}] rejected: {} {}: {}",
-                show_candidate(candidate),
-                show_pred(predicate),
-                value.show_qualified(nodes_prefixmap),
-                error.show_qualified(&show_pred, &show_node),
-            ),
-            NoMatchReason::CardinalityFailed {
-                candidate,
-                predicate,
-                expected,
-                current,
-            } => format!(
-                "Candidate [{}] rejected: predicate {} required cardinality {expected:?} but got {current}",
-                show_candidate(candidate),
-                show_pred(predicate),
-            ),
-            NoMatchReason::Other { candidate, detail } => {
-                format!("Candidate [{}] rejected: {detail}", show_candidate(candidate))
-            },
-        }
-    }
-}
 
 #[derive(Error, Debug, Clone)]
 pub enum ValidatorError {
@@ -632,8 +562,8 @@ impl ValidatorError {
         schema: &SchemaIR,
         width: usize,
     ) -> Result<String, PrefixMapError> {
-        // A shape made of a single triple constraint (the overwhelmingly common
-        // case) rejected on its one and only candidate reduces to a single
+        // A shape made of a single triple constraint rejected on its one
+        // and only candidate reduces to a single
         // `ConditionFailed` reason. Render that flat, naming the node and
         // property involved, instead of the generic
         // "Shape ... failed ...: no candidates matched" + one-line tree.


### PR DESCRIPTION
- Move NoMatchReason from validator_error.rs into shex_validation::no_match_reason
- Clarify ConditionFailed/rbe_error wording ("No candidates to match. Missing: ...")
- Fix ShapemapConfig::default_fail_color(), which returned Green instead of Red