### PR TITLE
fix(shex): skip extends pre-check shortcut on predicate overlap solving issue 768

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4439,6 +4439,7 @@ dependencies = [
  "rudof_config",
  "rudof_iri",
  "rudof_rdf",
+ "rust_decimal",
  "serde",
  "sparql_service",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -311,7 +311,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bench-issue730"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "rudof_lib",
@@ -320,7 +320,7 @@ dependencies = [
 
 [[package]]
 name = "bench-shex"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "criterion",
@@ -1130,7 +1130,7 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "dctap"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "calamine",
  "csv",
@@ -1299,7 +1299,7 @@ dependencies = [
 
 [[package]]
 name = "emacs-rudof"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "emacs",
@@ -2436,7 +2436,7 @@ dependencies = [
 
 [[package]]
 name = "mie"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "hashlink",
  "rudof_iri",
@@ -2932,7 +2932,7 @@ dependencies = [
 
 [[package]]
 name = "pgschema"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "prefixmap"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "colored",
  "indexmap 2.14.0",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "pyrudof"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "pyo3",
  "pythonize",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "rbe"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "criterion",
  "either",
@@ -3517,7 +3517,7 @@ dependencies = [
 
 [[package]]
 name = "rbe_testsuite"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "indoc",
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "rdf_config"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "hashlink",
  "indexmap 2.14.0",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_cli"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -3787,7 +3787,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_config"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "dirs",
  "serde",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_generate"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_iri"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "getrandom 0.3.4",
  "indexmap 2.14.0",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_lib"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "colored",
  "crossterm",
@@ -3876,7 +3876,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_mcp"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -3906,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "rudof_rdf"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "bollard",
  "colored",
@@ -4426,7 +4426,7 @@ dependencies = [
 
 [[package]]
 name = "shacl"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "shapes_comparator"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "prefixmap",
  "rudof_config",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "shapes_converter"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "chrono",
  "dctap",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "shex_ast"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "colored",
  "const_format",
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "shex_testsuite"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -4553,7 +4553,7 @@ dependencies = [
 
 [[package]]
 name = "shex_validation"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "either",
  "indexmap 2.14.0",
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "sparql_service"
-version = "0.3.7"
+version = "0.3.8"
 dependencies = [
  "colored",
  "const_format",

--- a/rudof_rdf/src/rdf_core/parser/rdf_node_parser/constructors/property.rs
+++ b/rudof_rdf/src/rdf_core/parser/rdf_node_parser/constructors/property.rs
@@ -412,6 +412,35 @@ where
 
 /// Parser for a single integer value.
 #[derive(Debug, Clone)]
+pub struct SingleLiteralPropertyParser<RDF> {
+    property: IriS,
+    _marker: PhantomData<RDF>,
+}
+
+impl<RDF> SingleLiteralPropertyParser<RDF> {
+    pub fn new(property: IriS) -> Self {
+        SingleLiteralPropertyParser {
+            property,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<RDF> RDFNodeParse<RDF> for SingleLiteralPropertyParser<RDF>
+where
+    RDF: FocusRDF,
+{
+    type Output = RDF::Literal;
+
+    fn parse_focused(&self, rdf: &mut RDF) -> Result<Self::Output, RDFError> {
+        SingleValuePropertyParser::new(self.property.clone())
+            .parse_focused(rdf)
+            .and_then(|term| term_to_literal::<RDF>(&term))
+    }
+}
+
+/// Parser for a single integer value.
+#[derive(Debug, Clone)]
 pub struct SingleIntegerPropertyParser<RDF> {
     property: IriS,
     _marker: PhantomData<RDF>,

--- a/shacl/Cargo.toml
+++ b/shacl/Cargo.toml
@@ -12,19 +12,20 @@ repository.workspace = true
 
 [features]
 default = ["sparql"]
-sparql = ["sparql_service/sparql", "rudof_rdf/sparql" ]
+sparql = ["sparql_service/sparql", "rudof_rdf/sparql"]
 
 [dependencies]
 anyhow.workspace = true
 dashmap.workspace = true
 indoc.workspace = true
 itertools.workspace = true
-rudof_config.workspace = true
-rudof_iri.workspace = true
 petgraph.workspace = true
 prefixmap.workspace = true
 rayon.workspace = true
 rudof_rdf.workspace = true
+rudof_config.workspace = true
+rudof_iri.workspace = true
+rust_decimal.workspace = true
 serde.workspace = true
 sparql_service.workspace = true
 thiserror.workspace = true
@@ -32,4 +33,4 @@ toml.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-oxrdf = { workspace = true, features = [ "oxsdatatypes" ] }
+oxrdf = { workspace = true, features = ["oxsdatatypes"] }

--- a/shacl/src/ast/node_shape.rs
+++ b/shacl/src/ast/node_shape.rs
@@ -16,8 +16,8 @@ pub struct ASTNodeShape {
     // ignored_properties: Vec<IriRef>,
     message: Option<MessageMap>,
     severity: Option<Severity>,
-    name: MessageMap,
-    description: MessageMap,
+    name: Option<MessageMap>,
+    description: Option<MessageMap>,
     group: Option<Object>,
     // source_iri: Option<IriRef>,
 }
@@ -31,8 +31,8 @@ impl ASTNodeShape {
             property_shapes: Vec::new(),
             message: None,
             severity: None,
-            name: MessageMap::new(),
-            description: MessageMap::new(),
+            name: None,
+            description: None,
             group: None,
         }
     }
@@ -82,12 +82,12 @@ impl ASTNodeShape {
         &self.property_shapes
     }
 
-    pub fn name(&self) -> &MessageMap {
-        &self.name
+    pub fn name(&self) -> Option<&MessageMap> {
+        self.name.as_ref()
     }
 
-    pub fn description(&self) -> &MessageMap {
-        &self.description
+    pub fn description(&self) -> Option<&MessageMap> {
+        self.description.as_ref()
     }
 
     pub fn message(&self) -> Option<&MessageMap> {

--- a/shacl/src/ast/property_shape.rs
+++ b/shacl/src/ast/property_shape.rs
@@ -1,11 +1,11 @@
 use crate::ast::error::ASTError;
 use crate::ast::reifier_info::ReifierInfo;
 use crate::ast::{ASTComponent, ASTSchema, defined_properties_for};
+use crate::ir::OrderValue;
 use crate::types::{ClosedInfo, MessageMap, Severity, Target};
 use rudof_iri::IriS;
 use rudof_rdf::rdf_core::SHACLPath;
 use rudof_rdf::rdf_core::term::Object;
-use rudof_rdf::rdf_core::term::literal::NumericLiteral;
 use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 
@@ -22,9 +22,9 @@ pub struct ASTPropertyShape {
     deactivated: bool,
     message: Option<MessageMap>,
     severity: Option<Severity>,
-    name: MessageMap,
-    description: MessageMap,
-    order: Option<NumericLiteral>,
+    name: Option<MessageMap>,
+    description: Option<MessageMap>,
+    order: Option<OrderValue>,
     group: Option<Object>,
     // source_iri: Option<IriRef>,
     // annotations: Vec<(IriRef, RDFNode)>
@@ -46,8 +46,8 @@ impl ASTPropertyShape {
             deactivated: false,
             message: None,
             severity: None,
-            name: MessageMap::new(),
-            description: MessageMap::new(),
+            name: None,
+            description: None,
             order: None,
             group: None,
             reifier_info: None,
@@ -57,17 +57,17 @@ impl ASTPropertyShape {
         }
     }
 
-    pub fn with_name(mut self, name: MessageMap) -> Self {
+    pub fn with_name(mut self, name: Option<MessageMap>) -> Self {
         self.name = name;
         self
     }
 
-    pub fn with_description(mut self, description: MessageMap) -> Self {
+    pub fn with_description(mut self, description: Option<MessageMap>) -> Self {
         self.description = description;
         self
     }
 
-    pub fn with_order(mut self, order: Option<NumericLiteral>) -> Self {
+    pub fn with_order(mut self, order: Option<OrderValue>) -> Self {
         self.order = order;
         self
     }
@@ -144,12 +144,12 @@ impl ASTPropertyShape {
         &self.path
     }
 
-    pub fn name(&self) -> &MessageMap {
-        &self.name
+    pub fn name(&self) -> Option<&MessageMap> {
+        self.name.as_ref()
     }
 
-    pub fn description(&self) -> &MessageMap {
-        &self.description
+    pub fn description(&self) -> Option<&MessageMap> {
+        self.description.as_ref()
     }
 
     pub fn is_closed(&self) -> &bool {
@@ -176,7 +176,7 @@ impl ASTPropertyShape {
         &self.property_shapes
     }
 
-    pub fn order(&self) -> Option<&NumericLiteral> {
+    pub fn order(&self) -> Option<&OrderValue> {
         self.order.as_ref()
     }
 
@@ -235,6 +235,10 @@ impl Display for ASTPropertyShape {
         for reifier in self.reifier_info.iter() {
             writeln!(f, "\tReifierInfo {reifier}")?
         }
+        for message in self.message.iter() {
+            writeln!(f, "\tMessage {message}")?
+        }
+
         for component in self.components.iter() {
             writeln!(f, "\t{component}")?
         }

--- a/shacl/src/ir/mod.rs
+++ b/shacl/src/ir/mod.rs
@@ -12,6 +12,7 @@ pub mod components;
 pub mod dg;
 pub(crate) mod error;
 mod node_shape;
+mod order_value;
 mod property_shape;
 mod reifier_info;
 mod schema;
@@ -21,6 +22,7 @@ mod test;
 
 pub use component::IRComponent;
 pub use node_shape::IRNodeShape;
+pub use order_value::OrderValue;
 pub use property_shape::IRPropertyShape;
 pub use reifier_info::ReifierInfo;
 pub use schema::IRSchema;

--- a/shacl/src/ir/node_shape.rs
+++ b/shacl/src/ir/node_shape.rs
@@ -11,6 +11,7 @@ use rudof_rdf::rdf_core::BuildRDF;
 use rudof_rdf::rdf_core::term::Object;
 use rudof_rdf::rdf_core::vocabs::ShaclVocab;
 use std::collections::{HashMap, HashSet};
+use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone)]
 pub struct IRNodeShape {
@@ -23,8 +24,13 @@ pub struct IRNodeShape {
 
     message: Option<MessageMap>,
     severity: Option<Severity>,
-    name: MessageMap,
-    description: MessageMap,
+
+    // Notice that SHACL recommendation specifies that sh:name and sh:description should be applied only for property shapes.
+    // In SHACL 1.2, it recommends to used rdfs:label and rdfs:comment for name and description.
+    // We leave name and description here in case that in the future we want to suppport names and descriptions specifically.
+    name: Option<MessageMap>,
+    description: Option<MessageMap>,
+
     group: Option<Object>,
     // source_iri: S::Iri
 }
@@ -40,8 +46,8 @@ impl IRNodeShape {
             deactivated: false,
             message: None,
             severity: None,
-            name: MessageMap::new(),
-            description: MessageMap::new(),
+            name: None,
+            description: None,
             group: None,
         }
     }
@@ -76,12 +82,12 @@ impl IRNodeShape {
         self
     }
 
-    pub fn with_name(mut self, name: MessageMap) -> Self {
+    pub fn with_name(mut self, name: Option<MessageMap>) -> Self {
         self.name = name;
         self
     }
 
-    pub fn with_description(mut self, description: MessageMap) -> Self {
+    pub fn with_description(mut self, description: Option<MessageMap>) -> Self {
         self.description = description;
         self
     }
@@ -134,6 +140,14 @@ impl IRNodeShape {
     pub fn message(&self) -> Option<&MessageMap> {
         self.message.as_ref()
     }
+
+    pub fn name(&self) -> Option<&MessageMap> {
+        self.name.as_ref()
+    }
+
+    pub fn description(&self) -> Option<&MessageMap> {
+        self.description.as_ref()
+    }
 }
 
 impl IRNodeShape {
@@ -161,8 +175,8 @@ impl IRNodeShape {
             .with_closed_info(closed_info)
             .with_deactivated(shape.is_deactivated())
             .with_severity(shape.severity().cloned())
-            .with_name(shape.name().to_owned())
-            .with_description(shape.description().to_owned())
+            .with_name(shape.name().cloned())
+            .with_description(shape.description().cloned())
             .with_group(shape.group().cloned())
             .with_message(shape.message().cloned());
 
@@ -181,17 +195,21 @@ impl IRNodeShape {
             .add_type(id.clone(), ShaclVocab::sh_node_shape())
             .map_err(|e| IRError::from_rdf_err::<RDF>("add type", e))?;
 
-        self.name.iter_literals().try_for_each(|lit| {
-            graph
-                .add_triple::<_, _, RDF::Literal>(id.clone(), ShaclVocab::sh_name(), lit.into())
-                .map_err(IRError::add_triple::<RDF>)
-        })?;
+        if let Some(name) = &self.name {
+            name.iter_literals().try_for_each(|lit| {
+                graph
+                    .add_triple::<_, _, RDF::Literal>(id.clone(), ShaclVocab::sh_name(), lit.into())
+                    .map_err(IRError::add_triple::<RDF>)
+            })?;
+        }
 
-        self.description.iter_literals().try_for_each(|lit| {
-            graph
-                .add_triple::<_, _, RDF::Literal>(id.clone(), ShaclVocab::sh_description(), lit.into())
-                .map_err(IRError::add_triple::<RDF>)
-        })?;
+        if let Some(description) = &self.description {
+            description.iter_literals().try_for_each(|lit| {
+                graph
+                    .add_triple::<_, _, RDF::Literal>(id.clone(), ShaclVocab::sh_description(), lit.into())
+                    .map_err(IRError::add_triple::<RDF>)
+            })?;
+        }
 
         self.components
             .iter()
@@ -248,5 +266,53 @@ impl IRNodeShape {
                 }
             }
         }
+    }
+}
+
+impl Display for IRNodeShape {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "NodeShape {}", self.id())?;
+        if let Some(message) = self.message() {
+            writeln!(f, " message: {message}")?;
+        }
+        if let Some(name) = self.name() {
+            writeln!(f, " name: {name}")?;
+        }
+        if let Some(description) = self.description() {
+            writeln!(f, " description: {description}")?;
+        }
+
+        if self.deactivated() {
+            writeln!(f, " Deactivated: {}", self.deactivated())?;
+        }
+        if self.severity() != &Severity::Violation {
+            writeln!(f, " Severity: {}", self.severity())?;
+        }
+        if self.closed() {
+            writeln!(f, " closed: {}", self.closed())?;
+        }
+        let mut components = self.components().iter().peekable();
+        if components.peek().is_some() {
+            writeln!(f, "Components:")?;
+            for component in components {
+                writeln!(f, " - {component}")?;
+            }
+        }
+        let mut targets = self.targets().iter().peekable();
+        if targets.peek().is_some() {
+            writeln!(f, "Targets:")?;
+            for target in targets {
+                writeln!(f, " - {target}")?;
+            }
+        }
+        let mut property_shapes = self.property_shapes().iter().peekable();
+        if property_shapes.peek().is_some() {
+            writeln!(
+                f,
+                " Property Shapes: [{}]",
+                property_shapes.map(|ps| ps.to_string()).collect::<Vec<_>>().join(", ")
+            )?;
+        }
+        Ok(())
     }
 }

--- a/shacl/src/ir/order_value.rs
+++ b/shacl/src/ir/order_value.rs
@@ -1,0 +1,18 @@
+use std::fmt::Display;
+
+use rust_decimal::Decimal;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum OrderValue {
+    Integer(i128),
+    Decimal(Decimal),
+}
+
+impl Display for OrderValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OrderValue::Integer(i) => write!(f, "{}", i),
+            OrderValue::Decimal(d) => write!(f, "{}", d),
+        }
+    }
+}

--- a/shacl/src/ir/property_shape.rs
+++ b/shacl/src/ir/property_shape.rs
@@ -236,8 +236,9 @@ impl IRPropertyShape {
             let lit: RDF::Literal = match order {
                 OrderValue::Integer(i) => (*i).into(),
                 OrderValue::Decimal(d) => {
-                    let decimal_literal = ConcreteLiteral::NumericLiteral(NumericLiteral::Decimal(d.clone()));
-                    let literal: RDF::Literal = decimal_literal.try_into().unwrap_or_else(|_| unreachable!());
+                    let decimal_literal = ConcreteLiteral::NumericLiteral(NumericLiteral::Decimal(*d));
+                    let literal: RDF::Literal =
+                        <ConcreteLiteral as std::convert::Into<RDF::Literal>>::into(decimal_literal);
                     literal
                 },
             };

--- a/shacl/src/ir/property_shape.rs
+++ b/shacl/src/ir/property_shape.rs
@@ -1,18 +1,19 @@
 use crate::ast::{ASTPropertyShape, ASTSchema};
-use crate::ir::ReifierInfo;
 use crate::ir::component::IRComponent;
 use crate::ir::dg::{DependencyGraph, PosNeg};
 use crate::ir::error::IRError;
 use crate::ir::schema::IRSchema;
 use crate::ir::shape::IRShape;
 use crate::ir::shape_label_idx::ShapeLabelIdx;
+use crate::ir::{OrderValue, ReifierInfo};
 use crate::types::{ClosedInfo, MessageMap, Severity, Target};
 use rudof_iri::IriS;
 use rudof_rdf::rdf_core::term::Object;
-use rudof_rdf::rdf_core::term::literal::NumericLiteral;
+use rudof_rdf::rdf_core::term::literal::{ConcreteLiteral, NumericLiteral};
 use rudof_rdf::rdf_core::vocabs::ShaclVocab;
 use rudof_rdf::rdf_core::{BuildRDF, SHACLPath};
 use std::collections::{HashMap, HashSet};
+use std::fmt::{Display, Formatter};
 
 #[derive(Debug, Clone)]
 pub struct IRPropertyShape {
@@ -26,12 +27,13 @@ pub struct IRPropertyShape {
     message: Option<MessageMap>,
     severity: Option<Severity>,
 
+    name: Option<MessageMap>,
+    description: Option<MessageMap>,
+    order: Option<OrderValue>,
+    group: Option<Object>,
+
     // SHACL 1.2: Reifier info is only present for property shapes
     reifier_info: Option<ReifierInfo>,
-    name: MessageMap,
-    description: MessageMap,
-    order: Option<NumericLiteral>,
-    group: Option<Object>,
     // source_iri: Option<S::IRI>,
     // annotations: Vec<(S::IRI, S::Term)>,
 }
@@ -49,8 +51,8 @@ impl IRPropertyShape {
             message: None,
             severity: None,
             reifier_info: None,
-            name: MessageMap::new(),
-            description: MessageMap::new(),
+            name: None,
+            description: None,
             order: None,
             group: None,
         }
@@ -81,15 +83,15 @@ impl IRPropertyShape {
         self
     }
 
-    pub fn with_name(mut self, name: MessageMap) -> Self {
+    pub fn with_name(mut self, name: Option<MessageMap>) -> Self {
         self.name = name;
         self
     }
-    pub fn with_description(mut self, description: MessageMap) -> Self {
+    pub fn with_description(mut self, description: Option<MessageMap>) -> Self {
         self.description = description;
         self
     }
-    pub fn with_order(mut self, order: Option<NumericLiteral>) -> Self {
+    pub fn with_order(mut self, order: Option<OrderValue>) -> Self {
         self.order = order;
         self
     }
@@ -150,6 +152,18 @@ impl IRPropertyShape {
     pub fn message(&self) -> Option<&MessageMap> {
         self.message.as_ref()
     }
+
+    pub fn name(&self) -> Option<&MessageMap> {
+        self.name.as_ref()
+    }
+
+    pub fn description(&self) -> Option<&MessageMap> {
+        self.description.as_ref()
+    }
+
+    pub fn order(&self) -> Option<&OrderValue> {
+        self.order.as_ref()
+    }
 }
 
 impl IRPropertyShape {
@@ -170,6 +184,8 @@ impl IRPropertyShape {
 
         let reifier_info = ReifierInfo::get_reifier_info(shape, ast, ir)?;
 
+        println!("Compiling property shape with order: {:?}", shape.order());
+
         let compiled_prop_shape = IRPropertyShape::new(shape.id().clone(), shape.path().to_owned(), closed_info)
             .with_components(compiled_components)
             .with_targets(shape.targets().to_owned())
@@ -177,8 +193,8 @@ impl IRPropertyShape {
             .with_deactivated(shape.is_deactivated())
             .with_severity(shape.severity().cloned())
             .with_reifier_info(reifier_info)
-            .with_name(shape.name().to_owned())
-            .with_description(shape.description().to_owned())
+            .with_name(shape.name().cloned())
+            .with_description(shape.description().cloned())
             .with_order(shape.order().cloned())
             .with_group(shape.group().cloned())
             .with_message(shape.message().cloned());
@@ -188,6 +204,8 @@ impl IRPropertyShape {
 }
 
 impl IRPropertyShape {
+    // Register the property shape in the RDF graph
+    // This is used for serializing the IR back to RDF
     pub fn register<RDF: BuildRDF>(
         &self,
         graph: &mut RDF,
@@ -198,35 +216,30 @@ impl IRPropertyShape {
             .add_type(id.clone(), ShaclVocab::sh_property_shape())
             .map_err(|e| IRError::from_rdf_err::<RDF>("add type", e))?;
 
-        self.name.iter_literals().try_for_each(|lit| {
-            graph
-                .add_triple::<_, _, RDF::Literal>(id.clone(), ShaclVocab::sh_name(), lit.into())
-                .map_err(IRError::add_triple::<RDF>)
-        })?;
+        if let Some(name) = &self.name {
+            name.iter_literals().try_for_each(|lit| {
+                graph
+                    .add_triple::<_, _, RDF::Literal>(id.clone(), ShaclVocab::sh_name(), lit.into())
+                    .map_err(IRError::add_triple::<RDF>)
+            })?;
+        }
 
-        self.description.iter_literals().try_for_each(|lit| {
-            graph
-                .add_triple::<_, _, RDF::Literal>(id.clone(), ShaclVocab::sh_description(), lit.into())
-                .map_err(IRError::add_triple::<RDF>)
-        })?;
+        if let Some(description) = &self.description {
+            description.iter_literals().try_for_each(|lit| {
+                graph
+                    .add_triple::<_, _, RDF::Literal>(id.clone(), ShaclVocab::sh_description(), lit.into())
+                    .map_err(IRError::add_triple::<RDF>)
+            })?;
+        }
 
         if let Some(order) = &self.order {
             let lit: RDF::Literal = match order {
-                NumericLiteral::Integer(i) => (*i).into(),
-                NumericLiteral::Byte(_) => todo!(),
-                NumericLiteral::Short(_) => todo!(),
-                NumericLiteral::NonNegativeInteger(_) => todo!(),
-                NumericLiteral::UnsignedLong(_) => todo!(),
-                NumericLiteral::UnsignedInt(_) => todo!(),
-                NumericLiteral::UnsignedShort(_) => todo!(),
-                NumericLiteral::UnsignedByte(_) => todo!(),
-                NumericLiteral::PositiveInteger(_) => todo!(),
-                NumericLiteral::NegativeInteger(_) => todo!(),
-                NumericLiteral::NonPositiveInteger(_) => todo!(),
-                NumericLiteral::Long(_) => todo!(),
-                NumericLiteral::Decimal(_) => todo!(),
-                NumericLiteral::Double(f) => (*f).into(),
-                NumericLiteral::Float(f) => f.to_string().into(),
+                OrderValue::Integer(i) => (*i).into(),
+                OrderValue::Decimal(d) => {
+                    let decimal_literal = ConcreteLiteral::NumericLiteral(NumericLiteral::Decimal(d.clone()));
+                    let literal: RDF::Literal = decimal_literal.try_into().unwrap_or_else(|_| unreachable!());
+                    literal
+                },
             };
 
             graph
@@ -297,5 +310,70 @@ impl IRPropertyShape {
                 }
             }
         }
+    }
+}
+
+impl Display for IRPropertyShape {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "PropertyShape {}", self.id())?;
+        writeln!(f, " path: {}", self.path())?;
+        if let Some(reifier_info) = self.reifier_info() {
+            writeln!(
+                f,
+                " reifier info: reification required: {}, reifier shapes: [{}]",
+                reifier_info.reification_required(),
+                reifier_info
+                    .reifier_shape()
+                    .iter()
+                    .map(|s| s.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )?;
+        }
+        if let Some(message) = self.message() {
+            writeln!(f, " message: {message}")?;
+        }
+        if let Some(name) = self.name() {
+            writeln!(f, " name: {name}")?;
+        }
+        if let Some(description) = self.description() {
+            writeln!(f, " description: {description}")?;
+        }
+        if let Some(order) = self.order() {
+            writeln!(f, " order: {order}")?;
+        }
+
+        if self.deactivated() {
+            writeln!(f, " Deactivated: {}", self.deactivated())?;
+        }
+        if self.severity() != &Severity::Violation {
+            writeln!(f, " Severity: {}", self.severity())?;
+        }
+        if self.closed() {
+            writeln!(f, " closed: {}", self.closed())?;
+        }
+        let mut components = self.components().iter().peekable();
+        if components.peek().is_some() {
+            writeln!(f, "Components:")?;
+            for component in components {
+                writeln!(f, " - {component}")?;
+            }
+        }
+        let mut targets = self.targets().iter().peekable();
+        if targets.peek().is_some() {
+            writeln!(f, "Targets:")?;
+            for target in targets {
+                writeln!(f, " - {target}")?;
+            }
+        }
+        let mut property_shapes = self.property_shapes().iter().peekable();
+        if property_shapes.peek().is_some() {
+            writeln!(
+                f,
+                " Property Shapes: [{}]",
+                property_shapes.map(|ps| ps.to_string()).collect::<Vec<_>>().join(", ")
+            )?;
+        }
+        Ok(())
     }
 }

--- a/shacl/src/ir/shape.rs
+++ b/shacl/src/ir/shape.rs
@@ -105,6 +105,20 @@ impl IRShape {
             IRShape::PropertyShape(ps) => ps.message(),
         }
     }
+
+    pub fn name(&self) -> Option<&MessageMap> {
+        match self {
+            IRShape::NodeShape(ns) => ns.name(),
+            IRShape::PropertyShape(ps) => ps.name(),
+        }
+    }
+
+    pub fn description(&self) -> Option<&MessageMap> {
+        match self {
+            IRShape::NodeShape(ns) => ns.description(),
+            IRShape::PropertyShape(ps) => ps.description(),
+        }
+    }
 }
 
 impl IRShape {
@@ -126,57 +140,9 @@ impl IRShape {
 impl Display for IRShape {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            IRShape::NodeShape(_) => writeln!(f, "NodeShape")?,
-            IRShape::PropertyShape(shape) => {
-                writeln!(f, "PropertyShape")?;
-                writeln!(f, " path: {}", shape.path())?;
-                if let Some(reifier_info) = shape.reifier_info() {
-                    writeln!(
-                        f,
-                        " reifier info: reification required: {}, reifier shapes: [{}]",
-                        reifier_info.reification_required(),
-                        reifier_info
-                            .reifier_shape()
-                            .iter()
-                            .map(|s| s.to_string())
-                            .collect::<Vec<_>>()
-                            .join(", ")
-                    )?;
-                }
-            },
+            IRShape::NodeShape(ns) => write!(f, "{ns}")?,
+            IRShape::PropertyShape(ps) => write!(f, "{ps}")?,
         }
-        if self.deactivated() {
-            writeln!(f, " Deactivated: {}", self.deactivated())?;
-        }
-        if self.severity() != &Severity::Violation {
-            writeln!(f, " Severity: {}", self.severity())?;
-        }
-        if self.closed() {
-            writeln!(f, " closed: {}", self.closed())?;
-        }
-        let mut components = self.components().iter().peekable();
-        if components.peek().is_some() {
-            writeln!(f, "Components:")?;
-            for component in components {
-                writeln!(f, " - {component}")?;
-            }
-        }
-        let mut targets = self.targets().iter().peekable();
-        if targets.peek().is_some() {
-            writeln!(f, "Targets:")?;
-            for target in targets {
-                writeln!(f, " - {target}")?;
-            }
-        }
-        let mut property_shapes = self.property_shapes().iter().peekable();
-        if property_shapes.peek().is_some() {
-            writeln!(
-                f,
-                " Property Shapes: [{}]",
-                property_shapes.map(|ps| ps.to_string()).collect::<Vec<_>>().join(", ")
-            )?;
-        }
-
         Ok(())
     }
 }

--- a/shacl/src/rdf/parsers/components.rs
+++ b/shacl/src/rdf/parsers/components.rs
@@ -52,7 +52,7 @@ pub(crate) fn components<RDF: FocusRDF>() -> impl RDFNodeParse<RDF, Output = Vec
         Box::new(has_value()),
         Box::new(in_component()),
         // Non-validating constraint components
-        
+
         // SPARQL based constraints and SPARQL based constraint components
         Box::new(basic_sparql()),
         // TODO: deactivated is not a shape component...move this code elsewhere?

--- a/shacl/src/rdf/parsers/components.rs
+++ b/shacl/src/rdf/parsers/components.rs
@@ -51,6 +51,8 @@ pub(crate) fn components<RDF: FocusRDF>() -> impl RDFNodeParse<RDF, Output = Vec
         Box::new(closed()),
         Box::new(has_value()),
         Box::new(in_component()),
+        // Non-validating constraint components
+        
         // SPARQL based constraints and SPARQL based constraint components
         Box::new(basic_sparql()),
         // TODO: deactivated is not a shape component...move this code elsewhere?

--- a/shacl/src/rdf/parsers/non_shape/description.rs
+++ b/shacl/src/rdf/parsers/non_shape/description.rs
@@ -1,0 +1,21 @@
+use crate::types::MessageMap;
+use rudof_rdf::rdf_core::parser::rdf_node_parser::constructors::LiteralsPropertyParser;
+use rudof_rdf::rdf_core::parser::rdf_node_parser::{ParserExt, RDFNodeParse};
+use rudof_rdf::rdf_core::vocabs::ShaclVocab;
+use rudof_rdf::rdf_core::{FocusRDF, RDFError};
+
+pub(crate) fn description<RDF: FocusRDF>() -> impl RDFNodeParse<RDF, Output = MessageMap> {
+    LiteralsPropertyParser::new(ShaclVocab::sh_description()).flat_map(|lits| {
+        if lits.is_empty() {
+            return Err(RDFError::ParseFailError {
+                msg: "No sh:description found".to_string(),
+            });
+        }
+        let map = lits.into_iter().fold(MessageMap::new(), |acc, lit| {
+            let lang = lit.lang();
+            let text = lit.lexical_form().to_string();
+            acc.with_message(lang, text)
+        });
+        Ok(map)
+    })
+}

--- a/shacl/src/rdf/parsers/non_shape/mod.rs
+++ b/shacl/src/rdf/parsers/non_shape/mod.rs
@@ -1,7 +1,13 @@
 mod deactivated;
+mod description;
 mod message;
+mod name;
+mod order;
 mod severity;
 
 pub(crate) use deactivated::deactivated;
+pub(crate) use description::description;
 pub(crate) use message::message;
+pub(crate) use name::name;
+pub(crate) use order::order;
 pub(crate) use severity::severity;

--- a/shacl/src/rdf/parsers/non_shape/name.rs
+++ b/shacl/src/rdf/parsers/non_shape/name.rs
@@ -1,0 +1,22 @@
+use crate::types::MessageMap;
+use rudof_rdf::rdf_core::parser::rdf_node_parser::constructors::LiteralsPropertyParser;
+use rudof_rdf::rdf_core::parser::rdf_node_parser::{ParserExt, RDFNodeParse};
+use rudof_rdf::rdf_core::vocabs::ShaclVocab;
+use rudof_rdf::rdf_core::{FocusRDF, RDFError};
+
+pub(crate) fn name<RDF: FocusRDF>() -> impl RDFNodeParse<RDF, Output = MessageMap> {
+    LiteralsPropertyParser::new(ShaclVocab::sh_name()).flat_map(|lits| {
+        // TODO: Check that the values of name are only of type xsd:string, rdf:langString or rdf:dirLangString according to SHACL 1.2
+        if lits.is_empty() {
+            return Err(RDFError::ParseFailError {
+                msg: "No value for sh:name found".to_string(),
+            });
+        }
+        let map = lits.into_iter().fold(MessageMap::new(), |acc, lit| {
+            let lang = lit.lang();
+            let text = lit.lexical_form().to_string();
+            acc.with_message(lang, text)
+        });
+        Ok(map)
+    })
+}

--- a/shacl/src/rdf/parsers/non_shape/order.rs
+++ b/shacl/src/rdf/parsers/non_shape/order.rs
@@ -1,0 +1,70 @@
+use crate::ir::OrderValue;
+use rudof_rdf::rdf_core::parser::rdf_node_parser::constructors::SingleLiteralPropertyParser;
+use rudof_rdf::rdf_core::parser::rdf_node_parser::{ParserExt, RDFNodeParse};
+use rudof_rdf::rdf_core::term::literal::{ConcreteLiteral, NumericLiteral};
+use rudof_rdf::rdf_core::vocabs::{ShaclVocab, XsdVocab};
+use rudof_rdf::rdf_core::{FocusRDF, RDFError};
+use rust_decimal::Decimal;
+
+pub(crate) fn order<RDF: FocusRDF>() -> impl RDFNodeParse<RDF, Output = OrderValue> {
+    println!("Parsing sh:order");
+    SingleLiteralPropertyParser::new(ShaclVocab::sh_order()).flat_map(|lit: RDF::Literal| match lit.try_into() {
+        Ok(concrete_literal) => {
+            println!("Parsed literal: {}", concrete_literal);
+            parse_order_value(concrete_literal)
+        },
+        Err(_e) => Err(RDFError::ParseFailError {
+            msg: format!("Failed to convert literal to concrete literal"),
+        }),
+    })
+}
+
+fn parse_order_value(concrete_literal: ConcreteLiteral) -> Result<OrderValue, RDFError> {
+    println!("Parsing order value from concrete literal: {}", concrete_literal);
+    match concrete_literal {
+        ConcreteLiteral::NumericLiteral(NumericLiteral::Integer(i)) => {
+            println!("Parsed order value as integer: {}", i);
+            Ok(OrderValue::Integer(i))
+        },
+        ConcreteLiteral::NumericLiteral(NumericLiteral::Decimal(d)) => Ok(OrderValue::Decimal(d)),
+        ConcreteLiteral::DatatypeLiteral { lexical_form, datatype } => {
+            let datatype_iris = datatype.get_iri().map_err(|e| RDFError::ParseFailError {
+                msg: format!("Failed to get datatype IRI: {}", e),
+            })?;
+            if datatype_iris == &XsdVocab::xsd_integer() {
+                match lexical_form.parse::<i128>() {
+                    Ok(i) => Ok(OrderValue::Integer(i)),
+                    Err(e) => Err(RDFError::ParseFailError {
+                        msg: format!("Failed to parse integer from lexical form '{}': {}", lexical_form, e),
+                    }),
+                }
+            } else if datatype_iris == &XsdVocab::xsd_decimal() {
+                match Decimal::from_str_exact(&lexical_form) {
+                    Ok(d) => Ok(OrderValue::Decimal(d)),
+                    Err(e) => Err(RDFError::ParseFailError {
+                        msg: format!("Failed to parse decimal from lexical form '{}': {}", lexical_form, e),
+                    }),
+                }
+            } else {
+                Err(RDFError::ParseFailError {
+                    msg: format!(
+                        "Value of sh:order must be an integer or a decimal literal. Got datatype {}",
+                        datatype
+                    ),
+                })
+            }
+        },
+        _ => {
+            println!(
+                "Failed to parse order value from concrete literal: {:?}",
+                concrete_literal
+            );
+            Err(RDFError::ParseFailError {
+                msg: format!(
+                    "Value of sh:order must be an integer or a decimal literal. Got {}",
+                    concrete_literal
+                ),
+            })
+        },
+    }
+}

--- a/shacl/src/rdf/parsers/non_shape/order.rs
+++ b/shacl/src/rdf/parsers/non_shape/order.rs
@@ -14,7 +14,7 @@ pub(crate) fn order<RDF: FocusRDF>() -> impl RDFNodeParse<RDF, Output = OrderVal
             parse_order_value(concrete_literal)
         },
         Err(_e) => Err(RDFError::ParseFailError {
-            msg: format!("Failed to convert literal to concrete literal"),
+            msg: "Failed to convert literal to concrete literal".to_string(),
         }),
     })
 }

--- a/shacl/src/rdf/parsers/shape_type/property_shape.rs
+++ b/shacl/src/rdf/parsers/shape_type/property_shape.rs
@@ -1,6 +1,6 @@
 use crate::ast::ASTPropertyShape;
 use crate::rdf::parsers::components::components;
-use crate::rdf::parsers::non_shape::message;
+use crate::rdf::parsers::non_shape::{description, message, name, order};
 use crate::rdf::parsers::{path, property, reifier_shape, severity, targets};
 use rudof_rdf::rdf_core::FocusRDF;
 use rudof_rdf::rdf_core::parser::rdf_node_parser::constructors::{
@@ -28,6 +28,18 @@ pub(crate) fn property_shape<RDF: FocusRDF + 'static>() -> impl RDFNodeParse<RDF
                 message()
                     .optional()
                     .flat_map(move |msg| Ok(ps.clone().with_message(msg)))
+            })
+            .then(|ps| name().optional().flat_map(move |name| Ok(ps.clone().with_name(name))))
+            .then(|ps| {
+                order().optional().flat_map(move |order| {
+                    println!("Parsed order: {:?}", order);
+                    Ok(ps.clone().with_order(order))
+                })
+            })
+            .then(|ps| {
+                description()
+                    .optional()
+                    .flat_map(move |desc| Ok(ps.clone().with_description(desc)))
             })
             .then(|ps| reifier_shape().flat_map(move |r_shape| Ok(ps.clone().with_reifier_shape(r_shape))))
             .then(|ps| targets().flat_map(move |ts| Ok(ps.clone().with_targets(ts))))

--- a/shacl/src/types/message_map.rs
+++ b/shacl/src/types/message_map.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use rudof_rdf::rdf_core::term::literal::{ConcreteLiteral, Lang};
 use std::collections::HashMap;
 use std::collections::hash_map::IntoIter;
@@ -75,16 +74,27 @@ impl From<String> for MessageMap {
 
 impl Display for MessageMap {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "MessageMap {{")?;
+        let mut entries: Vec<_> = self.messages.iter().collect();
 
-        let data = self
-            .iter()
-            .map(|(l, msg)| match l {
-                None => format!("default: {:?}", msg),
-                Some(l) => format!("{:?}: {:?}", l, msg),
-            })
-            .join(", ");
+        entries.sort_by_key(|(lang, _)| lang.as_ref());
 
-        write!(f, "{data}}}")
+        if entries.len() == 1 {
+            if let Some((None, msg)) = entries.first() {
+                return write!(f, "\"{msg}\"");
+            }
+        }
+
+        for (i, (lang, msg)) in entries.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+
+            match lang {
+                None => write!(f, "\"{msg}\"")?,
+                Some(lang) => write!(f, "\"{msg}\"@{lang}")?,
+            }
+        }
+
+        Ok(())
     }
 }

--- a/shacl/src/types/message_map.rs
+++ b/shacl/src/types/message_map.rs
@@ -78,10 +78,10 @@ impl Display for MessageMap {
 
         entries.sort_by_key(|(lang, _)| lang.as_ref());
 
-        if entries.len() == 1 {
-            if let Some((None, msg)) = entries.first() {
-                return write!(f, "\"{msg}\"");
-            }
+        if entries.len() == 1
+            && let Some((None, msg)) = entries.first()
+        {
+            return write!(f, "\"{msg}\"");
         }
 
         for (i, (lang, msg)) in entries.iter().enumerate() {

--- a/shex_validation/src/engine.rs
+++ b/shex_validation/src/engine.rs
@@ -1433,7 +1433,16 @@ impl Engine {
                     .triple_expr()
                     .components()
                     .all(|(_, _, cond)| !cond_has_ref(&cond));
-                if !main_preds.is_empty() && no_shape_refs {
+                // Skip this shortcut when the ancestor's predicates overlap with the child
+                // shape's own declared predicates. In that case a single triple can satisfy
+                // both the ancestor's condition (e.g. a datatype constraint) and the child's
+                // own, more specific condition (e.g. a value set), and how many triples go to
+                // each side is exactly the counting problem the partition algorithm in
+                // check_node_shape_extends solves; this exhaustive pre-filter cannot (it can
+                // only keep-or-exclude a triple wholesale, not split a run of them between
+                // the two buckets in the right proportions).
+                let overlaps_child_preds = shape.preds().iter().any(|p| main_preds.contains(p));
+                if !main_preds.is_empty() && no_shape_refs && !overlaps_child_preds {
                     let (all_values, _) = self.neighs(node, main_preds, rdf)?;
                     let all_values_ctx: Vec<_> = all_values
                         .iter()


### PR DESCRIPTION
fix(shex): skip extends pre-check shortcut on predicate overlap

When an ancestor's predicates overlap the child shape's own declared
predicates, a single triple can satisfy both conditions, so the
exhaustive keep-or-exclude pre-filter can't correctly split triples
between the two buckets. Defer to the partition algorithm in
check_node_shape_extends instead, which handles the counting properly.