### PR TITLE
feat: Add --show-intermediate-results to stream ShEx validation progress

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4192,6 +4192,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "rudof_typing"
+version = "0.3.16"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "rudof_viz"
 version = "0.3.16"
 dependencies = [
@@ -4829,6 +4836,7 @@ dependencies = [
 name = "shex_validation"
 version = "0.3.16"
 dependencies = [
+ "colored",
  "either",
  "indexmap 2.14.0",
  "itertools 0.14.0",
@@ -4837,6 +4845,7 @@ dependencies = [
  "rudof_config",
  "rudof_iri",
  "rudof_rdf",
+ "rudof_typing",
  "serde",
  "serde_json",
  "shex_ast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "shex_ast",
     "shex_testsuite",
     "shex_validation",
+    "rudof_typing",
     "sparql_service",
     "benchmarks/bench-shex",
     "benchmarks/bench-issue730",
@@ -334,6 +335,7 @@ rudof_cli = { version = "0.3.16", path = "./rudof_cli" }
 rudof_config = { version = "0.3.16", path = "./rudof_config" }
 rudof_iri = { version = "0.3.16", path = "./rudof_iri" }
 rudof_rdf = { version = "0.3.16", path = "./rudof_rdf", default-features = false }
+rudof_typing = { version = "0.3.16", path = "./rudof_typing" }
 rudof_viz = { version = "0.3.16", path = "./rudof_viz" }
 rudof_generate = { version = "0.3.16", path = "./rudof_generate" }
 rudof_lib = { version = "0.3.16", path = "./rudof_lib" }

--- a/examples/user.ttl
+++ b/examples/user.ttl
@@ -13,7 +13,7 @@ prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
    schema:knows :c       .
 
 :c a :Person ;
-   :status      :Inactive ;
+   :status      :Active ;
    schema:name  "Carol"  .
 
 :d a :Person ;

--- a/rudof_cli/src/cli/parser/shex_validate.rs
+++ b/rudof_cli/src/cli/parser/shex_validate.rs
@@ -172,6 +172,12 @@ pub struct ShexValidateArgs {
     )]
     pub list_external_resolvers: bool,
 
+    #[arg(
+        long = "show-intermediate-results",
+        help = "Print each (node, shape) result as soon as it's computed, instead of only the final report"
+    )]
+    pub show_intermediate_results: bool,
+
     #[command(flatten)]
     pub common: CommonArgsAll,
 }

--- a/rudof_cli/src/cli/parser/validate.rs
+++ b/rudof_cli/src/cli/parser/validate.rs
@@ -135,6 +135,12 @@ pub struct ValidateArgs {
     #[arg(long = "map-state", value_name = "FILE", help = "MapState file name")]
     pub map_state: Option<PathBuf>,
 
+    #[arg(
+        long = "show-intermediate-results",
+        help = "Print each (node, shape) result as soon as it's computed, instead of only the final report"
+    )]
+    pub show_intermediate_results: bool,
+
     #[command(flatten)]
     pub common: CommonArgsAll,
 }

--- a/rudof_cli/src/commands/shex_validate.rs
+++ b/rudof_cli/src/commands/shex_validate.rs
@@ -58,7 +58,11 @@ impl Command for ShexValidateCommand {
         // dependencies instead of failing fast.
         {
             let mut cfg = ctx.rudof.config().execute().clone();
-            let vc = cfg.shex_validator().clone().with_max_steps(Some(self.args.max_steps));
+            let vc = cfg
+                .shex_validator()
+                .clone()
+                .with_max_steps(Some(self.args.max_steps))
+                .with_show_intermediate_results(self.args.show_intermediate_results);
             cfg = cfg.with_shex_validator(vc);
             ctx.rudof.update_config(cfg).execute();
         }

--- a/rudof_cli/src/commands/validate.rs
+++ b/rudof_cli/src/commands/validate.rs
@@ -50,6 +50,7 @@ impl ValidateCommand {
             strict_iris: false,
             external_resolvers: Vec::new(),
             list_external_resolvers: false,
+            show_intermediate_results: self.args.show_intermediate_results,
             common: self.args.common.clone(),
         })
     }

--- a/rudof_typing/Cargo.toml
+++ b/rudof_typing/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rudof_typing"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation = "https://docs.rs/rudof_typing"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+either.workspace = true

--- a/rudof_typing/src/lib.rs
+++ b/rudof_typing/src/lib.rs
@@ -1,0 +1,144 @@
+//! Generic `(node, shape label) -> outcome` memoization cache with an
+//! observer hook, shared across rudof's validators.
+//!
+//! A validator proves `(node, shape label)` pairs, possibly several times
+//! via different recursive paths. [`Typing`] is the cache that lets a pair
+//! be proved once and reused; [`TypingObserver`] lets a caller be notified
+//! of each newly-cached result as it happens, e.g. to show progress or to
+//! recover partial results if validation is interrupted.
+//!
+//! `N` is the node type, `L` the shape-label type, `E` the error type
+//! explaining why a pair doesn't conform, and `Ev` the evidence type
+//! explaining why it does (e.g. for ShEx: `Node`, `ShapeLabelIdx`,
+//! `ValidatorError`, `Reason`).
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+use std::hash::Hash;
+use std::sync::Arc;
+
+use either::Either;
+
+/// The outcome of proving one `(node, shape label)` pair: either it
+/// conforms (with a list of `Ev` evidence of why), or it doesn't (with a
+/// list of `E` errors explaining why not).
+pub type ValidationResult<E, Ev> = Either<Vec<E>, Vec<Ev>>;
+
+/// A cache of `(N, L) -> ValidationResult<E, Ev>` built up during
+/// validation. Results are memoized here and reused across recursive
+/// calls, so a pair reachable from several branches is proved once.
+pub trait Typing<N, L, E, Ev> {
+    fn get(&self, key: &(N, L)) -> Option<&ValidationResult<E, Ev>>;
+    fn insert(&mut self, key: (N, L), value: ValidationResult<E, Ev>);
+}
+
+/// Notified whenever an [`ObservableTyping`] caches a newly-proved
+/// `(node, shape)` result. Lets a caller surface validation progress as it
+/// happens, or collect partial results if validation is later interrupted.
+pub trait TypingObserver<N, L, E, Ev>: Send + Sync + Debug {
+    fn on_insert(&self, key: &(N, L), value: &ValidationResult<E, Ev>);
+}
+
+/// Default [`Typing`] implementation: a plain memoization cache that also
+/// notifies an optional [`TypingObserver`] on every insert.
+#[derive(Debug, Clone)]
+pub struct ObservableTyping<N, L, E, Ev>
+where
+    N: Eq + Hash + Clone + Debug,
+    L: Eq + Hash + Clone + Debug,
+{
+    map: HashMap<(N, L), ValidationResult<E, Ev>>,
+    observer: Option<Arc<dyn TypingObserver<N, L, E, Ev>>>,
+}
+
+impl<N, L, E, Ev> ObservableTyping<N, L, E, Ev>
+where
+    N: Eq + Hash + Clone + Debug,
+    L: Eq + Hash + Clone + Debug,
+{
+    pub fn new(observer: Option<Arc<dyn TypingObserver<N, L, E, Ev>>>) -> Self {
+        ObservableTyping {
+            map: HashMap::new(),
+            observer,
+        }
+    }
+}
+
+// Not `#[derive(Default)]`: that would force `N`/`L`/`E`/`Ev`: Default too,
+// which none of this crate's actual instantiations need or provide.
+impl<N, L, E, Ev> Default for ObservableTyping<N, L, E, Ev>
+where
+    N: Eq + Hash + Clone + Debug,
+    L: Eq + Hash + Clone + Debug,
+{
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+impl<N, L, E, Ev> Typing<N, L, E, Ev> for ObservableTyping<N, L, E, Ev>
+where
+    N: Eq + Hash + Clone + Debug,
+    L: Eq + Hash + Clone + Debug,
+{
+    fn get(&self, key: &(N, L)) -> Option<&ValidationResult<E, Ev>> {
+        self.map.get(key)
+    }
+
+    fn insert(&mut self, key: (N, L), value: ValidationResult<E, Ev>) {
+        if let Some(observer) = &self.observer {
+            observer.on_insert(&key, &value);
+        }
+        self.map.insert(key, value);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    #[test]
+    fn insert_then_get_returns_the_cached_value() {
+        let mut typing: ObservableTyping<i32, i32, String, String> = ObservableTyping::default();
+        assert!(typing.get(&(1, 2)).is_none());
+        typing.insert((1, 2), Either::Right(vec!["ok".to_string()]));
+        assert_eq!(typing.get(&(1, 2)), Some(&Either::Right(vec!["ok".to_string()])));
+    }
+
+    #[test]
+    fn get_on_a_different_key_is_none() {
+        let mut typing: ObservableTyping<i32, i32, String, String> = ObservableTyping::default();
+        typing.insert((1, 2), Either::Left(vec!["bad".to_string()]));
+        assert!(typing.get(&(1, 3)).is_none());
+        assert!(typing.get(&(2, 2)).is_none());
+    }
+
+    #[derive(Debug, Default)]
+    struct RecordingObserver {
+        seen: Mutex<Vec<(i32, i32, ValidationResult<String, String>)>>,
+    }
+
+    impl TypingObserver<i32, i32, String, String> for RecordingObserver {
+        fn on_insert(&self, key: &(i32, i32), value: &ValidationResult<String, String>) {
+            self.seen.lock().unwrap().push((key.0, key.1, value.clone()));
+        }
+    }
+
+    #[test]
+    fn observer_is_notified_on_insert_with_the_right_key_and_value() {
+        let observer = Arc::new(RecordingObserver::default());
+        let mut typing: ObservableTyping<i32, i32, String, String> = ObservableTyping::new(Some(observer.clone()));
+        typing.insert((7, 9), Either::Right(vec!["evidence".to_string()]));
+        let seen = observer.seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0], (7, 9, Either::Right(vec!["evidence".to_string()])));
+    }
+
+    #[test]
+    fn no_observer_means_no_panic_and_no_notification() {
+        let mut typing: ObservableTyping<i32, i32, String, String> = ObservableTyping::default();
+        typing.insert((1, 1), Either::Right(vec![]));
+        assert!(typing.get(&(1, 1)).is_some());
+    }
+}

--- a/shex_validation/Cargo.toml
+++ b/shex_validation/Cargo.toml
@@ -13,6 +13,7 @@ repository.workspace = true
 #default = []
 
 [dependencies]
+colored.workspace = true
 either.workspace = true     # "1"
 indexmap.workspace = true   # { version = "2" }
 rudof_config.workspace = true
@@ -20,6 +21,7 @@ rudof_iri.workspace = true
 itertools.workspace = true
 prefixmap.workspace = true
 rbe.workspace = true
+rudof_typing.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 shex_ast.workspace = true

--- a/shex_validation/src/engine.rs
+++ b/shex_validation/src/engine.rs
@@ -7,6 +7,7 @@ use crate::ValidatorErrors;
 use crate::atom;
 use crate::no_match_reason::NoMatchReason;
 use crate::ref_typing::RefTyping;
+use crate::typing::{ObservableTyping, Typing, ValidationResult};
 use crate::validator_error::*;
 use either::Either;
 use indexmap::IndexSet;
@@ -43,7 +44,6 @@ type Atom = atom::Atom<(Node, ShapeLabelIdx)>;
 type NegAtom = (Node, ShapeLabelIdx);
 type PosAtom = (Node, ShapeLabelIdx);
 type Neighs = (Vec<(Pred, Node)>, Vec<Pred>);
-type ValidationResult = Either<Vec<ValidatorError>, Vec<Reason>>;
 
 #[derive(Debug, Clone)]
 pub struct Engine {
@@ -53,7 +53,7 @@ pub struct Engine {
     step_counter: usize,
     reasons: HashMap<PosAtom, Vec<Reason>>,
     errors: HashMap<NegAtom, Vec<ValidatorError>>,
-    typing: HashMap<(Node, ShapeLabelIdx), ValidationResult>,
+    typing: ObservableTyping,
     hyp_touched: bool,
 }
 
@@ -66,7 +66,7 @@ impl Engine {
             step_counter: 0,
             reasons: HashMap::new(),
             errors: HashMap::new(),
-            typing: HashMap::new(),
+            typing: ObservableTyping::new(config.typing_observer()),
             hyp_touched: false,
         }
     }
@@ -95,13 +95,26 @@ impl Engine {
                         continue;
                     }
                     let mut hyp = Vec::new();
-                    match self.prove(&node, &idx, &mut hyp, schema, rdf)? {
-                        Either::Right(reasons) => {
+                    match self.prove(&node, &idx, &mut hyp, schema, rdf) {
+                        Ok(Either::Right(reasons)) => {
                             self.add_checked_pos(atom, reasons);
                         },
-                        Either::Left(errors) => {
+                        Ok(Either::Left(errors)) => {
                             self.add_checked_neg(atom, errors);
                         },
+                        Err(ValidatorError::Cancelled { .. }) => {
+                            // Validation was interrupted: stop here and let the
+                            // caller see whatever was already proved. The
+                            // in-flight pair goes back to `pending` so it's
+                            // reported as `Pending` rather than lost.
+                            debug!(
+                                pending = self.pending.len() + 1,
+                                "ShEx validation cancelled; returning partial results"
+                            );
+                            self.pending.insert(atom);
+                            break;
+                        },
+                        Err(e) => return Err(e),
                     }
                 },
                 Atom::Neg((node, idx)) => {

--- a/shex_validation/src/typing.rs
+++ b/shex_validation/src/typing.rs
@@ -1,22 +1,125 @@
 use std::collections::HashMap;
 
-use shex_ast::{Node, ShapeLabelIdx, shapemap::ValidationStatus};
+use colored::{Color, Colorize};
+use either::Either;
+use prefixmap::PrefixMap;
+use shex_ast::ir::schema_ir::SchemaIR;
+use shex_ast::ir::shape_label::ShapeLabel;
+use shex_ast::{Node, ShapeLabelIdx};
 
-/// Typing represents a mapping from (Node, ShapeLabelIdx) to ValidationStatus
-/// This will be used to collect errors and reasons during validation
-#[derive(Debug, Clone)]
-pub struct Typing {
-    _map: HashMap<(Node, ShapeLabelIdx), ValidationStatus>,
-}
+use crate::reason::Reason;
+use crate::validator_error::ValidatorError;
 
-impl Typing {
-    pub fn new() -> Self {
-        Typing { _map: HashMap::new() }
+/// ShEx's instantiation of `rudof_typing`'s generic validation outcome:
+/// either the reasons why a `(Node, ShapeLabelIdx)` pair conforms, or the
+/// errors why it doesn't.
+pub type ValidationResult = rudof_typing::ValidationResult<ValidatorError, Reason>;
+
+/// ShEx's instantiation of the generic memoization-cache trait. See
+/// [`rudof_typing::Typing`] for the generic contract.
+pub use rudof_typing::Typing;
+
+/// ShEx's instantiation of the generic memoization cache: a plain
+/// `HashMap`-backed [`Typing`] that also notifies an optional
+/// [`TypingObserver`] on every insert.
+pub type ObservableTyping = rudof_typing::ObservableTyping<Node, ShapeLabelIdx, ValidatorError, Reason>;
+
+/// ShEx's instantiation of the generic typing-observer trait, as the exact
+/// `dyn` type stored in [`crate::ValidatorConfig`] and passed around as
+/// `Arc<TypingObserver>`. A new observer (see [`ConsoleTypingObserver`]
+/// below) implements `rudof_typing::TypingObserver<Node, ShapeLabelIdx,
+/// ValidatorError, Reason>` directly, which coerces to this type.
+pub type TypingObserver = dyn rudof_typing::TypingObserver<Node, ShapeLabelIdx, ValidatorError, Reason>;
+
+/// Qualifies a shape label against a prefixmap, mirroring `ShapeLabel`'s own
+/// `Display` impl but relativizing the `Iri` case.
+fn qualify_shape_label(label: &ShapeLabel, prefixmap: &PrefixMap) -> String {
+    match label {
+        ShapeLabel::Iri(iri) => prefixmap.qualify(iri),
+        ShapeLabel::BNode(bnode) => bnode.to_string(),
+        ShapeLabel::Start => "Start".to_string(),
     }
 }
 
-impl Default for Typing {
-    fn default() -> Self {
-        Self::new()
+/// Default [`TypingObserver`] for `show_intermediate_results`: prints each
+/// `(node, shape)` result to stderr as soon as it's cached, so a user can
+/// follow validation progress instead of waiting for the final report.
+/// Nodes and shape labels are qualified against their prefixmaps, and the
+/// conformant/non-conformant verdict is colorized.
+#[derive(Debug)]
+pub struct ConsoleTypingObserver {
+    labels: HashMap<ShapeLabelIdx, String>,
+    nodes_prefixmap: PrefixMap,
+    conformant_color: Color,
+    non_conformant_color: Color,
+}
+
+impl ConsoleTypingObserver {
+    pub fn new(
+        schema: &SchemaIR,
+        nodes_prefixmap: PrefixMap,
+        conformant_color: Color,
+        non_conformant_color: Color,
+    ) -> Self {
+        let shapes_prefixmap = schema.prefixmap();
+        let mut labels = HashMap::new();
+        for (label, _iri, _expr) in schema.shapes() {
+            if let Ok(idx) = schema.get_shape_label_idx(label) {
+                labels.insert(idx, qualify_shape_label(label, &shapes_prefixmap));
+            }
+        }
+        ConsoleTypingObserver {
+            labels,
+            nodes_prefixmap,
+            conformant_color,
+            non_conformant_color,
+        }
+    }
+}
+
+impl rudof_typing::TypingObserver<Node, ShapeLabelIdx, ValidatorError, Reason> for ConsoleTypingObserver {
+    fn on_insert(&self, key: &(Node, ShapeLabelIdx), value: &ValidationResult) {
+        let (node, idx) = key;
+        let node = node.show_qualified(&self.nodes_prefixmap);
+        let shape = self.labels.get(idx).map(String::as_str).unwrap_or("?");
+        match value {
+            Either::Right(reasons) => {
+                let status = "conformant".color(self.conformant_color);
+                eprintln!(
+                    "[validating] {node} @ {shape} -> {status} ({} reason(s))",
+                    reasons.len()
+                );
+            },
+            Either::Left(errors) => {
+                let status = "non-conformant".color(self.non_conformant_color);
+                eprintln!("[validating] {node} @ {shape} -> {status} ({} error(s))", errors.len());
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rudof_iri::IriS;
+    use shex_ast::BNode;
+
+    #[test]
+    fn qualify_shape_label_qualifies_iris_against_the_prefixmap() {
+        let prefixmap: PrefixMap = std::collections::HashMap::from([("ex", "http://a.example/")])
+            .try_into()
+            .unwrap();
+        let label = ShapeLabel::iri(IriS::new_unchecked("http://a.example/S"));
+        assert_eq!(qualify_shape_label(&label, &prefixmap), "ex:S");
+    }
+
+    #[test]
+    fn qualify_shape_label_leaves_bnodes_and_start_untouched() {
+        let prefixmap = PrefixMap::default();
+        assert_eq!(
+            qualify_shape_label(&ShapeLabel::from_bnode(BNode::from("b1")), &prefixmap),
+            "_:b1"
+        );
+        assert_eq!(qualify_shape_label(&ShapeLabel::Start, &prefixmap), "Start");
     }
 }

--- a/shex_validation/src/validator.rs
+++ b/shex_validation/src/validator.rs
@@ -3,6 +3,7 @@ use crate::ValidatorConfig;
 use crate::atom;
 use crate::engine::Engine;
 use crate::validator_error::*;
+use colored::Color;
 use prefixmap::PrefixMap;
 use rudof_rdf::rdf_core::{NeighsRDF, query::QueryRDF};
 use serde_json::Value;
@@ -14,6 +15,7 @@ use shex_ast::ir::shape_label::ShapeLabel;
 use shex_ast::shapemap::ResultShapeMap;
 use shex_ast::shapemap::ValidationStatus;
 use shex_ast::shapemap::query_shape_map::QueryShapeMap;
+use std::str::FromStr;
 use tracing::trace;
 
 type Result<T> = std::result::Result<T, ValidatorError>;
@@ -91,6 +93,29 @@ impl Validator {
         &self.schema
     }
 
+    /// The config to hand `Engine::new`: same as `self.config`, except that
+    /// when `show_intermediate_results` is on and no observer was installed
+    /// explicitly, a [`ConsoleTypingObserver`] is added, bound to the
+    /// prefixmaps available for *this* call — `schema`'s own prefixmap for
+    /// shape labels, and `maybe_nodes_prefixmap` (only known per-call, not
+    /// at construction time) for nodes.
+    fn engine_config(&self, schema: &SchemaIR, maybe_nodes_prefixmap: &Option<PrefixMap>) -> ValidatorConfig {
+        if self.config.show_intermediate_results() && self.config.typing_observer().is_none() {
+            let nodes_prefixmap = maybe_nodes_prefixmap.clone().unwrap_or_default();
+            let conformant_color = Color::from_str(self.config.conformant_color()).unwrap_or(Color::Green);
+            let non_conformant_color = Color::from_str(self.config.non_conformant_color()).unwrap_or(Color::Red);
+            let observer = crate::typing::ConsoleTypingObserver::new(
+                schema,
+                nodes_prefixmap,
+                conformant_color,
+                non_conformant_color,
+            );
+            self.config.clone().with_typing_observer(std::sync::Arc::new(observer))
+        } else {
+            self.config.clone()
+        }
+    }
+
     /// validate a node against a shape label
     pub fn validate_node_shape<S>(
         &mut self,
@@ -103,7 +128,7 @@ impl Validator {
     where
         S: NeighsRDF + QueryRDF,
     {
-        let mut engine = Engine::new(&self.config);
+        let mut engine = Engine::new(&self.engine_config(schema, maybe_nodes_prefixmap));
         let shape_expr_label: ShapeExprLabel = shape.into();
         let idx = self.get_shape_expr_label(&shape_expr_label, schema)?;
         engine.add_pending(node.clone(), idx);
@@ -131,7 +156,7 @@ impl Validator {
     where
         S: NeighsRDF + QueryRDF,
     {
-        let mut engine = Engine::new(&self.config);
+        let mut engine = Engine::new(&self.engine_config(schema, maybe_nodes_prefixmap));
 
         // Fill the engine's pending atoms with the node-shape pairs from the QueryShapeMap,
         // converting shape labels to indices and nodes to objects as needed.

--- a/shex_validation/src/validator_config.rs
+++ b/shex_validation/src/validator_config.rs
@@ -6,6 +6,7 @@ use shex_ast::shapemap::ShapemapConfig;
 use std::sync::Arc;
 
 use crate::ShExConfig;
+use crate::typing::TypingObserver;
 
 /// This struct can be used to customize the behavour of ShEx validators
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -42,6 +43,31 @@ pub struct ValidatorConfig {
     /// [`Self::with_external_resolver`].
     #[serde(skip)]
     pub(crate) external_resolvers: ExternalShapeResolverRegistry,
+
+    /// Observer notified whenever the ShEx engine caches a newly-proved
+    /// `(node, shape)` result, for surfacing intermediate validation
+    /// progress to the caller. Cannot be loaded from TOML — install it
+    /// programmatically via [`Self::with_typing_observer`].
+    #[serde(skip)]
+    pub(crate) typing_observer: Option<Arc<TypingObserver>>,
+
+    /// Whether to print each `(node, shape)` result as soon as it's cached,
+    /// instead of only showing the final report (default: false). When set
+    /// and no [`Self::with_typing_observer`] was installed explicitly, the
+    /// validator installs a default console-printing observer.
+    #[serde(rename = "show_intermediate_results")]
+    pub(crate) show_intermediate_results: bool,
+
+    /// Color used to print "conformant" in intermediate results (default:
+    /// "green"). An unrecognized color name falls back to the default.
+    #[serde(rename = "conformant_color")]
+    pub(crate) conformant_color: String,
+
+    /// Color used to print "non-conformant" in intermediate results
+    /// (default: "red"). An unrecognized color name falls back to the
+    /// default.
+    #[serde(rename = "non_conformant_color")]
+    pub(crate) non_conformant_color: String,
 }
 
 impl PartialEq for ValidatorConfig {
@@ -52,6 +78,9 @@ impl PartialEq for ValidatorConfig {
             && self.shapemap == other.shapemap
             && self.check_negation_requirement == other.check_negation_requirement
             && self.width == other.width
+            && self.show_intermediate_results == other.show_intermediate_results
+            && self.conformant_color == other.conformant_color
+            && self.non_conformant_color == other.non_conformant_color
     }
 }
 
@@ -65,6 +94,10 @@ impl ValidatorConfig {
             shapemap: Self::default_shapemap(),
             check_negation_requirement: Self::default_check_negation_requirement(),
             external_resolvers: ExternalShapeResolverRegistry::default(),
+            typing_observer: None,
+            show_intermediate_results: Self::default_show_intermediate_results(),
+            conformant_color: Self::default_conformant_color(),
+            non_conformant_color: Self::default_non_conformant_color(),
         }
     }
 
@@ -114,6 +147,29 @@ impl ValidatorConfig {
         self.external_resolvers = std::mem::take(&mut self.external_resolvers).with_resolver_arc(r);
         self
     }
+
+    /// Install an observer notified on every newly-cached `(node, shape)`
+    /// validation result. Returns the updated config for builder-style
+    /// chaining.
+    pub fn with_typing_observer(mut self, observer: Arc<TypingObserver>) -> Self {
+        self.typing_observer = Some(observer);
+        self
+    }
+
+    pub fn with_show_intermediate_results(mut self, flag: bool) -> Self {
+        self.show_intermediate_results = flag;
+        self
+    }
+
+    pub fn with_conformant_color(mut self, color: impl Into<String>) -> Self {
+        self.conformant_color = color.into();
+        self
+    }
+
+    pub fn with_non_conformant_color(mut self, color: impl Into<String>) -> Self {
+        self.non_conformant_color = color.into();
+        self
+    }
 }
 
 impl ValidatorConfig {
@@ -144,6 +200,22 @@ impl ValidatorConfig {
     pub fn external_resolvers(&self) -> &ExternalShapeResolverRegistry {
         &self.external_resolvers
     }
+
+    pub fn typing_observer(&self) -> Option<Arc<TypingObserver>> {
+        self.typing_observer.clone()
+    }
+
+    pub fn show_intermediate_results(&self) -> bool {
+        self.show_intermediate_results
+    }
+
+    pub fn conformant_color(&self) -> &str {
+        &self.conformant_color
+    }
+
+    pub fn non_conformant_color(&self) -> &str {
+        &self.non_conformant_color
+    }
 }
 
 /// Serde stuff
@@ -156,6 +228,9 @@ impl ValidatorConfig {
     #[inline] fn default_shapemap() -> ShapemapConfig { ShapemapConfig::new() }
     #[inline] fn default_check_negation_requirement() -> bool { true }
     #[inline] fn default_width() -> usize { 80 }
+    #[inline] fn default_show_intermediate_results() -> bool { false }
+    #[inline] fn default_conformant_color() -> String { "green".to_string() }
+    #[inline] fn default_non_conformant_color() -> String { "red".to_string() }
 }
 
 impl Default for ValidatorConfig {
@@ -179,6 +254,24 @@ mod tests {
             ValidatorConfig::default_check_negation_requirement()
         );
         assert_eq!(c.width(), ValidatorConfig::default_width());
+        assert!(!c.show_intermediate_results());
+        assert_eq!(c.conformant_color(), "green");
+        assert_eq!(c.non_conformant_color(), "red");
+    }
+
+    #[test]
+    fn toml_configures_intermediate_results_and_colors() {
+        let c: ValidatorConfig = toml::from_str(
+            r#"
+            show_intermediate_results = true
+            conformant_color = "cyan"
+            non_conformant_color = "magenta"
+        "#,
+        )
+        .unwrap();
+        assert!(c.show_intermediate_results());
+        assert_eq!(c.conformant_color(), "cyan");
+        assert_eq!(c.non_conformant_color(), "magenta");
     }
 
     #[test]

--- a/shex_validation/tests/typing_observer_integration.rs
+++ b/shex_validation/tests/typing_observer_integration.rs
@@ -1,0 +1,206 @@
+//! End-to-end tests for `TypingObserver`: observing intermediate validation
+//! results as they're cached, and using that hook to recover partial results
+//! when validation is cancelled mid-run.
+
+use std::sync::{Arc, Mutex};
+
+use either::Either;
+use rudof_iri::IriS;
+use rudof_rdf::rdf_core::RDFFormat;
+use rudof_rdf::rdf_impl::{OxigraphInMemory, ReaderMode};
+use shex_ast::ir::shape_label::ShapeLabel;
+use shex_ast::ir::{map_state::MapState, schema_ir::SchemaIR, semantic_actions_registry::SemanticActionsRegistry};
+use shex_ast::shapemap::{NodeSelector, QueryShapeMap, ShapeSelector};
+use shex_ast::{Node, ResolveMethod, ShExParser, ShapeExprLabel, ir::ast2ir::AST2IR};
+use shex_validation::{Reason, ValidationResult, Validator, ValidatorConfig, ValidatorError};
+
+fn compile(schema_src: &str, config: &ValidatorConfig) -> SchemaIR {
+    let base = IriS::new_unchecked("http://a.example/");
+    let ast = ShExParser::parse(schema_src, Some(base.clone()), &base).expect("parse schema");
+    let mut map_state = MapState::default();
+    let registry = SemanticActionsRegistry::default();
+    registry.set_map_state(&mut map_state);
+    let mut compiler = AST2IR::new(&ResolveMethod::default(), map_state);
+    let mut compiled = SchemaIR::new(registry);
+    compiler
+        .compile(
+            &ast,
+            &base,
+            &Some(base.clone()),
+            &mut compiled,
+            config.external_resolvers(),
+        )
+        .expect("compile to IR");
+    compiled
+}
+
+fn shapemap(pairs: &[(&str, &str)]) -> QueryShapeMap {
+    let mut sm = QueryShapeMap::new();
+    for (node, shape) in pairs {
+        let node = Node::parse(node, None).expect("parse focus node");
+        let shape_label: ShapeExprLabel = (&ShapeLabel::iri(IriS::new_unchecked(shape))).into();
+        sm.add_association(
+            NodeSelector::Node((&node).try_into().expect("node as object value")),
+            &None,
+            ShapeSelector::label(shape_label),
+            &None,
+        )
+        .expect("add association");
+    }
+    sm
+}
+
+#[derive(Debug, Default)]
+struct RecordingObserver {
+    seen: Mutex<Vec<(String, ValidationResult)>>,
+}
+
+impl rudof_typing::TypingObserver<Node, shex_ast::ShapeLabelIdx, ValidatorError, Reason> for RecordingObserver {
+    fn on_insert(&self, key: &(Node, shex_ast::ShapeLabelIdx), value: &ValidationResult) {
+        self.seen.lock().unwrap().push((key.0.to_string(), value.clone()));
+    }
+}
+
+const NESTED_SCHEMA: &str = r#"
+<http://a.example/T> { <http://a.example/q> . }
+<http://a.example/S> { <http://a.example/p> @<http://a.example/T> }
+"#;
+const NESTED_DATA: &str = r#"<http://a.example/n1> <http://a.example/p> <http://a.example/n2> .
+<http://a.example/n2> <http://a.example/q> "x" ."#;
+
+#[test]
+fn observer_sees_dependency_result_before_the_shape_that_needed_it() {
+    let observer = Arc::new(RecordingObserver::default());
+    let config = ValidatorConfig::default().with_typing_observer(observer.clone());
+    let compiled = compile(NESTED_SCHEMA, &config);
+    let mut validator = Validator::new(&compiled, &config).expect("validator");
+    let graph =
+        OxigraphInMemory::from_str(NESTED_DATA, &RDFFormat::Turtle, None, &ReaderMode::Strict).expect("parse graph");
+    let node = Node::parse("http://a.example/n1", None).expect("parse focus");
+    let shape = ShapeLabel::iri(IriS::new_unchecked("http://a.example/S"));
+
+    let result = validator
+        .validate_node_shape(&node, &shape, &graph, &compiled, &Some(graph.prefixmap().clone()))
+        .expect("validate");
+    assert!(result.get_info(&node, &shape).expect("status").is_conformant());
+
+    let seen = observer.seen.lock().unwrap();
+    // n2@T (S's dependency) is cached before n1@S (the shape that depends on it).
+    assert_eq!(
+        seen.len(),
+        2,
+        "expected one cached result per (node, shape) pair: {seen:?}"
+    );
+    assert_eq!(seen[0].0, "http://a.example/n2");
+    assert_eq!(seen[1].0, "http://a.example/n1");
+    assert!(matches!(seen[0].1, Either::Right(_)), "n2@T should conform");
+    assert!(matches!(seen[1].1, Either::Right(_)), "n1@S should conform");
+}
+
+#[test]
+fn show_intermediate_results_auto_installs_a_default_observer() {
+    // No `with_typing_observer` call at all: `show_intermediate_results(true)`
+    // alone must be enough for `Validator::new` to install a default
+    // (console-printing) observer, and validation must still succeed.
+    let config = ValidatorConfig::default().with_show_intermediate_results(true);
+    let compiled = compile(NESTED_SCHEMA, &config);
+    let mut validator = Validator::new(&compiled, &config).expect("validator");
+    let graph =
+        OxigraphInMemory::from_str(NESTED_DATA, &RDFFormat::Turtle, None, &ReaderMode::Strict).expect("parse graph");
+    let node = Node::parse("http://a.example/n1", None).expect("parse focus");
+    let shape = ShapeLabel::iri(IriS::new_unchecked("http://a.example/S"));
+
+    let result = validator
+        .validate_node_shape(&node, &shape, &graph, &compiled, &Some(graph.prefixmap().clone()))
+        .expect("validate");
+    assert!(result.get_info(&node, &shape).expect("status").is_conformant());
+}
+
+#[test]
+fn explicit_observer_wins_over_show_intermediate_results() {
+    // When both are set, the explicitly-supplied observer must be the one
+    // that's actually notified, not silently replaced by the default one.
+    let observer = Arc::new(RecordingObserver::default());
+    let config = ValidatorConfig::default()
+        .with_show_intermediate_results(true)
+        .with_typing_observer(observer.clone());
+    let compiled = compile(NESTED_SCHEMA, &config);
+    let mut validator = Validator::new(&compiled, &config).expect("validator");
+    let graph =
+        OxigraphInMemory::from_str(NESTED_DATA, &RDFFormat::Turtle, None, &ReaderMode::Strict).expect("parse graph");
+    let node = Node::parse("http://a.example/n1", None).expect("parse focus");
+    let shape = ShapeLabel::iri(IriS::new_unchecked("http://a.example/S"));
+
+    validator
+        .validate_node_shape(&node, &shape, &graph, &compiled, &Some(graph.prefixmap().clone()))
+        .expect("validate");
+
+    assert_eq!(
+        observer.seen.lock().unwrap().len(),
+        2,
+        "explicit observer should still be notified"
+    );
+}
+
+const INDEPENDENT_SCHEMA: &str = r#"
+<http://a.example/S1> { <http://a.example/p1> . }
+<http://a.example/S2> { <http://a.example/p2> . }
+"#;
+const INDEPENDENT_DATA: &str = r#"<http://a.example/n1> <http://a.example/p1> "x" .
+<http://a.example/n2> <http://a.example/p2> "y" ."#;
+
+#[derive(Debug)]
+struct CancelAfterFirstInsert;
+
+impl rudof_typing::TypingObserver<Node, shex_ast::ShapeLabelIdx, ValidatorError, Reason> for CancelAfterFirstInsert {
+    fn on_insert(&self, _key: &(Node, shex_ast::ShapeLabelIdx), _value: &ValidationResult) {
+        rudof_rdf::cancellation::request_cancellation();
+    }
+}
+
+#[test]
+fn cancelling_mid_validation_still_returns_results_for_finished_independent_pairs() {
+    rudof_rdf::cancellation::reset();
+
+    let config = ValidatorConfig::default().with_typing_observer(Arc::new(CancelAfterFirstInsert));
+    let compiled = compile(INDEPENDENT_SCHEMA, &config);
+    let validator = Validator::new(&compiled, &config).expect("validator");
+    let graph = OxigraphInMemory::from_str(INDEPENDENT_DATA, &RDFFormat::Turtle, None, &ReaderMode::Strict)
+        .expect("parse graph");
+
+    let n1 = Node::parse("http://a.example/n1", None).expect("parse n1");
+    let n2 = Node::parse("http://a.example/n2", None).expect("parse n2");
+    let s1 = ShapeLabel::iri(IriS::new_unchecked("http://a.example/S1"));
+    let s2 = ShapeLabel::iri(IriS::new_unchecked("http://a.example/S2"));
+
+    let sm = shapemap(&[
+        ("http://a.example/n1", "http://a.example/S1"),
+        ("http://a.example/n2", "http://a.example/S2"),
+    ]);
+
+    // Cancellation is requested from inside the observer once the first pair
+    // is cached, simulating a user interrupting the run mid-way. The engine
+    // should still hand back a result: the pair proved before cancellation
+    // was requested, and `Pending` for the one it never got to.
+    let result = validator
+        .validate_shapemap(&sm, &graph, &compiled, &Some(graph.prefixmap().clone()))
+        .expect("validate_shapemap should succeed with partial results, not error out");
+
+    rudof_rdf::cancellation::reset();
+
+    let status1 = result.get_info(&n1, &s1).expect("status for n1@S1");
+    let status2 = result.get_info(&n2, &s2).expect("status for n2@S2");
+    let statuses = [status1.is_conformant(), status2.is_conformant()];
+    let pendings = [status1.is_pending(), status2.is_pending()];
+
+    assert_eq!(
+        statuses.iter().filter(|c| **c).count(),
+        1,
+        "exactly one pair should have finished before cancellation: {status1:?} / {status2:?}"
+    );
+    assert_eq!(
+        pendings.iter().filter(|p| **p).count(),
+        1,
+        "exactly one pair should be left pending: {status1:?} / {status2:?}"
+    );
+}


### PR DESCRIPTION
Extracts the (node, shape) memoization cache used by the ShEx engine into a new generic rudof_typing crate (Typing/ObservableTyping/ TypingObserver), so the cache can notify an observer on every insert without shex_validation depending on any particular output format.

shex_validation instantiates it as Typing/ObservableTyping/ TypingObserver over (Node, ShapeLabelIdx, ValidatorError, Reason), and adds ConsoleTypingObserver, which prints each result to stderr as soon as it's cached, with nodes and shape labels qualified against their prefixmaps and the verdict colorized (configurable via the new conformant_color/non_conformant_color settings).

Wire it up end-to-end: ValidatorConfig gains show_intermediate_results and the color settings (with builder methods and TOML support), the validator installs a ConsoleTypingObserver when the flag is set and no observer was given explicitly, and both `validate` and `shex-validate` CLI subcommands gain a --show-intermediate-results flag.

Also make the engine's main proving loop handle a Cancelled error from prove() explicitly instead of propagating it via `?`, putting the in-flight atom back into `pending` so interrupted validation still reports it as Pending rather than losing it.